### PR TITLE
fix: preserve empty arr instead of converting to null

### DIFF
--- a/internal/suggestions/fileFormatter.go
+++ b/internal/suggestions/fileFormatter.go
@@ -60,7 +60,7 @@ func recurseYamlToJson(v interface{}) interface{} {
 	case reflect.TypeOf(yaml.MapSlice{}):
 		return yamlToJson(v.(yaml.MapSlice))
 	case reflect.TypeOf([]interface{}{}):
-		var vals []interface{}
+		vals := make([]interface{}, 0)
 		for _, v := range v.([]interface{}) {
 			vals = append(vals, recurseYamlToJson(v))
 		}
@@ -89,7 +89,7 @@ func recurseJsonToYaml(v interface{}) interface{} {
 	case reflect.TypeOf(orderedmap.OrderedMap{}):
 		return jsonToYaml(v.(orderedmap.OrderedMap))
 	case reflect.TypeOf([]interface{}{}):
-		var vals []interface{}
+		vals := make([]interface{}, 0)
 		for _, v := range v.([]interface{}) {
 			vals = append(vals, recurseJsonToYaml(v))
 		}


### PR DESCRIPTION
Could definitely benefit from having more unit tests in suggest portion of CLI: https://linear.app/speakeasy/issue/SPE-1995/unit-tests-for-suggest-portion-of-cli

Making this fix quickly for now to see if we can't get some suggest results for customer specs by EOD 