### PR TITLE
fix: merge supports local lookups

### DIFF
--- a/internal/merge/merge.go
+++ b/internal/merge/merge.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/hashicorp/go-version"
 	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/datamodel"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/utils"
 )
@@ -63,7 +64,9 @@ func merge(inSchemas [][]byte) ([]byte, error) {
 
 // TODO better errors
 func loadOpenAPIDocument(data []byte) (*v3.Document, error) {
-	doc, err := libopenapi.NewDocument(data)
+	doc, err := libopenapi.NewDocumentWithConfiguration(data, &datamodel.DocumentConfiguration{
+		AllowFileReferences: true,
+	})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Will write a test soon, but I tested this locally to ensure it enables `speakeasy merge` to run successfully with local file lookup. The problem is that this CLI command will run from the wrong context on Prove's `generate` step in the action. I would prefer to release this in conjunction with https://github.com/speakeasy-api/sdk-generation-action/pull/35 to test and unblock Prove asap before adding to `merge_test.go`. 