### PR TITLE
feat: quickstart streamlining

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -129,7 +129,7 @@ func configureTarget(cmd *cobra.Command, args []string) error {
 		return errors.New("you must have a source to configure a target try speakeasy quickstart")
 	}
 
-	targetName, target, err := prompts.PromptForNewTarget(workflowFile, "")
+	targetName, target, err := prompts.PromptForNewTarget(workflowFile, "", "")
 	if err != nil {
 		return err
 	}

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -26,6 +27,8 @@ var quickstartCmd = &cobra.Command{
 
 func quickstartInit() {
 	quickstartCmd.Flags().BoolP("compile", "c", true, "run SDK validation and generation after quickstart")
+	quickstartCmd.Flags().StringP("schema", "s", "", "local filepath or URL for the OpenAPI schema")
+	quickstartCmd.Flags().StringP("target", "t", "", fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(prompts.GetSupportedTargets(), ", ")))
 	rootCmd.AddCommand(quickstartCmd)
 }
 
@@ -35,6 +38,16 @@ func quickstartExec(cmd *cobra.Command, args []string) error {
 	}
 
 	shouldCompile, err := cmd.Flags().GetBool("compile")
+	if err != nil {
+		return err
+	}
+
+	schemaPath, err := cmd.Flags().GetString("schema")
+	if err != nil {
+		return err
+	}
+
+	targetType, err := cmd.Flags().GetString("target")
 	if err != nil {
 		return err
 	}
@@ -59,6 +72,14 @@ func quickstartExec(cmd *cobra.Command, args []string) error {
 			Targets: make(map[string]workflow.Target),
 		},
 		LanguageConfigs: make(map[string]*config.Configuration),
+	}
+
+	if schemaPath != "" {
+		quickstartObj.Defaults.SchemaPath = &schemaPath
+	}
+
+	if targetType != "" {
+		quickstartObj.Defaults.TargetType = &targetType
 	}
 
 	nextState := prompts.SourceBase

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -14,6 +14,12 @@ type Quickstart struct {
 	WorkflowFile    *workflow.Workflow
 	LanguageConfigs map[string]*config.Configuration
 	GithubWorkflow  *config.GenerateWorkflow
+	Defaults        Defaults
+}
+
+type Defaults struct {
+	SchemaPath *string
+	TargetType *string
 }
 
 // Define constants using iota

--- a/prompts/utils.go
+++ b/prompts/utils.go
@@ -15,7 +15,7 @@ func getSourcesFromWorkflow(inputWorkflow *workflow.Workflow) []string {
 	return sources
 }
 
-func getSupportedTargets() []string {
+func GetSupportedTargets() []string {
 	targets := generate.GetSupportedLanguages()
 	filteredTargets := []string{}
 


### PR DESCRIPTION
Adjustments to streamline quickstart

- Autofill source name and target name
- Only prompt for authentication if remote URL fetch doesn't succeed
- Optionally provide schemaURL as an argument
- Optionally provide target type as an argument