### PR TITLE
feat: hide non relevant commands from interactive mode

### DIFF
--- a/cmd/api.go
+++ b/cmd/api.go
@@ -12,7 +12,8 @@ var apiCmd = &cobra.Command{
 	Long: `Provides access to the Speakeasy API via the CLI.
 To authenticate with the Speakeasy API, you must first create an API key via https://app.speakeasyapi.dev
 and then set the SPEAKEASY_API_KEY environment variable to the value of the API key.`,
-	RunE: interactivity.InteractiveRunFn("Choose an API endpoint:"),
+	RunE:   interactivity.InteractiveRunFn("Choose an API endpoint:"),
+	Hidden: true,
 }
 
 func apiInit() {

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -1,8 +1,9 @@
 package cmd
 
 import (
-	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 
 	"github.com/speakeasy-api/speakeasy/internal/config"
 	"github.com/speakeasy-api/speakeasy/internal/docsgen"
@@ -10,10 +11,11 @@ import (
 )
 
 var docsCmd = &cobra.Command{
-	Use:   "docs",
-	Short: "Use this command to generate content, compile, and publish SDK docs.",
-	Long:  "Use this command to generate content, compile, and publish SDK docs. This feature is currently in closed beta, please reach out to speakeasy for more information.",
-	RunE:  interactivity.InteractiveRunFn("Provide a docs sub command"),
+	Use:    "docs",
+	Short:  "Use this command to generate content, compile, and publish SDK docs.",
+	Long:   "Use this command to generate content, compile, and publish SDK docs. This feature is currently in closed beta, please reach out to speakeasy for more information.",
+	RunE:   interactivity.InteractiveRunFn("Provide a docs sub command"),
+	Hidden: true,
 }
 
 var genDocsContentCmd = &cobra.Command{

--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -10,10 +10,11 @@ import (
 )
 
 var proxyCmd = &cobra.Command{
-	Use:   "proxy",
-	Short: "Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities",
-	Long:  `Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities`,
-	RunE:  proxyExec,
+	Use:    "proxy",
+	Short:  "Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities",
+	Long:   `Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities`,
+	RunE:   proxyExec,
+	Hidden: true,
 }
 
 func proxyInit() {


### PR DESCRIPTION
Uses cobras existing construct to hide non-relevant commands from interactive mode

Next Steps
- Try to enable custom ordering of commands (should be doable)
- Deprecate inactive commands (docs we can definitely deprecate)