### PR TITLE
feat: configure new target

### DIFF
--- a/internal/charm/utils.go
+++ b/internal/charm/utils.go
@@ -14,6 +14,14 @@ func NewBranchPrompt(title string, output *bool) *huh.Group {
 		Value(output))
 }
 
+func NewSelectPrompt(title string, description string, options []string, output *string) *huh.Group {
+	return huh.NewGroup(huh.NewSelect[string]().
+		Title(title).
+		Description(description + "\n").
+		Options(huh.NewOptions(options...)...).
+		Value(output))
+}
+
 func FormatCommandTitle(title string, description string) string {
 	titleStyle := lipgloss.NewStyle().Foreground(styles.Focused.GetForeground()).Bold(true)
 	descriptionStyle := lipgloss.NewStyle().Foreground(styles.Dimmed.GetForeground()).Italic(true)

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -44,3 +44,25 @@ func CopyFile(src, dst string) error {
 
 	return nil
 }
+
+func MoveFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	if err != nil {
+		return err
+	}
+
+	err = os.Remove(src)
+	return err
+}


### PR DESCRIPTION
Sets up configure new target. This allows us to optionally add a new target to an existing workflow file. We will also enforce that the user sets an output directory for any existing defined target.