### PR TITLE
feat: add LLM suggestions to CLI

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,11 @@ func Init(version, artifactArch string) {
 	authInit()
 	usageInit()
 	mergeInit()
+<<<<<<< HEAD
 	updateInit(version, artifactArch)
+=======
+	suggestInit()
+>>>>>>> 94557f4 (feat: new top level command)
 }
 
 func Execute(version, artifactArch string) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,11 +45,8 @@ func Init(version, artifactArch string) {
 	authInit()
 	usageInit()
 	mergeInit()
-<<<<<<< HEAD
 	updateInit(version, artifactArch)
-=======
 	suggestInit()
->>>>>>> 94557f4 (feat: new top level command)
 }
 
 func Execute(version, artifactArch string) {

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"fmt"
+	"github.com/manifoldco/promptui"
+	"github.com/speakeasy-api/speakeasy/internal/validation"
+	"github.com/spf13/cobra"
+)
+
+var suggestCmd = &cobra.Command{
+	Use:   "suggest",
+	Short: "Validate an OpenAPI document and get fixes suggested by ChatGPT",
+	Long: `The "suggest" command validates an OpenAPI spec and uses OpenAI's ChatGPT to suggest fixes to your spec.
+You will need to set your OpenAI API key in a SPEAKEASY_API_KEY_OPENAI environment variable. You will also need to authenticate with the Speakeasy API,
+you must first create an API key via https://app.speakeasyapi.dev and then set the SPEAKEASY_API_KEY environment variable to the value of the API key.`,
+	RunE: suggestFixesOpenAPI,
+}
+
+func suggestInit() {
+	suggestCmd.Flags().StringP("schema", "s", "", "path to the OpenAPI document")
+	_ = suggestCmd.MarkFlagRequired("schema")
+	rootCmd.AddCommand(suggestCmd)
+}
+
+func suggestFixesOpenAPI(cmd *cobra.Command, args []string) error {
+	// no authentication required for validating specs
+
+	schemaPath, err := cmd.Flags().GetString("schema")
+	if err != nil {
+		return err
+	}
+
+	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath, true); err != nil {
+		rootCmd.SilenceUsage = true
+
+		return err
+	}
+
+	uploadCommand := promptui.Styler(promptui.FGCyan, promptui.FGBold)("speakeasy api register-schema --schema=" + schemaPath)
+	fmt.Printf("\nYou can upload your schema to Speakeasy using the following command:\n%s\n", uploadCommand)
+
+	return nil
+}

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -11,7 +11,7 @@ var suggestCmd = &cobra.Command{
 	Use:   "suggest",
 	Short: "Validate an OpenAPI document and get fixes suggested by ChatGPT",
 	Long: `The "suggest" command validates an OpenAPI spec and uses OpenAI's ChatGPT to suggest fixes to your spec.
-You will need to set your OpenAI API key in a SPEAKEASY_API_KEY_OPENAI environment variable. You will also need to authenticate with the Speakeasy API,
+You will need to set your OpenAI API key in a OPENAI_API_KEY environment variable. You will also need to authenticate with the Speakeasy API,
 you must first create an API key via https://app.speakeasyapi.dev and then set the SPEAKEASY_API_KEY environment variable to the value of the API key.`,
 	RunE: suggestFixesOpenAPI,
 }

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -38,6 +38,7 @@ func validateInit() {
 
 //nolint:errcheck
 func validateOpenAPIInit() {
+	validateOpenAPICmd.Flags().BoolP("fix", "f", false, "fix openapi failures with llm suggestions")
 	validateOpenAPICmd.Flags().StringP("schema", "s", "", "path to the OpenAPI document")
 	_ = validateOpenAPICmd.MarkFlagRequired("schema")
 
@@ -59,7 +60,12 @@ func validateOpenAPI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath); err != nil {
+	fix, err := cmd.Flags().GetBool("fix")
+	if err != nil {
+		return err
+	}
+
+	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath, fix); err != nil {
 		rootCmd.SilenceUsage = true
 
 		return err

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	go.uber.org/zap v1.24.0
 	golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561
 	golang.org/x/term v0.7.0
+	gopkg.in/yaml.v2 v2.4.0
 )
 
 require (
@@ -117,6 +118,5 @@ require (
 	google.golang.org/appengine v1.6.7 // indirect
 	google.golang.org/protobuf v1.28.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -435,10 +435,19 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/speakeasy-api/easytemplate v0.7.0 h1:TWjHsf2KiRl2to56rXs2IK8B2/vJir7jMpIHEqQvb7Q=
 github.com/speakeasy-api/easytemplate v0.7.0/go.mod h1:TZukKvzzqorzug8vAyKMeSh8cHDC2MwftcalRdDLg4k=
+<<<<<<< HEAD
 github.com/speakeasy-api/openapi-generation/v2 v2.32.2 h1:fDxpjQvb84LMlbjzs087jLMhxmD4NnyYYidxGQPKYm4=
 github.com/speakeasy-api/openapi-generation/v2 v2.32.2/go.mod h1:qFe+uGRlwyrHfPajrGnBzcyjt04Q/E37zJefBU1Lm3A=
 github.com/speakeasy-api/sdk-gen-config v0.5.0 h1:c7sU09H5LhJuhSHSyeA7WdiqmRlfwuTmPgTSIfn9nJo=
 github.com/speakeasy-api/sdk-gen-config v0.5.0/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
+=======
+github.com/speakeasy-api/openapi-generation/v2 v2.28.0 h1:ymnVODwkhsGs2d0gZX7COBy6cLz+4pqwpGEUNyBYe6M=
+github.com/speakeasy-api/openapi-generation/v2 v2.28.0/go.mod h1:4nrYkHvPrQ166PbxpsfX2FJE2kQTdPUlOmQXA4MmDNY=
+github.com/speakeasy-api/openapi-generation/v2 v2.29.0 h1:juXkS8AY4O7ALyMnu12ml5iE1yaQp9bjk8FZVesL5ZM=
+github.com/speakeasy-api/openapi-generation/v2 v2.29.0/go.mod h1:4nrYkHvPrQ166PbxpsfX2FJE2kQTdPUlOmQXA4MmDNY=
+github.com/speakeasy-api/sdk-gen-config v0.4.2 h1:7mcoLMF4Q4VLkT2TYvjfOMOwxMdnGhFMihTPNIanYCM=
+github.com/speakeasy-api/sdk-gen-config v0.4.2/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
+>>>>>>> 6ddb746 (feat: add LLM suggestions to CLI)
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0 h1:RqYjM0okHjjEyKRxumaTmZDWt68nGZo1sbIfALyqLCg=
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0/go.mod h1:xsmMkmsZjL9uh97GY6VbihZ6jScY90xoq2Dc7ukwB98=
 github.com/speakeasy-api/speakeasy-core v0.0.0-20220906154214-c4cfc66c4bb7 h1:3rKvk9/Xgj7ugJ3eGq3w4A+IW27U1lmQ+pBOMpbP6e8=

--- a/go.sum
+++ b/go.sum
@@ -435,19 +435,10 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/speakeasy-api/easytemplate v0.7.0 h1:TWjHsf2KiRl2to56rXs2IK8B2/vJir7jMpIHEqQvb7Q=
 github.com/speakeasy-api/easytemplate v0.7.0/go.mod h1:TZukKvzzqorzug8vAyKMeSh8cHDC2MwftcalRdDLg4k=
-<<<<<<< HEAD
 github.com/speakeasy-api/openapi-generation/v2 v2.32.2 h1:fDxpjQvb84LMlbjzs087jLMhxmD4NnyYYidxGQPKYm4=
 github.com/speakeasy-api/openapi-generation/v2 v2.32.2/go.mod h1:qFe+uGRlwyrHfPajrGnBzcyjt04Q/E37zJefBU1Lm3A=
 github.com/speakeasy-api/sdk-gen-config v0.5.0 h1:c7sU09H5LhJuhSHSyeA7WdiqmRlfwuTmPgTSIfn9nJo=
 github.com/speakeasy-api/sdk-gen-config v0.5.0/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
-=======
-github.com/speakeasy-api/openapi-generation/v2 v2.28.0 h1:ymnVODwkhsGs2d0gZX7COBy6cLz+4pqwpGEUNyBYe6M=
-github.com/speakeasy-api/openapi-generation/v2 v2.28.0/go.mod h1:4nrYkHvPrQ166PbxpsfX2FJE2kQTdPUlOmQXA4MmDNY=
-github.com/speakeasy-api/openapi-generation/v2 v2.29.0 h1:juXkS8AY4O7ALyMnu12ml5iE1yaQp9bjk8FZVesL5ZM=
-github.com/speakeasy-api/openapi-generation/v2 v2.29.0/go.mod h1:4nrYkHvPrQ166PbxpsfX2FJE2kQTdPUlOmQXA4MmDNY=
-github.com/speakeasy-api/sdk-gen-config v0.4.2 h1:7mcoLMF4Q4VLkT2TYvjfOMOwxMdnGhFMihTPNIanYCM=
-github.com/speakeasy-api/sdk-gen-config v0.4.2/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
->>>>>>> 6ddb746 (feat: add LLM suggestions to CLI)
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0 h1:RqYjM0okHjjEyKRxumaTmZDWt68nGZo1sbIfALyqLCg=
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0/go.mod h1:xsmMkmsZjL9uh97GY6VbihZ6jScY90xoq2Dc7ukwB98=
 github.com/speakeasy-api/speakeasy-core v0.0.0-20220906154214-c4cfc66c4bb7 h1:3rKvk9/Xgj7ugJ3eGq3w4A+IW27U1lmQ+pBOMpbP6e8=

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -10,9 +10,10 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 )
 
-// TODO: Replace client with Speakeasy SDK after updating the SDK
+const timeout = time.Minute * 2
 
 var baseURL = os.Getenv("SPEAKEASY_SERVER_URL")
 
@@ -50,11 +51,12 @@ func Upload(filePath string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+
 	_, err = part.Write(fileData)
 	if err != nil {
 		return "", err
 	}
-	
+
 	err = writer.Close()
 	if err != nil {
 		return "", err
@@ -69,7 +71,9 @@ func Upload(filePath string) (string, error) {
 	req.Header.Set("x-openai-key", openAIKey)
 	req.Header.Set("x-api-key", apiKey)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: timeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error making request for upload: %v", err)
@@ -120,7 +124,9 @@ func Suggestion(token string, error string, lineNumber int) (string, error) {
 	req.Header.Set("x-openai-key", openAIKey)
 	req.Header.Set("x-api-key", apiKey)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: timeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error making request for suggest: %v", err)
@@ -133,6 +139,9 @@ func Suggestion(token string, error string, lineNumber int) (string, error) {
 	}
 
 	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
 
 	var response suggestionResponse
 	if err := json.Unmarshal(body, &response); err != nil {
@@ -157,7 +166,9 @@ func Clear(token string) error {
 	req.Header.Set("x-session-token", token)
 	req.Header.Set("x-api-key", apiKey)
 
-	client := &http.Client{}
+	client := &http.Client{
+		Timeout: timeout,
+	}
 	resp, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("error making request for suggest: %v", err)

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -194,7 +194,7 @@ func Clear(token string) error {
 func getOpenAIKey() (string, error) {
 	key := os.Getenv("OPENAI_API_KEY")
 	if key == "" {
-		return "", fmt.Errorf("A OPENAI_API_KEY must be set to use LLM Suggestions")
+		return "", fmt.Errorf("OPENAI_API_KEY must be set to use LLM Suggestions")
 	}
 
 	return key, nil

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -1,0 +1,191 @@
+package suggestions
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/config"
+	"io/ioutil"
+	"mime/multipart"
+	"net/http"
+	"os"
+	"path/filepath"
+)
+
+// TODO: Replace client with Speakeasy SDK after updating the SDK
+
+var baseURL = os.Getenv("SPEAKEASY_SERVER_URL")
+
+type suggestionResponse struct {
+	Suggestion string `json:"suggestion"`
+}
+
+type suggestionRequest struct {
+	Error      string `json:"error"`
+	LineNumber int    `json:"line_number"`
+}
+
+func Upload(filePath string) (string, error) {
+	openAIKey, err := getOpenAIKey()
+	if err != nil {
+		return "", err
+	}
+
+	apiKey, err := getSpeakeasyAPIKey()
+	if err != nil {
+		return "", err
+	}
+
+	fileData, err := os.ReadFile(filePath)
+	if err != nil {
+		return "", err
+	}
+
+	body := new(bytes.Buffer)
+	writer := multipart.NewWriter(body)
+	part, err := writer.CreatePart(map[string][]string{
+		"Content-Disposition": {"form-data; name=\"file\"; filename=\"" + filepath.Base(filePath) + "\""},
+		"Content-Type":        {detectFileType(filePath)}, // Set the MIME type here
+	})
+	if err != nil {
+		return "", err
+	}
+	_, err = part.Write(fileData)
+	if err != nil {
+		return "", err
+	}
+	
+	err = writer.Close()
+	if err != nil {
+		return "", err
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/v1/llm/openapi", body)
+	if err != nil {
+		return "", fmt.Errorf("error creating request for upload: %v", err)
+	}
+
+	req.Header.Set("Content-Type", writer.FormDataContentType())
+	req.Header.Set("x-openai-key", openAIKey)
+	req.Header.Set("x-api-key", apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request for upload: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	token := resp.Header.Get("x-session-token")
+	if token == "" {
+		return "", fmt.Errorf("session token is empty")
+	}
+
+	return token, nil
+}
+
+func Suggestion(token string, error string, lineNumber int) (string, error) {
+	openAIKey, err := getOpenAIKey()
+	if err != nil {
+		return "", err
+	}
+
+	apiKey, err := getSpeakeasyAPIKey()
+	if err != nil {
+		return "", err
+	}
+
+	reqBody := suggestionRequest{
+		Error:      error,
+		LineNumber: lineNumber,
+	}
+
+	jsonPayload, err := json.Marshal(reqBody)
+	if err != nil {
+		return "", fmt.Errorf("error marshaling request payload: %v", err)
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/v1/llm/openapi/suggestion", bytes.NewBuffer(jsonPayload))
+	if err != nil {
+		return "", fmt.Errorf("error creating request for suggest: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-session-token", token)
+	req.Header.Set("x-openai-key", openAIKey)
+	req.Header.Set("x-api-key", apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error making request for suggest: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	body, err := ioutil.ReadAll(resp.Body)
+
+	var response suggestionResponse
+	if err := json.Unmarshal(body, &response); err != nil {
+		return "", fmt.Errorf("error unmarshaling response body: %v", err)
+	}
+
+	return response.Suggestion, nil
+}
+
+func Clear(token string) error {
+	apiKey, err := getSpeakeasyAPIKey()
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("DELETE", baseURL+"/v1/llm/openapi", nil)
+	if err != nil {
+		return fmt.Errorf("error creating request for suggest: %v", err)
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("x-session-token", token)
+	req.Header.Set("x-api-key", apiKey)
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("error making request for suggest: %v", err)
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("unexpected status code: %v", resp.StatusCode)
+	}
+
+	return nil
+}
+
+func getOpenAIKey() (string, error) {
+	key := os.Getenv("SPEAKEASY_API_KEY_OPENAI")
+	if key == "" {
+		return "", fmt.Errorf("SPEAKEASY_API_KEY_OPENAI must be set")
+	}
+
+	return key, nil
+}
+
+func getSpeakeasyAPIKey() (string, error) {
+	key, _ := config.GetSpeakeasyAPIKey()
+	if key == "" {
+		return "", fmt.Errorf("no api key available, please set SPEAKEASY_API_KEY or run 'speakeasy auth' to authenticate the CLI with the Speakeasy Platform")
+	}
+
+	return key, nil
+}

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -81,6 +81,10 @@ func Upload(filePath string) (string, error) {
 
 	defer resp.Body.Close()
 
+	if resp.StatusCode == http.StatusUnprocessableEntity {
+		return "", fmt.Errorf("OpenAPI document is larger than 50,000 line limit")
+	}
+
 	if resp.StatusCode != http.StatusOK {
 		return "", fmt.Errorf("unexpected status code: %v", resp.StatusCode)
 	}

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -14,7 +14,8 @@ import (
 	"time"
 )
 
-const timeout = time.Minute * 2
+const uploadTimeout = time.Minute * 2
+const suggestionTimeout = time.Minute * 1
 
 const ApiURL = "https://api.prod.speakeasyapi.dev"
 
@@ -75,7 +76,7 @@ func Upload(filePath string) (string, string, error) {
 	req.Header.Set("x-api-key", apiKey)
 
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout: uploadTimeout,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -133,7 +134,7 @@ func Suggestion(token string, error string, lineNumber int, fileType string) (st
 	req.Header.Set("x-file-type", fileType)
 
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout: suggestionTimeout,
 	}
 	resp, err := client.Do(req)
 	if err != nil {
@@ -175,7 +176,7 @@ func Clear(token string) error {
 	req.Header.Set("x-api-key", apiKey)
 
 	client := &http.Client{
-		Timeout: timeout,
+		Timeout: suggestionTimeout,
 	}
 	resp, err := client.Do(req)
 	if err != nil {

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -31,7 +31,7 @@ type suggestionRequest struct {
 }
 
 func Upload(filePath string) (string, string, error) {
-	openAIKey, err := getOpenAIKey()
+	openAIKey, err := GetOpenAIKey()
 	if err != nil {
 		return "", "", err
 	}
@@ -102,7 +102,7 @@ func Upload(filePath string) (string, string, error) {
 }
 
 func Suggestion(token string, error string, lineNumber int, fileType string) (string, error) {
-	openAIKey, err := getOpenAIKey()
+	openAIKey, err := GetOpenAIKey()
 	if err != nil {
 		return "", err
 	}
@@ -192,7 +192,7 @@ func Clear(token string) error {
 	return nil
 }
 
-func getOpenAIKey() (string, error) {
+func GetOpenAIKey() (string, error) {
 	key := os.Getenv("OPENAI_API_KEY")
 	if key == "" {
 		return "", fmt.Errorf("OPENAI_API_KEY must be set to use LLM Suggestions")
@@ -204,7 +204,7 @@ func getOpenAIKey() (string, error) {
 func getSpeakeasyAPIKey() (string, error) {
 	key, _ := config.GetSpeakeasyAPIKey()
 	if key == "" {
-		return "", fmt.Errorf("no api key available, please set SPEAKEASY_API_KEY or run 'speakeasy auth' to authenticate the CLI with the Speakeasy Platform")
+		return "", fmt.Errorf("no speakeasy api key available, please set SPEAKEASY_API_KEY or run 'speakeasy auth' to authenticate the CLI with the Speakeasy Platform")
 	}
 
 	return key, nil

--- a/internal/suggestions/utils.go
+++ b/internal/suggestions/utils.go
@@ -64,13 +64,11 @@ func escapeString(input string) string {
 }
 
 func formatYaml(input string) (string, error) {
-	// Unmarshal the YAML input into a generic interface{}
 	var data interface{}
 	if err := yaml.Unmarshal([]byte(input), &data); err != nil {
 		return "", err
 	}
 
-	// Marshal the interface{} back to YAML with no extra spaces
 	output, err := yaml.Marshal(data)
 	if err != nil {
 		return "", err
@@ -89,14 +87,12 @@ func removeTrailingComma(input string) string {
 }
 
 func formatJSON(input string) (string, error) {
-	// Unmarshal the YAML input into a generic interface{}
 	var data interface{}
 	jsonString := fmt.Sprintf(`{%s}`, removeTrailingComma(input))
 	if err := json.Unmarshal([]byte(jsonString), &data); err != nil {
 		return "", err
 	}
-
-	// Marshal the interface{} back to YAML with no extra spaces
+	
 	output, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return "", err

--- a/internal/suggestions/utils.go
+++ b/internal/suggestions/utils.go
@@ -92,7 +92,7 @@ func formatJSON(input string) (string, error) {
 	if err := json.Unmarshal([]byte(jsonString), &data); err != nil {
 		return "", err
 	}
-	
+
 	output, err := json.MarshalIndent(data, "", "  ")
 	if err != nil {
 		return "", err
@@ -158,16 +158,16 @@ func FindSuggestion(err error, token string, fileType string) {
 				fmt.Println(promptui.Styler(promptui.FGYellow, promptui.FGItalic)(explanation))
 				fmt.Println() // extra line for spacing
 				nextSuggestion()
+				return
 			}
 		} else {
 			if suggestionErr != nil {
 				if strings.Contains(suggestionErr.Error(), "401") || strings.Contains(suggestionErr.Error(), "403") {
-					fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)(suggestionErr.Error()))
+					fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)(fmt.Sprintf("No Suggestion Found: %s", suggestionErr.Error())))
 					return
 				}
 			}
-
-			fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)("No Suggestion Found"))
 		}
 	}
+	fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)("No Suggestion Found"))
 }

--- a/internal/suggestions/utils.go
+++ b/internal/suggestions/utils.go
@@ -127,6 +127,7 @@ func FindSuggestion(err error, token string, fileType string) {
 	if lineNumberErr == nil {
 		fmt.Println() // extra line for spacing
 		fmt.Println(promptui.Styler(promptui.FGBold)("Asking for a Suggestion!"))
+		fmt.Println() // extra line for spacing
 		suggestion, suggestionErr := Suggestion(token, errString, lineNumber, fileType)
 		if suggestionErr == nil && suggestion != "" && !strings.Contains(suggestion, "I cannot provide an answer") {
 			fixSplit := strings.Split(suggestion, "Suggested Fix:")
@@ -170,4 +171,5 @@ func FindSuggestion(err error, token string, fileType string) {
 		}
 	}
 	fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)("No Suggestion Found"))
+	fmt.Println() // extra line for spacing
 }

--- a/internal/suggestions/utils.go
+++ b/internal/suggestions/utils.go
@@ -1,0 +1,138 @@
+package suggestions
+
+import (
+	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"gopkg.in/yaml.v2"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+func getLineNumber(errStr string) (int, error) {
+	lineStr := strings.Split(errStr, "[line ")[1]
+	lineNumStr := strings.Split(lineStr, "]")[0]
+	lineNum, err := strconv.Atoi(lineNumStr)
+	if err != nil {
+		return 0, err
+	}
+	return lineNum, nil
+}
+
+func escapeString(input string) string {
+	re := regexp.MustCompile(`\\([abfnrtv\\'"])`)
+
+	// Replace escape sequences with their unescaped counterparts
+	output := re.ReplaceAllStringFunc(input, func(match string) string {
+		switch match {
+		case `\a`:
+			return "\a"
+		case `\b`:
+			return "\b"
+		case `\f`:
+			return "\f"
+		case `\n`:
+			return "\n"
+		case `\r`:
+			return "\r"
+		case `\t`:
+			return "\t"
+		case `\v`:
+			return "\v"
+		case `\\`:
+			return `\`
+		case `\'`:
+			return `'`
+		case `\"`:
+			return `"`
+		default:
+			// Should never happen, but just in case
+			return match
+		}
+	})
+
+	return output
+}
+
+func formatYaml(input string) (string, error) {
+	// Unmarshal the YAML input into a generic interface{}
+	var data interface{}
+	if err := yaml.Unmarshal([]byte(input), &data); err != nil {
+		return "", err
+	}
+
+	// Marshal the interface{} back to YAML with no extra spaces
+	output, err := yaml.Marshal(data)
+	if err != nil {
+		return "", err
+	}
+	outputStr := strings.TrimSpace(string(output))
+
+	return outputStr, nil
+}
+
+func waitForInput() {
+	var input string
+	for {
+		fmt.Scan(&input)
+		if strings.ToLower(input) == "yes" {
+			// TODO: Update an actual openapi revision, maybe push to speakeasy registry
+			fmt.Println(utils.Green("Suggestion Accepted"))
+			fmt.Println() // extra space
+			break
+		}
+
+		if strings.ToLower(input) == "no" {
+			// TODO: Update an actual openapi revision, maybe push to speakeasy registry
+			fmt.Println(utils.Red("Suggestion Rejected"))
+			fmt.Println() // extra space
+			break
+		}
+	}
+}
+
+func detectFileType(filename string) string {
+	ext := filepath.Ext(filename)
+
+	switch ext {
+	case ".yaml", ".yml":
+		return "text/yaml"
+	case ".json":
+		return "application/json"
+	default:
+		return "application/octet-stream"
+	}
+}
+
+func FindSuggestion(err error, token string) {
+	errString := err.Error()
+	lineNumber, lineNumberErr := getLineNumber(errString)
+	if lineNumberErr == nil {
+		fmt.Println() // extra line for spacing
+		fmt.Println("Asking for a Suggestion")
+		suggestion, suggestionErr := Suggestion(token, errString, lineNumber)
+		if suggestionErr == nil && suggestion != "" && !strings.Contains(suggestion, "I cannot provide an answer") {
+			fixSplit := strings.Split(suggestion, "Suggested Fix:")
+			if len(fixSplit) < 2 {
+				fmt.Println(utils.Yellow("No Suggestion Found"))
+				return
+			}
+			split := strings.Split(fixSplit[1], "Explanation:")
+			fix, yamlErr := formatYaml(escapeString(split[0][2:]))
+			if yamlErr == nil {
+				fmt.Println(utils.Green("Suggested Fix:"))
+				fmt.Println(utils.Green(fix))
+				fmt.Println() // extra line for spacing
+				fmt.Println(utils.Yellow("Explanation:"))
+				explanation := strings.TrimSpace(fmt.Sprintf("%s", escapeString(split[1][2:len(split[1])-1])))
+				fmt.Println(utils.Yellow(fmt.Sprintf("%s", explanation)))
+				fmt.Println() // extra line for spacing
+				fmt.Println(fmt.Sprintf("Type %s and Enter to accept the suggestion, type %s and Enter to skip:", utils.Green("yes"), utils.Red("no")))
+				waitForInput()
+			}
+		} else {
+			fmt.Println(utils.Yellow("No Suggestion Found"))
+		}
+	}
+}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -38,8 +38,8 @@ func ValidateOpenAPI(ctx context.Context, schemaPath string, findSuggestions boo
 		fileType := ""
 
 		if findSuggestions {
-			// local authentication just set in env variable
-			if os.Getenv("SPEAKEASY_SERVER_URL") == "http://localhost:35290" {
+			// local authentication should just be set in env variable
+			if os.Getenv("SPEAKEASY_SERVER_URL") != "http://localhost:35290" {
 				if err := auth.Authenticate(false); err != nil {
 					fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)(err.Error()))
 					findSuggestions = false

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -38,8 +38,8 @@ func ValidateOpenAPI(ctx context.Context, schemaPath string, findSuggestions boo
 		fileType := ""
 
 		if findSuggestions {
-			// local authentication just provided by API Key
-			if os.Getenv("SPEAKEASY_SERVER_URL") == "" || os.Getenv("SPEAKEASY_SERVER_URL") == suggestions.ApiURL {
+			// local authentication just set in env variable
+			if os.Getenv("SPEAKEASY_SERVER_URL") == "http://localhost:35290" {
 				if err := auth.Authenticate(false); err != nil {
 					fmt.Println(promptui.Styler(promptui.FGRed, promptui.FGBold)(err.Error()))
 					findSuggestions = false

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -37,7 +37,7 @@ func ValidateOpenAPI(ctx context.Context, schemaPath string, findSuggestions boo
 		if findSuggestions {
 			suggestionToken, err = suggestions.Upload(schemaPath)
 			if err != nil {
-				l.Error("cannot fetch llm suggestions due to error", zap.Error(err))
+				l.Error("cannot fetch llm suggestions", zap.Error(err))
 				findSuggestions = false
 			}
 		}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -54,6 +54,9 @@ func ValidateOpenAPI(ctx context.Context, schemaPath string, findSuggestions boo
 				} else {
 					hasWarnings = true
 					l.Warn("", zap.Error(err))
+					if findSuggestions {
+						suggestions.FindSuggestion(err, suggestionToken)
+					}
 				}
 			}
 


### PR DESCRIPTION
A sample CLI that communicates with downstream speakeasy API and LLM server.

Normal Testing (CLI)
1. Make sure you have OPENAI_API_KEY set.
2. go run main.go validate openapi --schema openapi-invalid.yaml --fix

Testing with Local API
Local Testing

cd speakeasy-registry (API)
1 Run local registry API
2. Make docker-llm (wait until Chroma is up to continue, you should see Uvicorn running on http://0.0.0.0:8000)
3. export SPEAKEASY_SERVER_URL=http://localhost:35290