### PR TITLE
feat: optional config path for usage snippet generation

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -217,7 +217,7 @@ func genSDKInit() {
 	genUsageSnippetCmd.Flags().StringP("namespace", "n", "", "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.")
 	genUsageSnippetCmd.Flags().StringP("out", "o", "", `By default this command will write to stdout. If a filepath is provided results will be written into that file.
 	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`)
-	genUsageSnippetCmd.Flags().StringP("config-path", "c", "./", "An optional argument to pass in the path to a directory that holds the gen.yaml configuration file.")
+	genUsageSnippetCmd.Flags().StringP("config-path", "c", ".", "An optional argument to pass in the path to a directory that holds the gen.yaml configuration file.")
 
 	genSDKCmd.AddCommand(genSDKVersionCmd)
 	genSDKCmd.AddCommand(genSDKChangelogCmd)

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -216,7 +216,9 @@ func genSDKInit() {
 	genUsageSnippetCmd.Flags().StringP("operation-id", "i", "", "The OperationID to generate usage snippet for")
 	genUsageSnippetCmd.Flags().StringP("namespace", "n", "", "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.")
 	genUsageSnippetCmd.Flags().StringP("out", "o", "", `By default this command will write to stdout. If a filepath is provided results will be written into that file.
+
 	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`)
+	genUsageSnippetCmd.Flags().StringP("config-path", "c", "./", "An optional argument to pass in the path to a gen.yaml configuration file.")
 
 	genSDKCmd.AddCommand(genSDKVersionCmd)
 	genSDKCmd.AddCommand(genSDKChangelogCmd)
@@ -314,10 +316,11 @@ func genUsageSnippets(cmd *cobra.Command, args []string) error {
 	}
 
 	out, _ := cmd.Flags().GetString("out")
+	configPath, _ := cmd.Flags().GetString("config-path")
 	operation, _ := cmd.Flags().GetString("operation-id")
 	namespace, _ := cmd.Flags().GetString("namespace")
 
-	if err := usagegen.Generate(cmd.Context(), config.GetCustomerID(), lang, schemaPath, header, token, out, operation, namespace); err != nil {
+	if err := usagegen.Generate(cmd.Context(), config.GetCustomerID(), lang, schemaPath, header, token, out, operation, namespace, configPath); err != nil {
 		rootCmd.SilenceUsage = true
 
 		return err

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -216,7 +216,6 @@ func genSDKInit() {
 	genUsageSnippetCmd.Flags().StringP("operation-id", "i", "", "The OperationID to generate usage snippet for")
 	genUsageSnippetCmd.Flags().StringP("namespace", "n", "", "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.")
 	genUsageSnippetCmd.Flags().StringP("out", "o", "", `By default this command will write to stdout. If a filepath is provided results will be written into that file.
-
 	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`)
 	genUsageSnippetCmd.Flags().StringP("config-path", "c", "./", "An optional argument to pass in the path to a gen.yaml configuration file.")
 

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -217,7 +217,7 @@ func genSDKInit() {
 	genUsageSnippetCmd.Flags().StringP("namespace", "n", "", "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.")
 	genUsageSnippetCmd.Flags().StringP("out", "o", "", `By default this command will write to stdout. If a filepath is provided results will be written into that file.
 	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`)
-	genUsageSnippetCmd.Flags().StringP("config-path", "c", "./", "An optional argument to pass in the path to a gen.yaml configuration file.")
+	genUsageSnippetCmd.Flags().StringP("config-path", "c", "./", "An optional argument to pass in the path to a directory that holds the gen.yaml configuration file.")
 
 	genSDKCmd.AddCommand(genSDKVersionCmd)
 	genSDKCmd.AddCommand(genSDKChangelogCmd)

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -4,9 +4,10 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/schema"
 	"os"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/schema"
 
 	"github.com/pkg/errors"
 	changelog "github.com/speakeasy-api/openapi-generation/v2"
@@ -27,7 +28,7 @@ var SupportedLanguagesUsageSnippets = []string{
 	"unity",
 }
 
-func Generate(ctx context.Context, customerID, lang, schemaPath, header, token, out, operation, namespace string) error {
+func Generate(ctx context.Context, customerID, lang, schemaPath, header, token, out, operation, namespace, configPath string) error {
 	matchedLanguage := false
 	for _, language := range SupportedLanguagesUsageSnippets {
 		if language == lang {
@@ -69,7 +70,7 @@ func Generate(ctx context.Context, customerID, lang, schemaPath, header, token, 
 		return err
 	}
 
-	if errs := g.Generate(context.Background(), schema, schemaPath, lang, "", isRemote); len(errs) > 0 {
+	if errs := g.Generate(context.Background(), schema, schemaPath, lang, configPath, isRemote); len(errs) > 0 {
 		for _, err := range errs {
 			l.Error("", zap.Error(err))
 		}


### PR DESCRIPTION
This solves two problems
1. Generation now does not allow "" to be passed as an out dir.
2. For usage snippet generation the out dir is not necessarily tied to where the gen.yaml config is when it's used in things like codespaces or potentially customers use it in docs areas. We should allow it to be an optional argument. We might rework this anyways with new workflow file developments.