### PR TITLE
feat: improve usage examples

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,7 @@ require (
 	github.com/pb33f/libopenapi v0.10.2
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.131.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.139.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0
 	github.com/speakeasy-api/speakeasy-core v0.0.0-20230614153131-6b4b81e1c6a4
 	github.com/speakeasy-api/speakeasy-proxy v0.0.0-20230602101639-c41c44041e5a
@@ -88,6 +88,7 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/jinzhu/copier v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/kyokomi/emoji/v2 v2.2.8 // indirect

--- a/go.sum
+++ b/go.sum
@@ -370,6 +370,8 @@ github.com/imdario/mergo v0.3.15/go.mod h1:WBLT9ZmE3lPoWsEzCh9LPo3TiwVN+ZKEjmz+h
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jessevdk/go-flags v1.4.0/go.mod h1:4FA24M0QyGHXBuZZK/XkWh8h0e1EYbRYJSGM75WSRxI=
+github.com/jinzhu/copier v0.4.0 h1:w3ciUoD19shMCRargcpm0cm91ytaBhDvuRpz1ODO/U8=
+github.com/jinzhu/copier v0.4.0/go.mod h1:DfbEm0FYsaqBcKcFuvmOZb218JkPGtvSHsKg8S8hyyg=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
 github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
@@ -527,6 +529,8 @@ github.com/speakeasy-api/easytemplate v0.7.5 h1:/yJMOb+ZvsCQc9uuZQ3yaH+Dg0s+CYZa
 github.com/speakeasy-api/easytemplate v0.7.5/go.mod h1:wpCVerXH0vA5Fu34xgXK2jJC5UEL42WRa6Pk+1K32yw=
 github.com/speakeasy-api/openapi-generation/v2 v2.131.1 h1:VOG+TN8DMmpkU19HxmEDpZTk2YCFrdx4yjiBqrL3dJA=
 github.com/speakeasy-api/openapi-generation/v2 v2.131.1/go.mod h1:i9XUubLtcxQUJ3JyOJS1Xf3o/2MV0K+cjAsdm1UVmrk=
+github.com/speakeasy-api/openapi-generation/v2 v2.139.0 h1:W5cpLXpDBPqF29gCO+VBAvwz2ILvADuI+jdaBk+aUDs=
+github.com/speakeasy-api/openapi-generation/v2 v2.139.0/go.mod h1:/3UFYIBv6c1e6rVxqHNwOnI9uAQUEZXXGssFo3fFrXw=
 github.com/speakeasy-api/sdk-gen-config v0.8.3 h1:+7aH98feuy6ol47j9XIo8m5LNuWoQHfhV5EhrPd2K/I=
 github.com/speakeasy-api/sdk-gen-config v0.8.3/go.mod h1:osr44mhKoRboNtEDMPaDoyH486pLLJH8yvKvnujqnUU=
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0 h1:RqYjM0okHjjEyKRxumaTmZDWt68nGZo1sbIfALyqLCg=


### PR DESCRIPTION
Fix #264

Usage example generation was improved in two ways:
- randomly generated data is now more stable to changes made to the spec [SPE-1670](https://linear.app/speakeasy/issue/SPE-1670/ensure-example-generation-in-usage-snippets-is-stable) [PR#573](https://github.com/speakeasy-api/openapi-generation/pull/573)
- additional faker methods were implemented to add relevance to the generated data based on fields format (or fieldname) [SPE-2022](https://linear.app/speakeasy/issue/SPE-2022/better-example-generation) [PR#580](https://github.com/speakeasy-api/openapi-generation/pull/580)