### PR TITLE
feat: enable PR comments on line numbers

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,6 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/speakeasy-api/easytemplate v0.7.4 h1:6iesUjK410/ClRYhBZtV2G1H70C3+S3PbWyYOUcnjkM=
 github.com/speakeasy-api/easytemplate v0.7.4/go.mod h1:wpCVerXH0vA5Fu34xgXK2jJC5UEL42WRa6Pk+1K32yw=
-github.com/speakeasy-api/openapi-generation/v2 v2.88.7 h1:oSLAaXESQUte2qkftYUxcexBchmGun2mLJ3v382GNo4=
-github.com/speakeasy-api/openapi-generation/v2 v2.88.7/go.mod h1:ts+SrgreXIKVAUL77djM6imWsSggfo7DWM8FkyI/vps=
 github.com/speakeasy-api/openapi-generation/v2 v2.89.1 h1:PeIUhXCCcLTsLG8LtPBG1Cbf+yk8TQ427Mu7SWgzcsw=
 github.com/speakeasy-api/openapi-generation/v2 v2.89.1/go.mod h1:ts+SrgreXIKVAUL77djM6imWsSggfo7DWM8FkyI/vps=
 github.com/speakeasy-api/sdk-gen-config v0.8.1 h1:2DQibuWJuWGpCixaDJMiHkQUODKEJOWiklWoBDmqtZA=

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -40,7 +40,9 @@ func NewLogger(associatedFile string) *Logger {
 func (l *Logger) Info(msg string, fields ...zapcore.Field) {
 	fields = append(l.fields, fields...)
 
-	fmt.Printf("%s%s%s\n", l.getPrefix(levelInfo, nil), msg, fieldsToJSON(fields))
+	msg, err, fields := getMessage(msg, fields)
+
+	fmt.Fprintf(os.Stderr, utils.Red("%s%s%s\n"), l.getPrefix(levelInfo, err), msg, fieldsToJSON(fields))
 }
 
 func (l *Logger) Warn(msg string, fields ...zapcore.Field) {

--- a/internal/suggestions/client.go
+++ b/internal/suggestions/client.go
@@ -57,7 +57,7 @@ func Upload(schema []byte, filePath string, model string) (string, string, error
 	writer := multipart.NewWriter(body)
 	part, err := writer.CreatePart(map[string][]string{
 		"Content-Disposition": {"form-data; name=\"file\"; filename=\"" + filepath.Base(filePath) + "\""},
-		"Content-Type":        {DetectFileType(filePath)}, // Set the MIME type here
+		"Content-Type":        {detectFileType(filePath)}, // Set the MIME type here
 	})
 	if err != nil {
 		return "", "", err


### PR DESCRIPTION
This PR makes the CLI output validation errors with the correct line number according to the original file type for `suggest`. Currently, if we run suggest on a YAML file, the `suggest` output will show the line number from the JSON conversion since that's the file type we're operating on in the agent loop. We need the output to reflect the original file type so the `finalize` stage of the action can use this for creating PR comments, but the agent can continue to work off the JSON conversion. 