### PR TITLE
feat: preserve order for CLI commands

### DIFF
--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -2,10 +2,11 @@ package cmd
 
 import (
 	"fmt"
+	"strings"
+
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/usagegen"
 	"golang.org/x/exp/slices"
@@ -243,7 +244,7 @@ func genSDKInit() {
 	genSDKDocsCmd.Flags().StringP("repo-subdir", "b", "", "the subdirectory of the repository where the SDK Docs are located in the repo, helps with documentation generation")
 
 	genSDKCmd.AddCommand(genSDKVersionCmd, genSDKChangelogCmd)
-	generateCmd.AddCommand(genSDKCmd, genUsageSnippetCmd, genSDKDocsCmd)
+	generateCmd.AddCommand(genSDKCmd, genSDKDocsCmd, genUsageSnippetCmd)
 }
 
 func genSDKs(cmd *cobra.Command, args []string) error {

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -1,9 +1,10 @@
 package cmd
 
 import (
+	"os"
+
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -40,9 +41,9 @@ var overlayApplyCmd = &cobra.Command{
 }
 
 func overlayInit() {
+	overlayCmd.AddCommand(overlayApplyCmd)
 	overlayCmd.AddCommand(overlayValidateCmd)
 	overlayCmd.AddCommand(overlayCompareCmd)
-	overlayCmd.AddCommand(overlayApplyCmd)
 
 	overlayValidateCmd.Flags().StringP("overlay", "o", "", "overlay file to validate")
 	overlayValidateCmd.MarkFlagRequired("overlay")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -34,6 +34,8 @@ var rootCmd = &cobra.Command{
 var l = log.New().WithLevel(log.LevelInfo)
 
 func init() {
+	// We want our commands to be sorted in defined order, not alphabetically
+	cobra.EnableCommandSorting = false
 	if err := config.Load(); err != nil {
 		l.Error("", zap.Error(err))
 		os.Exit(1)
@@ -43,19 +45,19 @@ func init() {
 func Init(version, artifactArch string) {
 	rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
 
-	genInit()
-	apiInit()
-	validateInit()
-	authInit()
-	mergeInit()
-	updateInit(version, artifactArch)
-	suggestInit()
-	proxyInit()
-	docsInit()
-	overlayInit()
 	quickstartInit()
 	runInit()
 	configureInit()
+	genInit()
+	validateInit()
+	authInit()
+	mergeInit()
+	overlayInit()
+	suggestInit()
+	updateInit(version, artifactArch)
+	proxyInit()
+	docsInit()
+	apiInit()
 }
 
 func Execute(version, artifactArch string) {


### PR DESCRIPTION
Controlling ordering is actually not too difficult. Cobra's interface of overriding exported `EnableCommandSorting` is a little weird, but this is the way you do it.