### PR TITLE
chore: releases to homebrew as a PR so we can control the release

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,7 +37,7 @@ brews:
       pull_request:
         enabled: true
         base: main
-      branch: release-main
+      branch: release-{{ .Major }}-{{ .Minor }}-{{ .Patch }}
     homepage: https://www.speakeasyapi.dev
     description: The Speakeasy CLI for interacting with the Speakeasy Platform
     license: Apache-2.0


### PR DESCRIPTION
This is a WIP not sure if I want to go this route yet, as the most common issue can probably be solved in the sdk-generation-action