### PR TITLE
fix: return single error when required for runE option

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -164,9 +164,9 @@ func genSDKs(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := sdkgen.Generate(cmd.Context(), vCfg.GetString("id"), lang, schemaPath, outDir, baseURL, genVersion, debug, autoYes); err != nil {
+	if errs := sdkgen.Generate(cmd.Context(), vCfg.GetString("id"), lang, schemaPath, outDir, baseURL, genVersion, debug, autoYes); len(errs) > 0 {
 		rootCmd.SilenceUsage = true
-		return err
+		return errs[0]
 	}
 
 	return nil

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -43,9 +43,9 @@ func validateOpenAPI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath); err != nil {
+	if errs := validation.ValidateOpenAPI(cmd.Context(), schemaPath); len(errs) > 0 {
 		rootCmd.SilenceUsage = true
-		return err
+		return errs[0]
 	}
 
 	return nil


### PR DESCRIPTION
Methods containing these changes are set as the `RunE` property of cobra command which has the following signature:
```
func(cmd *Command, args []string) error
```
So for now just returning the first error since these were modified in `openapi-generation` to return `[]error`. FYI @TristanSpeakEasy I think this may be why we had `GetOrderedErrorString` util method before?

I'm sending this PR just to fix the CLI asap but will create a linear ticket to look in to this more thoroughly.