### PR TITLE
feat: generated usage snippets in CLI

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -164,6 +164,7 @@ func genInit() {
 //nolint:errcheck
 func genSDKInit() {
 	genSDKCmd.Flags().StringP("lang", "l", "go", fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(generate.GetSupportedLanguages(), ", ")))
+
 	genSDKCmd.Flags().StringP("schema", "s", "./openapi.yaml", "path to the openapi schema")
 	genSDKCmd.MarkFlagRequired("schema")
 

--- a/go.mod
+++ b/go.mod
@@ -12,8 +12,9 @@ require (
 	github.com/iancoleman/orderedmap v0.3.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pb33f/libopenapi v0.9.9
+	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.101.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.107.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0
 	github.com/speakeasy-api/speakeasy-core v0.0.0-20230614153131-6b4b81e1c6a4
 	github.com/speakeasy-api/speakeasy-proxy v0.0.0-20230602101639-c41c44041e5a
@@ -110,7 +111,6 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/pkg/browser v0.0.0-20210911075715-681adbf594b8 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/posthog/posthog-go v0.0.0-20220817142604-0b0bbf0f9c0f // indirect
 	github.com/pterm/pterm v0.12.57 // indirect

--- a/go.sum
+++ b/go.sum
@@ -525,8 +525,8 @@ github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeV
 github.com/spaolacci/murmur3 v0.0.0-20180118202830-f09979ecbc72/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/speakeasy-api/easytemplate v0.7.4 h1:6iesUjK410/ClRYhBZtV2G1H70C3+S3PbWyYOUcnjkM=
 github.com/speakeasy-api/easytemplate v0.7.4/go.mod h1:wpCVerXH0vA5Fu34xgXK2jJC5UEL42WRa6Pk+1K32yw=
-github.com/speakeasy-api/openapi-generation/v2 v2.101.0 h1:fglRjFjKC8STrKLK8xz2u+77pVQxIIz0BkWQ/Dgp3Vs=
-github.com/speakeasy-api/openapi-generation/v2 v2.101.0/go.mod h1:ts+SrgreXIKVAUL77djM6imWsSggfo7DWM8FkyI/vps=
+github.com/speakeasy-api/openapi-generation/v2 v2.107.0 h1:9jZVYKsUJkisrxwo/SJzY3UCAkH6VkNkbJMegE3qxT8=
+github.com/speakeasy-api/openapi-generation/v2 v2.107.0/go.mod h1:dE5XOSpLWHKjrGxgbuWl28cQQRKmsGVxPJSi+B3vvC4=
 github.com/speakeasy-api/sdk-gen-config v0.8.1 h1:2DQibuWJuWGpCixaDJMiHkQUODKEJOWiklWoBDmqtZA=
 github.com/speakeasy-api/sdk-gen-config v0.8.1/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0 h1:RqYjM0okHjjEyKRxumaTmZDWt68nGZo1sbIfALyqLCg=

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -1,0 +1,196 @@
+package usagegen
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/pkg/errors"
+	changelog "github.com/speakeasy-api/openapi-generation/v2"
+	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"go.uber.org/zap"
+)
+
+var SupportedLanguagesUsageSnippets = []string{
+	"go",
+	"typescript",
+	"python",
+	"java",
+	"php",
+	"swift",
+	"ruby",
+}
+
+func Generate(ctx context.Context, customerID, lang, schemaPath, out, operation, namespace string) error {
+	matchedLanguage := false
+	for _, language := range SupportedLanguagesUsageSnippets {
+		if language == lang {
+			matchedLanguage = true
+		}
+	}
+
+	if !matchedLanguage {
+		return fmt.Errorf("language not supported: %s", lang)
+	}
+
+	schema, err := os.ReadFile(schemaPath)
+	if err != nil {
+		return fmt.Errorf("failed to read schema file %s: %w", schemaPath, err)
+	}
+
+	l := log.NewLogger(schemaPath)
+
+	outputBuffer := &bytes.Buffer{}
+	opts := []generate.GeneratorOptions{
+		generate.WithLogger(l),
+		generate.WithCustomerID(customerID),
+		generate.WithFileFuncs(writeFileWithBuffer(outputBuffer), os.ReadFile),
+		generate.WithRunLocation("cli"),
+		generate.WithGenVersion(strings.TrimPrefix(changelog.GetLatestVersion(), "v")),
+		generate.WithAllowRemoteReferences(),
+	}
+
+	if operation == "" && namespace == "" {
+		// TODO: Eventually we will just allow this to default to return the root usage snippets
+		return fmt.Errorf("must supply a operation or namespace")
+	} else if operation != "" {
+		opts = append(opts, generate.WithUsageSnippetArgsByOperationID(operation))
+	} else {
+		opts = append(opts, generate.WithUsageSnippetArgsByGroupName(namespace))
+	}
+
+	g, err := generate.New(opts...)
+	if err != nil {
+		return err
+	}
+
+	if errs := g.Generate(context.Background(), schema, schemaPath, lang, ""); len(errs) > 0 {
+		for _, err := range errs {
+			l.Error("", zap.Error(err))
+		}
+
+		return fmt.Errorf("failed to generate usage snippets for %s ✖", lang)
+	}
+
+	if out == "" {
+		// By default, write to stdout
+		fmt.Println(outputBuffer.String())
+	} else if isDirectory(out) {
+		return writeFormattedDirectory(lang, out, outputBuffer.String())
+	} else {
+		file, err := os.OpenFile(out, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o644)
+		if err != nil {
+			return errors.Wrap(err, "cannot write to provided file")
+		}
+		defer file.Close()
+
+		_, err = file.WriteString(outputBuffer.String())
+		if err != nil {
+			return errors.Wrap(err, "cannot write to provided file")
+		}
+	}
+
+	return nil
+}
+
+func writeFileWithBuffer(buf *bytes.Buffer) func(outFileName string, data []byte, mode os.FileMode) error {
+	return func(outFileName string, data []byte, mode os.FileMode) error {
+		// Make this resilient to additional files being inadvertently written
+		if strings.Contains(string(data), "Usage snippet provided for") {
+			_, err := buf.Write(data)
+			return err
+		}
+
+		return nil
+	}
+}
+
+// writeFormattedDirectory: writes each OperationIDs usage snippet into its own directory with a single main file
+// This will be used frequently by things like devcontainers
+func writeFormattedDirectory(lang, path, content string) error {
+	// Split the input string by the key phrase "Usage snippet provided for"
+	snippets := strings.Split(content, "Usage snippet provided for")
+
+	// Throw out the first line it will just be // or #
+	if strings.Contains(snippets[0], "//") || strings.Contains(snippets[0], "#") {
+		snippets = snippets[1:]
+	}
+
+	for _, snippet := range snippets {
+		lines := strings.Split(snippet, "\n")
+
+		// grab the operation name and trim it out of the snippet
+		operationName := strings.TrimSpace(lines[0])
+		lines = lines[1:]
+
+		// remove the trailing line if it includes an empty comment string
+		if strings.TrimSpace(lines[len(lines)-1]) == "//" || strings.TrimSpace(lines[len(lines)-1]) == "#" {
+			lines = lines[0 : len(lines)-1]
+		}
+
+		// trim empty lines at the end of the snippet
+		for len(strings.TrimSpace(lines[len(lines)-1])) == 0 {
+			lines = lines[0 : len(lines)-1]
+		}
+
+		// write out directory structure
+		directoryPath := path + "/" + strings.ToLower(operationName)
+		if err := writeExampleCode(lang, directoryPath, strings.Join(lines, "\n")); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func writeExampleCode(lang, path, code string) error {
+	outFile := ""
+	switch lang {
+	case "go":
+		outFile = path + "/main.go"
+	case "csharp":
+		outFile = path + "/Program.cs"
+	case "unity":
+		outFile = path + "/Program.cs"
+	case "java":
+		outFile = path + "/main.java"
+	case "php":
+		outFile = path + "/main.php"
+	case "python":
+		outFile = path + "/main.py"
+	case "ruby":
+		outFile = path + "/app.rb"
+	case "swift":
+		outFile = path + "/main.swift"
+	case "typescript":
+		outFile = path + "/index.ts"
+	default:
+		return fmt.Errorf("language not supported: %s", lang)
+	}
+
+	if err := os.RemoveAll(path); err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(path, 0o755); err != nil {
+		return err
+	}
+
+	if err := os.WriteFile(outFile, []byte(code), 0o644); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isDirectory(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+
+	return info.IsDir()
+}

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -22,6 +22,8 @@ var SupportedLanguagesUsageSnippets = []string{
 	"php",
 	"swift",
 	"ruby",
+	"csharp",
+	"unity",
 }
 
 func Generate(ctx context.Context, customerID, lang, schemaPath, out, operation, namespace string) error {
@@ -54,12 +56,11 @@ func Generate(ctx context.Context, customerID, lang, schemaPath, out, operation,
 	}
 
 	if operation == "" && namespace == "" {
-		// TODO: Eventually we will just allow this to default to return the root usage snippets
-		return fmt.Errorf("must supply a operation or namespace")
+		opts = append(opts, generate.WithUsageSnippetArgsByRootExample())
 	} else if operation != "" {
 		opts = append(opts, generate.WithUsageSnippetArgsByOperationID(operation))
 	} else {
-		opts = append(opts, generate.WithUsageSnippetArgsByGroupName(namespace))
+		opts = append(opts, generate.WithUsageSnippetArgsByNamespace(namespace))
 	}
 
 	g, err := generate.New(opts...)


### PR DESCRIPTION
Fixes SPE-1979

Adds on demand usage snippet generation to our CLI

Example by operation-id
speakeasy generate usage -s ./test.yaml -l go -i usageExamplePost

Example by namespace
speakeasy generate usage -s ./test.yaml -l go -n server

Example write to file
speakeasy generate usage -s ./test.yaml -l go -i usageExamplePost -o out.txt

Example formatted dir
speakeasy generate usage -s ./test.yaml -l go -i usageExamplePost -o ./out
