### PR TITLE
fix: make 1000 msgs global default

### DIFF
--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -45,8 +45,8 @@ func validateOpenAPIInit() {
 	validateOpenAPICmd.Flags().StringP("header", "H", "", "header key to use if authentication is required for downloading schema from remote URL")
 	validateOpenAPICmd.Flags().String("token", "", "token value to use if authentication is required for downloading schema from remote URL")
 
-	validateOpenAPICmd.Flags().Int("max-validation-warnings", 0, "limit the number of warnings to output (default 0 = no limit)")
-	validateOpenAPICmd.Flags().Int("max-validation-errors", 0, "limit the number of errors to output (default 0 = no limit)")
+	validateOpenAPICmd.Flags().Int("max-validation-warnings", 1000, "limit the number of warnings to output (default 1000, 0 = no limit)")
+	validateOpenAPICmd.Flags().Int("max-validation-errors", 1000, "limit the number of errors to output (default 1000, 0 = no limit)")
 
 	validateCmd.AddCommand(validateOpenAPICmd)
 }

--- a/internal/suggestions/suggestions.go
+++ b/internal/suggestions/suggestions.go
@@ -315,7 +315,10 @@ func (s *Suggestions) revalidate(printSummary bool) ([]errorAndCommentLineNumber
 }
 
 func validate(schema []byte, schemaPath string, level errors.Severity, isRemote, printSummary bool) ([]error, error) {
-	vErrs, vWarns, vInfo, err := validation.Validate(schema, schemaPath, isRemote, true)
+	limits := &validation.OutputLimits{
+		OutputHints: isRemote,
+	}
+	vErrs, vWarns, vInfo, err := validation.Validate(schema, schemaPath, limits, true)
 	if err != nil {
 		return nil, fmt.Errorf("failed to validate YAML: %v", err)
 	}


### PR DESCRIPTION
Go ahead and apply 1000 default to the CLI. This allows the fix to go through without needing an action update. When we release the next version of the action, we can make this default to 0 again, if we like