### PR TITLE
chore: initial log proxy in CLI

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -352,7 +352,7 @@ func collectSDKGenLoggingFields(lang, schemaPath, repo, repoSubDir string) []zap
 	}
 
 	if repo != "" {
-		logProxyFields = append(logProxyFields, zap.String("gh_repo", repo))
+		logProxyFields = append(logProxyFields, zap.String("gh_repository", fmt.Sprintf("https://github.com/%s", repo)))
 		parts := strings.Split(repo, "/")
 		logProxyFields = append(logProxyFields, zap.String("gh_organization", parts[0]))
 	}

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -342,7 +342,7 @@ func collectSDKGenLoggingFields(lang, schemaPath, repo, repoSubDir string) []zap
 		runLocation = "cli"
 	}
 	logProxyFields := []zap.Field{
-		zap.String("run_location", runLocation),
+		zap.String("run_origin", runLocation),
 		zap.String("language", lang),
 		zap.String("schema_path", schemaPath),
 		zap.String("target", "sdk"),
@@ -353,6 +353,8 @@ func collectSDKGenLoggingFields(lang, schemaPath, repo, repoSubDir string) []zap
 
 	if repo != "" {
 		logProxyFields = append(logProxyFields, zap.String("gh_repo", repo))
+		parts := strings.Split(repo, "/")
+		logProxyFields = append(logProxyFields, zap.String("gh_organization", parts[0]))
 	}
 	if repoSubDir != "" {
 		logProxyFields = append(logProxyFields, zap.String("gh_directory", repoSubDir))

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -341,7 +341,6 @@ func collectSDKGenLoggingFields(lang, schemaPath, repo, repoSubDir string) []zap
 	if runLocation == "" {
 		runLocation = "cli"
 	}
-	// TODO: find some way for the cli to detect version in use.
 	logProxyFields := []zap.Field{
 		zap.String("run_location", runLocation),
 		zap.String("language", lang),
@@ -349,6 +348,7 @@ func collectSDKGenLoggingFields(lang, schemaPath, repo, repoSubDir string) []zap
 		zap.String("target", "sdk"),
 		zap.String("customer_id", config.GetCustomerID()),
 		zap.String("command", "generate_sdk"),
+		zap.String("speakeasy_version", genVersion),
 	}
 
 	if repo != "" {

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -127,7 +127,7 @@ func collectValidationLoggingFields(schemaPath string) []zap.Field {
 		runLocation = "cli"
 	}
 	logProxyFields := []zap.Field{
-		zap.String("run_location", runLocation),
+		zap.String("run_origin", runLocation),
 		zap.String("schema_path", schemaPath),
 		zap.String("customer_id", config.GetCustomerID()),
 		zap.String("command", "validate_openapi"),

--- a/cmd/validate.go
+++ b/cmd/validate.go
@@ -126,12 +126,12 @@ func collectValidationLoggingFields(schemaPath string) []zap.Field {
 	if runLocation == "" {
 		runLocation = "cli"
 	}
-	// TODO: find some way for the cli to detect version in use.
 	logProxyFields := []zap.Field{
 		zap.String("run_location", runLocation),
 		zap.String("schema_path", schemaPath),
 		zap.String("customer_id", config.GetCustomerID()),
 		zap.String("command", "validate_openapi"),
+		zap.String("speakeasy_version", genVersion),
 	}
 
 	return logProxyFields

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -37,6 +37,20 @@ func NewLogger(associatedFile string) *Logger {
 	}
 }
 
+func (l *Logger) InfoProxy(msg string, fields ...zapcore.Field) {
+	fields = append(l.fields, fields...)
+	if err := flushLog(msg, logProxyLevelInfo, fields); err != nil {
+		fmt.Fprintf(os.Stderr, utils.Blue("error flushing info logs"))
+	}
+}
+
+func (l *Logger) ErrorProxy(msg string, fields ...zapcore.Field) {
+	fields = append(l.fields, fields...)
+	if err := flushLog(msg, logProxyLevelError, fields); err != nil {
+		fmt.Fprintf(os.Stderr, utils.Blue("error flushing error logs"))
+	}
+}
+
 func (l *Logger) Info(msg string, fields ...zapcore.Field) {
 	fields = append(l.fields, fields...)
 

--- a/internal/log/logproxy.go
+++ b/internal/log/logproxy.go
@@ -1,0 +1,77 @@
+package log
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/speakeasy-api/speakeasy/internal/config"
+	"go.uber.org/zap"
+)
+
+const ApiURL = "https://api.prod.speakeasyapi.dev"
+
+type logProxyLevel string
+
+const (
+	logProxyLevelInfo  logProxyLevel = "info"
+	logProxyLevelError logProxyLevel = "error"
+)
+
+type logProxyEntry struct {
+	LogLevel logProxyLevel `json:"log_level"`
+	Message  string        `json:"message"`
+	// We may make more logic decisions based source at some point.
+	Source string                 `json:"source"`
+	Tags   map[string]interface{} `json:"tags"`
+}
+
+func flushLog(message string, level logProxyLevel, fields []zap.Field) error {
+	key, _ := config.GetSpeakeasyAPIKey()
+	if key == "" {
+		return fmt.Errorf("no speakeasy api key available, please set SPEAKEASY_API_KEY or run 'speakeasy auth' to authenticate the CLI with the Speakeasy Platform")
+	}
+
+	request := logProxyEntry{
+		LogLevel: level,
+		Message:  message,
+		Source:   "cli",
+	}
+
+	tags := make(map[string]interface{}, 0)
+	for _, field := range fields {
+		tags[field.Key] = field.Interface
+	}
+	request.Tags = tags
+
+	body, err := json.Marshal(&request)
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("POST", ApiURL+"/v1/log/proxy", bytes.NewBuffer(body))
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Api-Key", key)
+
+	client := &http.Client{
+		Timeout: time.Second * 5,
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("session token is empty")
+	}
+
+	return nil
+}

--- a/internal/log/logproxy.go
+++ b/internal/log/logproxy.go
@@ -5,13 +5,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"time"
 
 	"github.com/speakeasy-api/speakeasy/internal/config"
 	"go.uber.org/zap"
 )
 
-const ApiURL = "https://api.prod.speakeasyapi.dev"
+const defaultAPIURL = "https://api.prod.speakeasyapi.dev"
 
 type logProxyLevel string
 
@@ -51,7 +52,12 @@ func flushLog(message string, level logProxyLevel, fields []zap.Field) error {
 		return err
 	}
 
-	req, err := http.NewRequest("POST", ApiURL+"/v1/log/proxy", bytes.NewBuffer(body))
+	baseURL := os.Getenv("SPEAKEASY_SERVER_URL")
+	if baseURL == "" {
+		baseURL = defaultAPIURL
+	}
+
+	req, err := http.NewRequest("POST", baseURL+"/v1/log/proxy", bytes.NewBuffer(body))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
An initial use case for proxied logging to get basic visibility into 
- SDK Generation Runs
- Spec Validation


Eventually I would like to just flush and proxy all logs collected by the CLI, but for a POC I just want to get basic logging with useful tags going for both the CLI and Github Actions.