### PR TITLE
fix: Make --lang required, edit copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,16 +330,16 @@ speakeasy [flags]
 `speakeasy`  
 
 
-The speakeasy cli tool provides access to the speakeasyapi.dev toolchain  
+The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain  
 
 ### Details
 
- A cli tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
-	- Generating Client SDKs from OpenAPI specs (go, python, typescript, java, php + more coming soon)
-	- Validating OpenAPI specs
-	- Interacting with the Speakeasy API to create and manage your API workspaces
-	- Generating OpenAPI specs from your API traffic 								(coming soon)
-	- Generating Postman collections from OpenAPI Specs 							(coming soon)
+ A CLI tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
+	* Generating Client SDKs from OpenAPI specs (Go, Python, TypeScript, Java, PHP)
+	* Validating OpenAPI specs
+	* Interacting with the Speakeasy API to create and manage your API workspaces
+	* Generating OpenAPI specs from your API traffic 								
+	* Generating Postman collections from OpenAPI Specs 							
 
 
 ### Usage

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -40,13 +40,12 @@ var generateCmd = &cobra.Command{
 
 var genSDKCmd = &cobra.Command{
 	Use:   "sdk",
-	Short: fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s + more coming soon)", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+	Short: fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s)", strings.Join(SDKSupportedLanguageTargets(), ", ")),
 	Long: fmt.Sprintf(`Using the "speakeasy generate sdk" command you can generate client SDK packages for various languages
 that are ready to use and publish to your favorite package registry.
 
 The following languages are currently supported:
 	- %s
-	- more coming soon
 
 By default the command will generate a Go SDK, but you can specify a different language using the --lang flag.
 It will also use generic defaults for things such as package name (openapi), etc.
@@ -177,6 +176,7 @@ func genInit() {
 //nolint:errcheck
 func genSDKInit() {
 	genSDKCmd.Flags().StringP("lang", "l", "go", fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")))
+	genSDKCmd.MarkFlagRequired("lang")
 
 	genSDKCmd.Flags().StringP("schema", "s", "./openapi.yaml", "local filepath or URL for the OpenAPI schema")
 	genSDKCmd.MarkFlagRequired("schema")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -18,13 +18,13 @@ import (
 
 var rootCmd = &cobra.Command{
 	Use:   "speakeasy",
-	Short: "The speakeasy cli tool provides access to the speakeasyapi.dev toolchain",
-	Long: ` A cli tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
-	- Generating Client SDKs from OpenAPI specs (go, python, typescript, java, php + more coming soon)
-	- Validating OpenAPI specs
-	- Interacting with the Speakeasy API to create and manage your API workspaces
-	- Generating OpenAPI specs from your API traffic 								(coming soon)
-	- Generating Postman collections from OpenAPI Specs 							(coming soon)
+	Short: "The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain",
+	Long: ` A CLI tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
+	* Generating Client SDKs from OpenAPI specs (Go, Python, TypeScript, Java, PHP)
+	* Validating OpenAPI specs
+	* Interacting with the Speakeasy API to create and manage your API workspaces
+	* Generating OpenAPI specs from your API traffic 								
+	* Generating Postman collections from OpenAPI Specs 							
 `,
 	RunE: rootExec,
 }

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,16 +2,16 @@
 `speakeasy`  
 
 
-The speakeasy cli tool provides access to the speakeasyapi.dev toolchain  
+The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain  
 
 ## Details
 
- A cli tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
-	- Generating Client SDKs from OpenAPI specs (go, python, typescript, java, php + more coming soon)
-	- Validating OpenAPI specs
-	- Interacting with the Speakeasy API to create and manage your API workspaces
-	- Generating OpenAPI specs from your API traffic 								(coming soon)
-	- Generating Postman collections from OpenAPI Specs 							(coming soon)
+ A CLI tool for interacting with the Speakeasy https://www.speakeasyapi.dev/ platform and its various functions including:
+	* Generating Client SDKs from OpenAPI specs (Go, Python, TypeScript, Java, PHP)
+	* Validating OpenAPI specs
+	* Interacting with the Speakeasy API to create and manage your API workspaces
+	* Generating OpenAPI specs from your API traffic 								
+	* Generating Postman collections from OpenAPI Specs 							
 
 
 ## Usage

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -24,7 +24,7 @@ speakeasy api [flags]
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
 * [speakeasy api download-latest-schema](download-latest-schema.md)	 - Download latest schema

