### PR TITLE
fix: improve merge interactive mode

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -17,6 +17,7 @@ Note: That any duplicate operations, components, etc. will be overwritten by the
 }
 
 func mergeInit() {
+	// TODO: Make the usage description change based on whether its being shown in interactive mode. Use a shared description for all array flags
 	mergeCmd.Flags().StringArrayP("schemas", "s", []string{}, "a list of paths to OpenAPI documents to merge, specify -s `path/to/schema1.json` -s `path/to/schema2.json` etc")
 	mergeCmd.MarkFlagRequired("schemas")
 	mergeCmd.Flags().StringP("out", "o", "", "path to the output file")


### PR DESCRIPTION
Three fixes:
- interactive mode handles array flags properly
- interactive mode properly skips optional flags if there aren't any
- logLevel flag properly hidden in interactive mode