### PR TITLE
Sample CLI Suggestions

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -36,6 +36,7 @@ func validateInit() {
 
 //nolint:errcheck
 func validateOpenAPIInit() {
+	validateOpenAPICmd.Flags().BoolP("suggest", "x", false, "fix openapi failures with llm suggestions")
 	validateOpenAPICmd.Flags().StringP("schema", "s", "", "path to the OpenAPI document")
 	_ = validateOpenAPICmd.MarkFlagRequired("schema")
 
@@ -64,7 +65,12 @@ func validateOpenAPI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath); err != nil {
+	suggest, err := cmd.Flags().GetBool("suggest")
+	if err != nil {
+		return err
+	}
+
+	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath, suggest); err != nil {
 		rootCmd.SilenceUsage = true
 
 		return err

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -1,0 +1,88 @@
+package suggestions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+)
+
+const baseURL = "http://localhost:5050"
+
+type suggestionResponse struct {
+	Suggestion string `json:"suggestion"`
+}
+
+type suggestionRequest struct {
+	Error      string `json:"error"`
+	LineNumber int    `json:"line_number"`
+}
+
+func Upload() (string, error) {
+	req, err := http.NewRequest("POST", baseURL+"/upload", nil)
+	if err != nil {
+		return "", fmt.Errorf("error creating request for upload: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request for upload: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	token := resp.Header.Get("x-session-token")
+	if token == "" {
+		return "", fmt.Errorf("session token is empty")
+	}
+
+	return token, nil
+}
+
+func Suggest(token string, error string, lineNumber int) (string, error) {
+	reqBody := suggestionRequest{
+		Error:      error,
+		LineNumber: lineNumber,
+	}
+
+	jsonPayload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling request payload: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/suggest", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return "", fmt.Errorf("error creating request for suggest: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-session-token", token)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request for suggest: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	var response suggestionResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("error unmarshaling response body: %v", err)
+	}
+
+	return response.Suggestion, nil
+}

--- a/internal/suggestions/utils.go
+++ b/internal/suggestions/utils.go
@@ -1,0 +1,92 @@
+package suggestions
+
+import (
+	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"gopkg.in/yaml.v2"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func GetLineNumber(errStr string) (int, error) {
+	lineStr := strings.Split(errStr, "[line ")[1]
+	lineNumStr := strings.Split(lineStr, "]")[0]
+	lineNum, err := strconv.Atoi(lineNumStr)
+	if err != nil {
+		return 0, err
+	}
+	return lineNum, nil
+}
+
+func EscapeString(input string) string {
+	re := regexp.MustCompile(`\\([abfnrtv\\'"])`)
+
+	// Replace escape sequences with their unescaped counterparts
+	output := re.ReplaceAllStringFunc(input, func(match string) string {
+		switch match {
+		case `\a`:
+			return "\a"
+		case `\b`:
+			return "\b"
+		case `\f`:
+			return "\f"
+		case `\n`:
+			return "\n"
+		case `\r`:
+			return "\r"
+		case `\t`:
+			return "\t"
+		case `\v`:
+			return "\v"
+		case `\\`:
+			return `\`
+		case `\'`:
+			return `'`
+		case `\"`:
+			return `"`
+		default:
+			// Should never happen, but just in case
+			return match
+		}
+	})
+
+	return output
+}
+
+func FormatYaml(input string) (string, error) {
+	// Unmarshal the YAML input into a generic interface{}
+	var data interface{}
+	if err := yaml.Unmarshal([]byte(input), &data); err != nil {
+		return "", err
+	}
+
+	// Marshal the interface{} back to YAML with no extra spaces
+	output, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	outputStr := strings.TrimSpace(string(output))
+
+	return outputStr, nil
+}
+
+func WaitForInput() {
+	var input string
+	for {
+		fmt.Scan(&input)
+		if strings.ToLower(input) == "yes" {
+			// TODO: Update an actual openapi revision, maybe push to speakeasy registry
+			fmt.Println(utils.Green("Suggestion Accepted"))
+			fmt.Println() // extra space
+			break
+		}
+
+		if strings.ToLower(input) == "no" {
+			// TODO: Update an actual openapi revision, maybe push to speakeasy registry
+			fmt.Println(utils.Red("Suggestion Rejected"))
+			fmt.Println() // extra space
+			break
+		}
+	}
+}


### PR DESCRIPTION
A sample CLI to provide LLM suggestions to a user when they validate their spec. This communicates with a downstream node API but the client could really be replaced with any form of communication with the LLM go library, goja, etc.

This is not ready to productionize there are definitely some things that need to be cleaned up. In general though we can use the foundation of it.

Use the command below to run the CLI

go run main.go validate openapi -s {.yaml} --suggest