### PR TITLE
fix: dont fail if max-suggestions applied

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/manifoldco/promptui"
 	"github.com/speakeasy-api/speakeasy/internal/sdkgen"
-	"github.com/speakeasy-api/speakeasy/internal/suggestions"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"github.com/speakeasy-api/speakeasy/internal/validation"
 	"github.com/spf13/cobra"
@@ -39,7 +38,6 @@ func validateInit() {
 
 //nolint:errcheck
 func validateOpenAPIInit() {
-	validateOpenAPICmd.Flags().BoolP("fix", "f", false, "fix openapi failures with llm suggestions")
 	validateOpenAPICmd.Flags().BoolP("output-hints", "o", false, "output validation hints in addition to warnings/errors")
 	validateOpenAPICmd.Flags().StringP("schema", "s", "", "path to the OpenAPI document")
 	_ = validateOpenAPICmd.MarkFlagRequired("schema")
@@ -62,22 +60,12 @@ func validateOpenAPI(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var suggestionsConfig *suggestions.Config
-	fix, err := cmd.Flags().GetBool("fix")
-	if err != nil {
-		return err
-	}
-
-	if fix {
-		suggestionsConfig = &suggestions.Config{}
-	}
-
 	outputHints, err := cmd.Flags().GetBool("output-hints")
 	if err != nil {
 		return err
 	}
 
-	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath, suggestionsConfig, outputHints); err != nil {
+	if err := validation.ValidateOpenAPI(cmd.Context(), schemaPath, nil, outputHints); err != nil {
 		rootCmd.SilenceUsage = true
 
 		return err

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -72,7 +72,10 @@ func ValidateOpenAPI(ctx context.Context, schemaPath string, suggestionsConfig *
 	if len(vErrs) > 0 {
 		status := "OpenAPI spec invalid ✖"
 		github.GenerateSummary(status, vErrs)
-		return fmt.Errorf(status)
+		if suggestionsConfig == nil {
+			return fmt.Errorf(status)
+		}
+		return nil
 	} else {
 		if findSuggestions {
 			fmt.Println(promptui.Styler(promptui.FGGreen, promptui.FGBold)("No errors found in OpenAPI spec, skipping suggestions!"))


### PR DESCRIPTION
Will disentangle in near future (ie. not have suggest and validate both run `validate.ValidateOpenAPI`).

Just want to get this fix in so when max-suggestions is applied, we don't fail the suggest action even if there are still >0 validation errors remaining in document. 