--- a/docs/auth/README.md
+++ b/docs/auth/README.md
@@ -22,7 +22,7 @@ speakeasy auth [flags]
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
 * [speakeasy auth login](login.md)	 - Authenticate the CLI

--- a/docs/docs/README.md
+++ b/docs/docs/README.md
@@ -22,7 +22,7 @@ speakeasy docs [flags]
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
 * [speakeasy docs generate](generate.md)	 - Use this command to generate content for the SDK docs directory.

--- a/docs/generate/README.md
+++ b/docs/generate/README.md
@@ -22,8 +22,8 @@ speakeasy generate [flags]
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
-* [speakeasy generate sdk](sdk/README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity + more coming soon)
+* [speakeasy generate sdk](sdk/README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity)
 * [speakeasy generate usage](usage.md)	 - Generate standalone usage snippets for SDKs in (go, typescript, python, java, php, swift, ruby, csharp, unity)

--- a/docs/generate/sdk/README.md
+++ b/docs/generate/sdk/README.md
@@ -2,7 +2,7 @@
 `speakeasy generate sdk`  
 
 
-Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity + more coming soon)  
+Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity)  
 
 ## Details
 
@@ -21,7 +21,6 @@ The following languages are currently supported:
 	- terraform
 	- typescript
 	- unity
-	- more coming soon
 
 By default the command will generate a Go SDK, but you can specify a different language using the --lang flag.
 It will also use generic defaults for things such as package name (openapi), etc.

--- a/docs/generate/sdk/changelog.md
+++ b/docs/generate/sdk/changelog.md
@@ -27,4 +27,4 @@ speakeasy generate sdk changelog [flags]
 
 ### Parent Command
 
-* [speakeasy generate sdk](README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity + more coming soon)
+* [speakeasy generate sdk](README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity)

--- a/docs/generate/sdk/version.md
+++ b/docs/generate/sdk/version.md
@@ -23,4 +23,4 @@ speakeasy generate sdk version [flags]
 
 ### Parent Command
 
-* [speakeasy generate sdk](README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity + more coming soon)
+* [speakeasy generate sdk](README.md)	 - Generating Client SDKs from OpenAPI specs (csharp, go, java, javav2, php, python, ruby, swift, terraform, typescript, unity)

--- a/docs/merge.md
+++ b/docs/merge.md
@@ -25,4 +25,4 @@ speakeasy merge [flags]
 
 ### Parent Command
 
-* [speakeasy](README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain

--- a/docs/overlay/README.md
+++ b/docs/overlay/README.md
@@ -12,7 +12,7 @@ Work with OpenAPI Overlays
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
 * [speakeasy overlay apply](apply.md)	 - Given an overlay, it will construct a new specification by extending a specification and applying the overlay, and output it to stdout.

--- a/docs/proxy.md
+++ b/docs/proxy.md
@@ -27,4 +27,4 @@ speakeasy proxy [flags]
 
 ### Parent Command
 
-* [speakeasy](README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain

--- a/docs/suggest.md
+++ b/docs/suggest.md
@@ -36,4 +36,4 @@ speakeasy suggest [flags]
 
 ### Parent Command
 
-* [speakeasy](README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain

--- a/docs/update.md
+++ b/docs/update.md
@@ -23,4 +23,4 @@ speakeasy update [flags]
 
 ### Parent Command
 
-* [speakeasy](README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain

--- a/docs/validate/README.md
+++ b/docs/validate/README.md
@@ -22,7 +22,7 @@ speakeasy validate [flags]
 
 ### Parent Command
 
-* [speakeasy](../README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain
+* [speakeasy](../README.md)	 - The speakeasy CLI tool provides access to the speakeasyapi.dev toolchain
 ### Sub Commands
 
 * [speakeasy validate config](config.md)	 - Validates a Speakeasy configuration file for SDK generation


### PR DESCRIPTION
* Fix to make the `--lang` flag required so CLI user has to provide a language and the generate command doesn't unknowingly default to Go
* Fix to update copy in CLI docs