### PR TITLE
docs: add document generation for doc site

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: *
+SHELL = /usr/bin/bash
+
+docs:
+	go run cmd/docs/main.go
+
+docsite:
+	go run cmd/docs/main.go -out-dir ../speakeasy-registry/web/packages/docsite/docs/speakeasy-cli -doc-site


### PR DESCRIPTION
This is a prerequisite to setting up automation for generating the docs for the CLI reference in the docs site.

It also automates what was previously a manual step of copying the .md files from this repo to the speakeasy-registry repo and manually updating all the links.