### PR TITLE
feat: openapi-overlays v0.3.0 (preserve order)

### DIFF
--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -97,7 +97,7 @@ func RunCompare(c *cobra.Command, args []string) error {
 
 	title := fmt.Sprintf("Overlay %s => %s", schemas[0], schemas[1])
 
-	o, err := overlay.Compare(title, schemas[0], y1, y2)
+	o, err := overlay.Compare(title, schemas[0], y1, *y2)
 	if err != nil {
 		return fmt.Errorf("failed to compare spec files %q and %q: %w", schemas[0], schemas[1], err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/openapi-generation/v2 v2.188.3
-	github.com/speakeasy-api/openapi-overlay v0.2.2
+	github.com/speakeasy-api/openapi-overlay v0.3.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0
 	github.com/speakeasy-api/speakeasy-core v0.0.0-20230614153131-6b4b81e1c6a4
 	github.com/speakeasy-api/speakeasy-proxy v0.0.0-20230602101639-c41c44041e5a

--- a/go.sum
+++ b/go.sum
@@ -539,6 +539,8 @@ github.com/speakeasy-api/openapi-generation/v2 v2.188.3 h1:s8FGJTaDiOD8ag/lIxALO
 github.com/speakeasy-api/openapi-generation/v2 v2.188.3/go.mod h1:z0XC8p7PbbUzY1ycwAhtfsfBP5265uIGdHzR1urIFi8=
 github.com/speakeasy-api/openapi-overlay v0.2.2 h1:Q2pU8PbJIWmyJUT/bDn94IBLefJojlOaXdGSILy1cSY=
 github.com/speakeasy-api/openapi-overlay v0.2.2/go.mod h1:Fv/Q+lUoJkRGx18rx7RFU0dwlA2vWDQIDDDlUQTqnJM=
+github.com/speakeasy-api/openapi-overlay v0.3.0 h1:+5hIbDzyO7rD0ix9num8Y0bxbhwzRF28QluZ+dCuugA=
+github.com/speakeasy-api/openapi-overlay v0.3.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.2.0 h1:u5UCrS63TXpNPgsBqU4iSmG0ZnFjKg7gDC8ICKVviu0=
 github.com/speakeasy-api/sdk-gen-config v1.2.0/go.mod h1:94mmqrM5tP6/O8triQo9PIb6YYqihtKeoH70uwQ+JF4=
 github.com/speakeasy-api/speakeasy-client-sdk-go v1.14.0 h1:RqYjM0okHjjEyKRxumaTmZDWt68nGZo1sbIfALyqLCg=


### PR DESCRIPTION
 * Makes overlay generation (via spec comparison) work better. Test cases strengthened.
 * Makes overlay apply work with arrays
 * Makes the order of yaml map content be preserved
 * Allows for merging in of $ref nodes via not resolving recursively: the speakeasy merge tool should be now be used to merge full openapi specs