### PR TITLE
fix: duplicate label interactive mode

### DIFF
--- a/internal/utils/interactiveexec.go
+++ b/internal/utils/interactiveexec.go
@@ -33,7 +33,7 @@ func InteractiveExec(cmd *cobra.Command, args []string, label string) error {
 
 func SelectCommand(label string, commands []*cobra.Command) *cobra.Command {
 	templates := &promptui.SelectTemplates{
-		Label:    "{{ . | cyan | bold }}",
+		Label:    "{{.}}",
 		Active:   "🐝 {{ .Name | yellow | bold }} - {{ .Short | faint }}",
 		Inactive: "   {{ .Name | white | bold }} - {{ .Short | faint }}",
 		Selected: "> {{ .Name | green | bold }}",
@@ -41,12 +41,13 @@ func SelectCommand(label string, commands []*cobra.Command) *cobra.Command {
 
 	prompt := promptui.Select{
 		HideHelp:  true,
-		Label:     label,
+		Label:     "",
 		Items:     commands,
 		Templates: templates,
 		Size:      len(commands),
 	}
 
+	fmt.Println(promptui.Styler(promptui.FGCyan, promptui.FGBold)(label))
 	index, _, err := prompt.Run()
 	if err != nil {
 		fmt.Printf("Prompt failed %v\n", err)


### PR DESCRIPTION
Fixes this problem with duplicate label in prompt UI
<img width="555" alt="Screenshot 2023-05-22 at 4 07 25 PM" src="https://github.com/speakeasy-api/speakeasy/assets/42415738/37d63112-f623-42ea-80c5-308cf7158f45">

Unfortunately you can't get rid of a space for the label entirely without forking promptui or creating a pretty involved custom wrapper for how it writes output. Not worth it right now.
<img width="568" alt="Screenshot 2023-05-22 at 4 08 19 PM" src="https://github.com/speakeasy-api/speakeasy/assets/42415738/b63c3f50-aa8b-4cb9-8bb8-614d9803bb89">
