### PR TITLE
fix: ensure executable permissions on install

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -148,7 +148,8 @@ do_install_binary() {
   (cd $tmp_dir && unzip -q "$asset_name")
 
   # Install binary
-  sudo -p "sudo password required for installing to $INSTALL_DIR: " mv "$tmp_dir/$BINARY_NAME" $INSTALL_DIR
+  sudo_cmd='mv '"$tmp_dir/$BINARY_NAME"' '"$INSTALL_DIR"' && chmod a+x '"$INSTALL_DIR/$BINARY_NAME"
+  sudo -p "sudo password required for installing to $INSTALL_DIR: " -- sh -c "$sudo_cmd"
   echo "Installed speakeasy to $INSTALL_DIR"
 
   # Cleanup


### PR DESCRIPTION
Noticed that install.sh does not correctly set +x perms on my Linux laptop. This fixes the problem.