### PR TITLE
feat: Move main CLI commands to new interface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ bin/
 .vscode/
 *.iml
 summary.md
+.speakeasy/

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -138,6 +138,7 @@ var genSDKCmd = &model.ExecutableCommand[GenerateFlags]{
 			Hidden:      true,
 		},
 	},
+	NonInteractiveSubcommands: []model.Command{genSDKVersionCmd, genSDKChangelogCmd},
 }
 
 type GenerateUsageSnippetFlags struct {

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -54,6 +54,7 @@ var (
 		Name:        "out",
 		Shorthand:   "o",
 		Description: "path to the output directory",
+		Required:    true,
 	}
 	debugFlag = model.BooleanFlag{
 		Name:        "debug",

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -109,9 +109,10 @@ var genSDKCmd = &model.ExecutableCommand[GenerateFlags]{
 	RequiresAuth: true,
 	Flags: []model.Flag{
 		model.StringFlag{
-			Name:        "lang",
-			Shorthand:   "l",
-			Description: fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+			Name:         "lang",
+			Shorthand:    "l",
+			DefaultValue: "go",
+			Description:  fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")),
 		},
 		schemaFlag,
 		outFlag,

--- a/cmd/generate.go
+++ b/cmd/generate.go
@@ -1,13 +1,13 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
-	"strings"
-
 	"github.com/speakeasy-api/speakeasy/internal/docsgen"
-	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/usagegen"
 	"golang.org/x/exp/slices"
@@ -16,10 +16,8 @@ import (
 	changelog "github.com/speakeasy-api/openapi-generation/v2"
 	"github.com/speakeasy-api/openapi-generation/v2/changelogs"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
-	"github.com/speakeasy-api/speakeasy/internal/auth"
 	"github.com/speakeasy-api/speakeasy/internal/config"
 	"github.com/speakeasy-api/speakeasy/internal/sdkgen"
-	"github.com/spf13/cobra"
 )
 
 func SDKSupportedLanguageTargets() []string {
@@ -35,17 +33,466 @@ func SDKSupportedLanguageTargets() []string {
 	return languages
 }
 
-var generateCmd = &cobra.Command{
-	Use:   "generate",
-	Short: "Generate client SDKs, docsites, and more",
-	Long:  `The "generate" command provides a set of commands for generating client SDKs, OpenAPI specs (coming soon) and more (coming soon).`,
-	RunE:  interactivity.InteractiveRunFn("What do you want to generate?"),
+var (
+	headerFlag = model.StringFlag{
+		Name:        "header",
+		Shorthand:   "H",
+		Description: "header key to use if authentication is required for downloading schema from remote URL",
+	}
+	tokenFlag = model.StringFlag{
+		Name:        "token",
+		Description: "token value to use if authentication is required for downloading schema from remote URL",
+	}
+	schemaFlag = model.StringFlag{
+		Name:         "schema",
+		Shorthand:    "s",
+		Description:  "local filepath or URL for the OpenAPI schema",
+		Required:     true,
+		DefaultValue: "./openapi.yaml",
+	}
+	outFlag = model.StringFlag{
+		Name:        "out",
+		Shorthand:   "o",
+		Description: "path to the output directory",
+	}
+	debugFlag = model.BooleanFlag{
+		Name:        "debug",
+		Shorthand:   "d",
+		Description: "enable writing debug files with broken code",
+	}
+	autoYesFlag = model.BooleanFlag{
+		Name:        "auto-yes",
+		Shorthand:   "y",
+		Description: "auto answer yes to all prompts",
+	}
+	repoFlag = model.StringFlag{
+		Name:        "repo",
+		Shorthand:   "r",
+		Description: "the repository URL for the SDK, if the published (-p) flag isn't used this will be used to generate installation instructions",
+	}
+	repoSubdirFlag = model.StringFlag{
+		Name:        "repo-subdir",
+		Shorthand:   "b",
+		Description: "the subdirectory of the repository where the SDK is located in the repo, helps with documentation generation",
+	}
+)
+
+var generateCmd = &model.CommandGroup{
+	Usage:          "generate",
+	Short:          "Generate client SDKs, docsites, and more",
+	Long:           `The "generate" command provides a set of commands for generating client SDKs, OpenAPI specs (coming soon) and more (coming soon).`,
+	InteractiveMsg: "What do you want to generate?",
+	Commands:       []model.Command{genSDKCmd, genSDKDocsCmd, genUsageSnippetCmd, genSDKVersionCmd, genSDKChangelogCmd},
 }
 
-var genSDKCmd = &cobra.Command{
-	Use:   "sdk",
-	Short: fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s + more coming soon)", strings.Join(SDKSupportedLanguageTargets(), ", ")),
-	Long: fmt.Sprintf(`Using the "speakeasy generate sdk" command you can generate client SDK packages for various languages
+type GenerateFlags struct {
+	Lang            string `json:"lang"`
+	SchemaPath      string `json:"schema"`
+	OutDir          string `json:"out"`
+	Header          string `json:"header"`
+	Token           string `json:"token"`
+	Debug           bool   `json:"debug"`
+	AutoYes         bool   `json:"auto-yes"`
+	InstallationURL string `json:"installationURL"`
+	Published       bool   `json:"published"`
+	Repo            string `json:"repo"`
+	RepoSubdir      string `json:"repo-subdir"`
+	OutputTests     bool   `json:"output-tests"`
+}
+
+var genSDKCmd = &model.ExecutableCommand[GenerateFlags]{
+	Usage:        "sdk",
+	Short:        fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s + more coming soon)", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+	Long:         generateLongDesc,
+	Run:          genSDKs,
+	RequiresAuth: true,
+	Flags: []model.Flag{
+		model.StringFlag{
+			Name:        "lang",
+			Shorthand:   "l",
+			Description: fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+		},
+		schemaFlag,
+		outFlag,
+		headerFlag,
+		tokenFlag,
+		debugFlag,
+		autoYesFlag,
+		model.StringFlag{
+			Name:        "installationURL",
+			Shorthand:   "i",
+			Description: "the language specific installation URL for installation instructions if the SDK is not published to a package manager",
+		},
+		model.BooleanFlag{
+			Name:        "published",
+			Shorthand:   "p",
+			Description: "whether the SDK is published to a package manager or not, determines the type of installation instructions to generate",
+		},
+		repoFlag,
+		repoSubdirFlag,
+		model.BooleanFlag{
+			Name:        "output-tests",
+			Shorthand:   "t",
+			Description: "output internal tests for internal speakeasy use cases",
+			Hidden:      true,
+		},
+	},
+}
+
+type GenerateUsageSnippetFlags struct {
+	Lang       string `json:"lang"`
+	SchemaPath string `json:"schema"`
+	Header     string `json:"header"`
+	Token      string `json:"token"`
+	Operation  string `json:"operation-id"`
+	Namespace  string `json:"namespace"`
+	Out        string `json:"out"`
+	ConfigPath string `json:"config-path"`
+}
+
+var genUsageSnippetCmd = &model.ExecutableCommand[GenerateUsageSnippetFlags]{
+	Usage: "usage",
+	Short: fmt.Sprintf("Generate standalone usage snippets for SDKs in (%s)", strings.Join(usagegen.SupportedLanguagesUsageSnippets, ", ")),
+	Long: fmt.Sprintf(`Using the "speakeasy generate usage" command you can generate usage snippets for various SDKs.
+
+The following languages are currently supported:
+	- %s
+	- more coming soon
+
+You can generate usage snippets by OperationID or by Namespace. By default this command will write to stdout.
+
+You can also select to write to a file or write to a formatted output directory.
+`, strings.Join(usagegen.SupportedLanguagesUsageSnippets, "\n	- ")),
+	Run: genUsageSnippets,
+	Flags: []model.Flag{
+		model.StringFlag{
+			Name:         "lang",
+			Shorthand:    "l",
+			Description:  fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(usagegen.SupportedLanguagesUsageSnippets, ", ")),
+			DefaultValue: "go",
+		},
+		schemaFlag,
+		headerFlag,
+		tokenFlag,
+		model.StringFlag{
+			Name:        "operation-id",
+			Shorthand:   "i",
+			Description: "The OperationID to generate usage snippet for",
+		},
+		model.StringFlag{
+			Name:        "namespace",
+			Shorthand:   "n",
+			Description: "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.",
+		},
+		model.StringFlag{
+			Name:      "out",
+			Shorthand: "o",
+			Description: `By default this command will write to stdout. If a filepath is provided results will be written into that file.
+	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`,
+		},
+		model.StringFlag{
+			Name:         "config-path",
+			Shorthand:    "c",
+			DefaultValue: ".",
+			Description:  "An optional argument to pass in the path to a directory that holds the gen.yaml configuration file.",
+		},
+	},
+}
+
+type GenerateSDKVersionFlags struct {
+	Language string `json:"language"`
+}
+
+var genSDKVersionCmd = &model.ExecutableCommand[GenerateSDKVersionFlags]{
+	Usage: "version",
+	Short: "Print the version number of the SDK generator",
+	Long:  `Print the version number of the SDK generator including the latest changelog entry`,
+	Run:   getLatestVersionInfo,
+	Flags: []model.Flag{
+		model.StringFlag{
+			Name:        "language",
+			Shorthand:   "l",
+			Description: "if language is set to one of the supported languages it will print version numbers for that languages features and the changelog for that language",
+		},
+	},
+}
+
+type GenerateSDKDocsFlags struct {
+	Langs      string `json:"langs"`
+	SchemaPath string `json:"schema"`
+	OutDir     string `json:"out"`
+	Header     string `json:"header"`
+	Token      string `json:"token"`
+	Debug      bool   `json:"debug"`
+	AutoYes    bool   `json:"auto-yes"`
+	Compile    bool   `json:"compile"`
+	Repo       string `json:"repo"`
+	RepoSubdir string `json:"repo-subdir"`
+}
+
+var genSDKDocsCmd = &model.ExecutableCommand[GenerateSDKDocsFlags]{
+	Usage: "docs",
+	Short: "Use this command to generate content for the SDK docs directory.",
+	Long:  "Use this command to generate content for the SDK docs directory.",
+	Run:   genSDKDocsContent,
+	Flags: []model.Flag{
+		outFlag,
+		schemaFlag,
+		model.StringFlag{
+			Name:        "langs",
+			Shorthand:   "l",
+			Description: "a list of languages to include in SDK Docs generation. Example usage -l go,python,typescript",
+		},
+		headerFlag,
+		tokenFlag,
+		debugFlag,
+		autoYesFlag,
+		model.BooleanFlag{
+			Name:        "compile",
+			Shorthand:   "c",
+			Description: "automatically compile SDK docs content for a single page doc site",
+		},
+		repoFlag,
+		repoSubdirFlag,
+	},
+}
+
+type GenerateSDKChangelogFlags struct {
+	TargetVersion   string `json:"target"`
+	PreviousVersion string `json:"previous"`
+	SpecificVersion string `json:"specific"`
+	Language        string `json:"language"`
+	Raw             bool   `json:"raw"`
+}
+
+var genSDKChangelogCmd = &model.ExecutableCommand[GenerateSDKChangelogFlags]{
+	Usage: "changelog",
+	Short: "Prints information about changes to the SDK generator",
+	Long:  `Prints information about changes to the SDK generator with the ability to filter by version and format the output for the terminal or parsing. By default it will print the latest changelog entry.`,
+	Run:   getChangelogs,
+	Flags: []model.Flag{
+		model.StringFlag{
+			Name:        "target",
+			Shorthand:   "t",
+			Description: "the version(s) to get changelogs from, if not specified the latest version(s) will be used",
+		},
+		model.StringFlag{
+			Name:        "previous",
+			Shorthand:   "p",
+			Description: "the version(s) to get changelogs between this and the target version(s)",
+		},
+		model.StringFlag{
+			Name:        "specific",
+			Shorthand:   "s",
+			Description: "the version to get changelogs for, not used if language is specified",
+		},
+		model.StringFlag{
+			Name:        "language",
+			Shorthand:   "l",
+			Description: "the language to get changelogs for, if not specified the changelog for the generator itself will be returned",
+		},
+		model.BooleanFlag{
+			Name:        "raw",
+			Shorthand:   "r",
+			Description: "don't format the output for the terminal",
+		},
+	},
+}
+
+var genVersion string
+
+func genSDKs(ctx context.Context, flags GenerateFlags) error {
+	if err := sdkgen.Generate(
+		ctx,
+		config.GetCustomerID(),
+		config.GetWorkspaceID(),
+		flags.Lang,
+		flags.SchemaPath,
+		flags.Header,
+		flags.Token,
+		flags.OutDir,
+		genVersion,
+		flags.InstallationURL,
+		flags.Debug,
+		flags.AutoYes,
+		flags.Published,
+		flags.OutputTests,
+		flags.Repo,
+		flags.RepoSubdir,
+		false,
+	); err != nil {
+		rootCmd.SilenceUsage = true
+
+		return err
+	}
+
+	return nil
+}
+
+func genUsageSnippets(ctx context.Context, flags GenerateUsageSnippetFlags) error {
+	if err := usagegen.Generate(
+		ctx,
+		config.GetCustomerID(),
+		flags.Lang,
+		flags.SchemaPath,
+		flags.Header,
+		flags.Token,
+		flags.Out,
+		flags.Operation,
+		flags.Namespace,
+		flags.ConfigPath,
+	); err != nil {
+		rootCmd.SilenceUsage = true
+
+		return err
+	}
+
+	return nil
+}
+
+func genSDKDocsContent(ctx context.Context, flags GenerateSDKDocsFlags) error {
+	languages := make([]string, 0)
+	if flags.Langs != "" {
+		for _, lang := range strings.Split(flags.Langs, ",") {
+			languages = append(languages, strings.TrimSpace(lang))
+		}
+	}
+
+	if err := docsgen.GenerateContent(
+		ctx,
+		languages,
+		config.GetCustomerID(),
+		flags.SchemaPath,
+		flags.Header,
+		flags.Token,
+		flags.OutDir,
+		flags.Repo,
+		flags.RepoSubdir,
+		flags.Debug,
+		flags.AutoYes,
+		flags.Compile,
+	); err != nil {
+		rootCmd.SilenceUsage = true
+
+		return err
+	}
+
+	return nil
+}
+
+func getLatestVersionInfo(ctx context.Context, flags GenerateSDKVersionFlags) error {
+	version := changelog.GetLatestVersion()
+	var changeLog string
+
+	logger := log.From(ctx)
+
+	logger.Printf("Version: %s", version)
+
+	lang := flags.Language
+	if lang != "" {
+		if !slices.Contains(generate.GetSupportedLanguages(), lang) {
+			return fmt.Errorf("unsupported language %s", lang)
+		}
+
+		latestVersions, err := changelogs.GetLatestVersions(lang)
+		if err != nil {
+			return fmt.Errorf("failed to get latest versions for language %s: %w", lang, err)
+		}
+
+		logger.Printf("Features:")
+
+		for feature, version := range latestVersions {
+			logger.Printf("  %s: %s", feature, version)
+		}
+
+		if len(latestVersions) > 0 {
+			logger.Printf("\n")
+		}
+
+		changeLog, err = changelogs.GetChangeLog(lang, latestVersions, nil)
+		if err != nil {
+			return fmt.Errorf("failed to get changelog for language %s: %w", lang, err)
+		}
+	} else {
+		changeLog = changelog.GetChangeLog(changelog.WithSpecificVersion(version))
+	}
+
+	logger.Printf(string(markdown.Render("# CHANGELOG\n\n"+changeLog, 100, 0)))
+
+	return nil
+}
+
+func getChangelogs(ctx context.Context, flags GenerateSDKChangelogFlags) error {
+	raw := flags.Raw || !utils.IsInteractive()
+
+	opts := []changelog.Option{}
+
+	var err error
+	var changeLog string
+
+	lang := flags.Language
+	if lang != "" {
+		if !slices.Contains(generate.GetSupportedLanguages(), lang) {
+			return fmt.Errorf("unsupported language %s", lang)
+		}
+
+		targetVersions := map[string]string{}
+
+		if flags.TargetVersion == "" {
+			targetVersions, err = changelogs.GetLatestVersions(lang)
+			if err != nil {
+				return err
+			}
+		} else {
+			pairs := strings.Split(flags.TargetVersion, ",")
+			for i := 0; i < len(pairs); i += 2 {
+				targetVersions[pairs[i]] = pairs[i+1]
+			}
+		}
+
+		var previousVersions map[string]string
+
+		if flags.PreviousVersion != "" {
+			previousVersions = map[string]string{}
+
+			pairs := strings.Split(flags.PreviousVersion, ",")
+			for i := 0; i < len(pairs); i += 2 {
+				previousVersions[pairs[i]] = pairs[i+1]
+			}
+		}
+
+		changeLog, err = changelogs.GetChangeLog(lang, targetVersions, previousVersions)
+		if err != nil {
+			return fmt.Errorf("failed to get changelog for language %s: %w", lang, err)
+		}
+	} else {
+		if flags.TargetVersion != "" {
+			opts = append(opts, changelog.WithTargetVersion(flags.TargetVersion))
+
+			if flags.PreviousVersion != "" {
+				opts = append(opts, changelog.WithPreviousVersion(flags.PreviousVersion))
+			}
+		} else if flags.SpecificVersion != "" {
+			opts = append(opts, changelog.WithSpecificVersion(flags.SpecificVersion))
+		} else {
+			opts = append(opts, changelog.WithSpecificVersion(changelog.GetLatestVersion()))
+		}
+
+		changeLog = changelog.GetChangeLog(opts...)
+	}
+
+	logger := log.From(ctx)
+
+	if raw {
+		logger.Printf(changeLog)
+		return nil
+	}
+
+	logger.Printf(string(markdown.Render("# CHANGELOG\n\n"+changeLog, 100, 0)))
+	return nil
+}
+
+var generateLongDesc = fmt.Sprintf(`Using the "speakeasy generate sdk" command you can generate client SDK packages for various languages
 that are ready to use and publish to your favorite package registry.
 
 The following languages are currently supported:
@@ -134,420 +581,4 @@ generate:
 `+"```"+`
 
 For additional documentation visit: https://docs.speakeasyapi.dev/docs/using-speakeasy/create-client-sdks/intro
-`, strings.Join(SDKSupportedLanguageTargets(), "\n	- ")),
-	PreRunE: interactivity.GetMissingFlagsPreRun,
-	RunE:    genSDKs,
-}
-
-var genUsageSnippetCmd = &cobra.Command{
-	Use:   "usage",
-	Short: fmt.Sprintf("Generate standalone usage snippets for SDKs in (%s)", strings.Join(usagegen.SupportedLanguagesUsageSnippets, ", ")),
-	Long: fmt.Sprintf(`Using the "speakeasy generate usage" command you can generate usage snippets for various SDKs.
-
-The following languages are currently supported:
-	- %s
-	- more coming soon
-
-You can generate usage snippets by OperationID or by Namespace. By default this command will write to stdout.
-
-You can also select to write to a file or write to a formatted output directory.
-`, strings.Join(usagegen.SupportedLanguagesUsageSnippets, "\n	- ")),
-	RunE: genUsageSnippets,
-}
-
-var genSDKVersionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Print the version number of the SDK generator",
-	Long:  `Print the version number of the SDK generator including the latest changelog entry`,
-	RunE:  getLatestVersionInfo,
-}
-
-var genSDKChangelogCmd = &cobra.Command{
-	Use:   "changelog",
-	Short: "Prints information about changes to the SDK generator",
-	Long:  `Prints information about changes to the SDK generator with the ability to filter by version and format the output for the terminal or parsing. By default it will print the latest changelog entry.`,
-	RunE:  getChangelogs,
-}
-
-var genSDKDocsCmd = &cobra.Command{
-	Use:   "docs",
-	Short: "Use this command to generate content for the SDK docs directory.",
-	Long:  "Use this command to generate content for the SDK docs directory.",
-	RunE:  genSDKDocsContent,
-}
-
-var genVersion string
-
-func genInit() {
-	rootCmd.AddCommand(generateCmd)
-
-	genVersion = rootCmd.Version
-
-	genSDKInit()
-}
-
-//nolint:errcheck
-func genSDKInit() {
-	genSDKCmd.Flags().StringP("lang", "l", "go", fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")))
-
-	genSDKCmd.Flags().StringP("schema", "s", "./openapi.yaml", "local filepath or URL for the OpenAPI schema")
-	genSDKCmd.MarkFlagRequired("schema")
-
-	genSDKCmd.Flags().StringP("header", "H", "", "header key to use if authentication is required for downloading schema from remote URL")
-	genSDKCmd.Flags().String("token", "", "token value to use if authentication is required for downloading schema from remote URL")
-
-	genSDKCmd.Flags().StringP("out", "o", "", "path to the output directory")
-	genSDKCmd.MarkFlagRequired("out")
-
-	genSDKCmd.Flags().BoolP("debug", "d", false, "enable writing debug files with broken code")
-
-	genSDKCmd.Flags().BoolP("auto-yes", "y", false, "auto answer yes to all prompts")
-
-	genSDKCmd.Flags().StringP("installationURL", "i", "", "the language specific installation URL for installation instructions if the SDK is not published to a package manager")
-	genSDKCmd.Flags().BoolP("published", "p", false, "whether the SDK is published to a package manager or not, determines the type of installation instructions to generate")
-
-	genSDKCmd.Flags().StringP("repo", "r", "", "the repository URL for the SDK, if the published (-p) flag isn't used this will be used to generate installation instructions")
-	genSDKCmd.Flags().StringP("repo-subdir", "b", "", "the subdirectory of the repository where the SDK is located in the repo, helps with documentation generation")
-
-	genSDKCmd.Flags().BoolP("output-tests", "t", false, "output internal tests for internal speakeasy use cases")
-	genSDKCmd.Flags().MarkHidden("output-tests")
-
-	genSDKChangelogCmd.Flags().StringP("target", "t", "", "the version(s) to get changelogs from, if not specified the latest version(s) will be used")
-	genSDKChangelogCmd.Flags().StringP("previous", "p", "", "the version(s) to get changelogs between this and the target version(s)")
-	genSDKChangelogCmd.Flags().StringP("specific", "s", "", "the version to get changelogs for, not used if language is specified")
-	genSDKChangelogCmd.Flags().StringP("language", "l", "", "the language to get changelogs for, if not specified the changelog for the generator itself will be returned")
-	genSDKChangelogCmd.Flags().BoolP("raw", "r", false, "don't format the output for the terminal")
-
-	genSDKVersionCmd.Flags().StringP("language", "l", "", "if language is set to one of the supported languages it will print version numbers for that languages features and the changelog for that language")
-
-	genUsageSnippetCmd.Flags().StringP("lang", "l", "go", fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")))
-	genUsageSnippetCmd.Flags().StringP("schema", "s", "./openapi.yaml", "path to the openapi schema")
-	genUsageSnippetCmd.MarkFlagRequired("schema")
-	genUsageSnippetCmd.Flags().StringP("header", "H", "", "header key to use if authentication is required for downloading schema from remote URL")
-	genUsageSnippetCmd.Flags().String("token", "", "token value to use if authentication is required for downloading schema from remote URL")
-	genUsageSnippetCmd.Flags().StringP("operation-id", "i", "", "The OperationID to generate usage snippet for")
-	genUsageSnippetCmd.Flags().StringP("namespace", "n", "", "The namespace to generate multiple usage snippets for. This could correspond to a tag or a x-speakeasy-group-name in your OpenAPI spec.")
-	genUsageSnippetCmd.Flags().StringP("out", "o", "", `By default this command will write to stdout. If a filepath is provided results will be written into that file.
-	If the path to an existing directory is provided, all results will be formatted into that directory with each operation getting its own sub folder.`)
-	genUsageSnippetCmd.Flags().StringP("config-path", "c", ".", "An optional argument to pass in the path to a directory that holds the gen.yaml configuration file.")
-
-	genSDKDocsCmd.Flags().StringP("out", "o", "", "path to the output directory")
-	genSDKDocsCmd.MarkFlagRequired("out")
-	genSDKDocsCmd.Flags().StringP("schema", "s", "./openapi.yaml", "local filepath or URL for the OpenAPI schema")
-	genSDKDocsCmd.MarkFlagRequired("schema")
-	genSDKDocsCmd.Flags().StringP("langs", "l", "", "a list of languages to include in SDK Doc generation. Example usage -l go,python,typescript")
-	genSDKDocsCmd.Flags().StringP("header", "H", "", "header key to use if authentication is required for downloading schema from remote URL")
-	genSDKDocsCmd.Flags().String("token", "", "token value to use if authentication is required for downloading schema from remote URL")
-	genSDKDocsCmd.Flags().BoolP("debug", "d", false, "enable writing debug files with broken code")
-	genSDKDocsCmd.Flags().BoolP("auto-yes", "y", false, "auto answer yes to all prompts")
-	genSDKDocsCmd.Flags().BoolP("compile", "c", false, "automatically compile SDK docs content for a single page doc site")
-	genSDKDocsCmd.Flags().StringP("repo", "r", "", "the repository URL for the SDK Docs repo")
-	genSDKDocsCmd.Flags().StringP("repo-subdir", "b", "", "the subdirectory of the repository where the SDK Docs are located in the repo, helps with documentation generation")
-
-	genSDKCmd.AddCommand(genSDKVersionCmd, genSDKChangelogCmd)
-	generateCmd.AddCommand(genSDKCmd, genSDKDocsCmd, genUsageSnippetCmd)
-}
-
-func genSDKs(cmd *cobra.Command, args []string) error {
-	if err := auth.Authenticate(cmd.Context(), false); err != nil {
-		return err
-	}
-
-	lang, _ := cmd.Flags().GetString("lang")
-
-	schemaPath, err := cmd.Flags().GetString("schema")
-	if err != nil {
-		return err
-	}
-
-	header, err := cmd.Flags().GetString("header")
-	if err != nil {
-		return err
-	}
-
-	token, err := cmd.Flags().GetString("token")
-	if err != nil {
-		return err
-	}
-
-	outDir, err := cmd.Flags().GetString("out")
-	if err != nil {
-		return err
-	}
-
-	debug, err := cmd.Flags().GetBool("debug")
-	if err != nil {
-		return err
-	}
-
-	autoYes, err := cmd.Flags().GetBool("auto-yes")
-	if err != nil {
-		return err
-	}
-
-	installationURL, err := cmd.Flags().GetString("installationURL")
-	if err != nil {
-		return err
-	}
-
-	published, err := cmd.Flags().GetBool("published")
-	if err != nil {
-		return err
-	}
-
-	repo, err := cmd.Flags().GetString("repo")
-	if err != nil {
-		return err
-	}
-
-	repoSubdir, err := cmd.Flags().GetString("repo-subdir")
-	if err != nil {
-		return err
-	}
-
-	outputTests, err := cmd.Flags().GetBool("output-tests")
-	if err != nil {
-		return err
-	}
-
-	if err := sdkgen.Generate(cmd.Context(), config.GetCustomerID(), config.GetWorkspaceID(), lang, schemaPath, header, token, outDir, genVersion, installationURL, debug, autoYes, published, outputTests, repo, repoSubdir, false); err != nil {
-		rootCmd.SilenceUsage = true
-
-		return err
-	}
-
-	return nil
-}
-
-func genUsageSnippets(cmd *cobra.Command, args []string) error {
-	lang, _ := cmd.Flags().GetString("lang")
-
-	schemaPath, err := cmd.Flags().GetString("schema")
-	if err != nil {
-		return err
-	}
-
-	header, err := cmd.Flags().GetString("header")
-	if err != nil {
-		return err
-	}
-
-	token, err := cmd.Flags().GetString("token")
-	if err != nil {
-		return err
-	}
-
-	out, _ := cmd.Flags().GetString("out")
-	configPath, _ := cmd.Flags().GetString("config-path")
-	operation, _ := cmd.Flags().GetString("operation-id")
-	namespace, _ := cmd.Flags().GetString("namespace")
-
-	if err := usagegen.Generate(cmd.Context(), config.GetCustomerID(), lang, schemaPath, header, token, out, operation, namespace, configPath); err != nil {
-		rootCmd.SilenceUsage = true
-
-		return err
-	}
-
-	return nil
-}
-
-func getLatestVersionInfo(cmd *cobra.Command, args []string) error {
-	version := changelog.GetLatestVersion()
-	var changeLog string
-
-	logger := log.From(cmd.Context())
-
-	logger.Printf("Version: %s", version)
-
-	lang, err := cmd.Flags().GetString("language")
-	if err != nil {
-		lang = ""
-	}
-
-	if lang != "" {
-		if !slices.Contains(generate.GetSupportedLanguages(), lang) {
-			return fmt.Errorf("unsupported language %s", lang)
-		}
-
-		latestVersions, err := changelogs.GetLatestVersions(lang)
-		if err != nil {
-			return fmt.Errorf("failed to get latest versions for language %s: %w", lang, err)
-		}
-
-		logger.Printf("Features:")
-
-		for feature, version := range latestVersions {
-			logger.Printf("  %s: %s", feature, version)
-		}
-
-		if len(latestVersions) > 0 {
-			logger.Printf("\n")
-		}
-
-		changeLog, err = changelogs.GetChangeLog(lang, latestVersions, nil)
-		if err != nil {
-			return fmt.Errorf("failed to get changelog for language %s: %w", lang, err)
-		}
-	} else {
-		changeLog = changelog.GetChangeLog(changelog.WithSpecificVersion(version))
-	}
-
-	logger.Printf(string(markdown.Render("# CHANGELOG\n\n"+changeLog, 100, 0)))
-
-	return nil
-}
-
-func getChangelogs(cmd *cobra.Command, args []string) error {
-	targetVersion, err := cmd.Flags().GetString("target")
-	if err != nil {
-		return err
-	}
-
-	previousVersion, err := cmd.Flags().GetString("previous")
-	if err != nil {
-		return err
-	}
-
-	specificVersion, err := cmd.Flags().GetString("specific")
-	if err != nil {
-		return err
-	}
-
-	lang, err := cmd.Flags().GetString("language")
-	if err != nil {
-		return err
-	}
-
-	raw, err := cmd.Flags().GetBool("raw")
-	if err != nil {
-		return err
-	}
-	raw = raw || !utils.IsInteractive()
-
-	opts := []changelog.Option{}
-
-	var changeLog string
-
-	if lang != "" {
-		if !slices.Contains(generate.GetSupportedLanguages(), lang) {
-			return fmt.Errorf("unsupported language %s", lang)
-		}
-
-		targetVersions := map[string]string{}
-
-		if targetVersion == "" {
-			targetVersions, err = changelogs.GetLatestVersions(lang)
-			if err != nil {
-				return err
-			}
-		} else {
-			pairs := strings.Split(targetVersion, ",")
-			for i := 0; i < len(pairs); i += 2 {
-				targetVersions[pairs[i]] = pairs[i+1]
-			}
-		}
-
-		var previousVersions map[string]string
-
-		if previousVersion != "" {
-			previousVersions = map[string]string{}
-
-			pairs := strings.Split(previousVersion, ",")
-			for i := 0; i < len(pairs); i += 2 {
-				previousVersions[pairs[i]] = pairs[i+1]
-			}
-		}
-
-		changeLog, err = changelogs.GetChangeLog(lang, targetVersions, previousVersions)
-		if err != nil {
-			return fmt.Errorf("failed to get changelog for language %s: %w", lang, err)
-		}
-	} else {
-		if targetVersion != "" {
-			opts = append(opts, changelog.WithTargetVersion(targetVersion))
-
-			if previousVersion != "" {
-				opts = append(opts, changelog.WithPreviousVersion(previousVersion))
-			}
-		} else if specificVersion != "" {
-			opts = append(opts, changelog.WithSpecificVersion(specificVersion))
-		} else {
-			opts = append(opts, changelog.WithSpecificVersion(changelog.GetLatestVersion()))
-		}
-
-		changeLog = changelog.GetChangeLog(opts...)
-	}
-
-	logger := log.From(cmd.Context())
-
-	if raw {
-		logger.Printf(changeLog)
-		return nil
-	}
-
-	logger.Printf(string(markdown.Render("# CHANGELOG\n\n"+changeLog, 100, 0)))
-	return nil
-}
-
-func genSDKDocsContent(cmd *cobra.Command, args []string) error {
-	languages := make([]string, 0)
-	langInput, _ := cmd.Flags().GetString("langs")
-	if langInput != "" {
-		for _, lang := range strings.Split(langInput, ",") {
-			languages = append(languages, strings.TrimSpace(lang))
-		}
-	}
-
-	schemaPath, err := cmd.Flags().GetString("schema")
-	if err != nil {
-		return err
-	}
-
-	header, err := cmd.Flags().GetString("header")
-	if err != nil {
-		return err
-	}
-
-	token, err := cmd.Flags().GetString("token")
-	if err != nil {
-		return err
-	}
-
-	outDir, err := cmd.Flags().GetString("out")
-	if err != nil {
-		return err
-	}
-
-	debug, err := cmd.Flags().GetBool("debug")
-	if err != nil {
-		return err
-	}
-
-	autoYes, err := cmd.Flags().GetBool("auto-yes")
-	if err != nil {
-		return err
-	}
-
-	compile, err := cmd.Flags().GetBool("compile")
-	if err != nil {
-		return err
-	}
-
-	repo, err := cmd.Flags().GetString("repo")
-	if err != nil {
-		return err
-	}
-
-	repoSubdir, err := cmd.Flags().GetString("repo-subdir")
-	if err != nil {
-		return err
-	}
-
-	if err := docsgen.GenerateContent(cmd.Context(), languages, config.GetCustomerID(), schemaPath, header, token, outDir, repo, repoSubdir, debug, autoYes, compile); err != nil {
-		rootCmd.SilenceUsage = true
-
-		return err
-	}
-
-	return nil
-}
+`, strings.Join(SDKSupportedLanguageTargets(), "\n	- "))

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/model"
 	"os"
 	"slices"
 	"strings"
@@ -45,11 +46,13 @@ func init() {
 func Init(version, artifactArch string) {
 	rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
 
-	quickstartInit()
-	runInit()
-	configureInit()
-	genInit()
-	validateInit()
+	//TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
+	addCommand(rootCmd, quickstartCmd)
+	addCommand(rootCmd, runCmd)
+	addCommand(rootCmd, configureCmd)
+	addCommand(rootCmd, generateCmd)
+	addCommand(rootCmd, validateCmd)
+
 	authInit()
 	mergeInit()
 	overlayInit()
@@ -57,6 +60,15 @@ func Init(version, artifactArch string) {
 	updateInit(version, artifactArch)
 	proxyInit()
 	apiInit()
+}
+
+func addCommand(cmd *cobra.Command, command model.Command) {
+	c, err := command.Init()
+	if err != nil {
+		l.Error("", zap.Error(err))
+		os.Exit(1)
+	}
+	cmd.AddCommand(c)
 }
 
 func Execute(version, artifactArch string) {

--- a/go.mod
+++ b/go.mod
@@ -74,6 +74,7 @@ require (
 	github.com/ettle/strcase v0.1.1 // indirect
 	github.com/evanw/esbuild v0.19.5 // indirect
 	github.com/fatih/color v1.14.1 // indirect
+	github.com/fatih/structs v1.1.0 // indirect
 	github.com/felixge/httpsnoop v1.0.3 // indirect
 	github.com/forPelevin/gomoji v1.1.7 // indirect
 	github.com/fsnotify/fsnotify v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -218,6 +218,8 @@ github.com/evanw/esbuild v0.19.5/go.mod h1:D2vIQZqV/vIf/VRHtViaUtViZmG7o+kKmlBfV
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
 github.com/fatih/color v1.14.1 h1:qfhVLaG5s+nCROl1zJsZRxFeYrHLqWroPOQ8BWiNb4w=
 github.com/fatih/color v1.14.1/go.mod h1:2oHN61fhTpgcxD3TSWCgKDiH1+x4OiDVVGH8WlgGZGg=
+github.com/fatih/structs v1.1.0 h1:Q7juDM0QtcnhCpeyLGQKyg4TOIghuNXrkL32pHAUMxo=
+github.com/fatih/structs v1.1.0/go.mod h1:9NiDSp5zOcgEDl+j00MP/WkGVPOlPRLejGD8Ga6PJ7M=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/felixge/httpsnoop v1.0.3 h1:s/nj+GCswXYzN5v2DpNMuMQYe+0DDwt5WVCU6CWBdXk=
 github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=

--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -208,7 +208,7 @@ func getSetFlags(flags *pflag.FlagSet) []*pflag.Flag {
 }
 
 func isCommandRunnable(cmd *cobra.Command) bool {
-	onlyHasHelpFlags := cmd.Flags().HasFlags()
+	onlyHasHelpFlags := true
 
 	if cmd.Flags().HasFlags() {
 		cmd.Flags().VisitAll(func(flag *pflag.Flag) {

--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -56,10 +56,9 @@ func SelectCommand(label string, cmd *cobra.Command) *cobra.Command {
 		}
 	}
 
-	// TODO figure out a better way to do this
+	// Don't ask for subcommands if the command itself is runnable
 	if isCommandRunnable(cmd) {
-		label = fmt.Sprintf("Continue with %s, or select a subcommand.", cmd.Name())
-		subcommands = append([]*cobra.Command{cmd}, subcommands...)
+		return cmd
 	}
 
 	selected := getSelectionFromList(label, subcommands)

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -53,7 +53,7 @@ type ExecutableCommand[F interface{}] struct {
 	RunInteractive       func(ctx context.Context, flags F) error
 	Hidden, RequiresAuth bool
 
-	// Deprecated: try to avoid using this
+	// Deprecated: try to avoid using this. It is only present for backwards compatibility with the old CLI
 	NonInteractiveSubcommands []Command
 }
 

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -1,0 +1,164 @@
+package model
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/fatih/structs"
+	"github.com/speakeasy-api/speakeasy/internal/auth"
+	"github.com/speakeasy-api/speakeasy/internal/env"
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"slices"
+	"strconv"
+)
+
+type Command interface {
+	Init() (*cobra.Command, error) // TODO: make private when rootCmd is refactored?
+}
+
+type CommandGroup struct {
+	Usage, Short, Long, InteractiveMsg string
+	Commands                           []Command
+}
+
+func (c CommandGroup) Init() (*cobra.Command, error) {
+	cmd := &cobra.Command{
+		Use:   c.Usage,
+		Short: c.Short,
+		Long:  c.Long,
+		RunE:  interactivity.InteractiveRunFn(c.InteractiveMsg),
+	}
+
+	for _, subcommand := range c.Commands {
+		subcmd, err := subcommand.Init()
+		if err != nil {
+			return nil, err
+		}
+		cmd.AddCommand(subcmd)
+	}
+
+	return cmd, nil
+}
+
+// ExecutableCommand is a runnable "leaf" command that can be executed directly and has no subcommands
+// F is a struct type that represents the flags for the command. The json tags on the struct fields are used to map to the command line flags
+type ExecutableCommand[F interface{}] struct {
+	Usage, Short, Long   string
+	Flags                []Flag
+	PreRun               func(ctx context.Context, flags *F) error
+	Run                  func(ctx context.Context, flags F) error
+	RunInteractive       func(ctx context.Context, flags F) error
+	Hidden, RequiresAuth bool
+}
+
+func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
+	run := func(cmd *cobra.Command, args []string) error {
+		if c.RequiresAuth {
+			if err := auth.Authenticate(cmd.Context(), false); err != nil {
+				return err
+			}
+		}
+
+		flags, err := c.GetFlags(cmd)
+		if err != nil {
+			return err
+		}
+
+		if c.PreRun != nil {
+			if err := c.PreRun(cmd.Context(), flags); err != nil {
+				return err
+			}
+		}
+
+		if c.RunInteractive != nil && utils.IsInteractive() && !env.IsGithubAction() {
+			return c.RunInteractive(cmd.Context(), *flags)
+		} else if c.Run != nil {
+			return c.Run(cmd.Context(), *flags)
+		} else {
+			return fmt.Errorf("this command is only available in an interactive terminal")
+		}
+	}
+
+	// Assert that the flags are valid
+	if err := c.checkFlags(); err != nil {
+		return nil, err
+	}
+
+	cmd := &cobra.Command{
+		Use:     c.Usage,
+		Short:   c.Short,
+		Long:    c.Long,
+		PreRunE: interactivity.GetMissingFlagsPreRun,
+		RunE:    run,
+		Hidden:  c.Hidden,
+	}
+
+	for _, flag := range c.Flags {
+		if err := flag.init(cmd); err != nil {
+			return nil, err
+		}
+	}
+
+	return cmd, nil
+}
+
+func (c ExecutableCommand[F]) checkFlags() error {
+	var f F
+	fields := structs.Fields(f)
+
+	tags := make([]string, len(fields))
+	for i, field := range fields {
+		tags[i] = field.Tag("json")
+	}
+
+	for _, flag := range c.Flags {
+		if !slices.Contains(tags, flag.getName()) {
+			return fmt.Errorf("flag %s is missing from flags type for command %s", flag.getName(), c.Usage)
+		}
+	}
+
+	return nil
+}
+
+func (c ExecutableCommand[F]) GetFlags(cmd *cobra.Command) (*F, error) {
+	var flags F
+
+	jsonFlags := make(map[string]interface{})
+	cmd.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Value.Type() == "string" {
+			jsonFlags[f.Name] = f.Value.String()
+		} else if f.Value.Type() == "bool" {
+			b, err := strconv.ParseBool(f.Value.String())
+			if err != nil {
+				return
+			}
+			jsonFlags[f.Name] = b
+		} else if f.Value.Type() == "int" {
+			i, err := strconv.Atoi(f.Value.String())
+			if err != nil {
+				return
+			}
+			jsonFlags[f.Name] = i
+		}
+	})
+
+	jsonBytes, err := json.Marshal(jsonFlags)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := json.Unmarshal(jsonBytes, &flags); err != nil {
+		return nil, err
+	}
+
+	return &flags, nil
+}
+
+// Verify that the command types implement the Command interface
+var _ = []Command{
+	&ExecutableCommand[interface{}]{},
+	&CommandGroup{},
+}

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -52,6 +52,9 @@ type ExecutableCommand[F interface{}] struct {
 	Run                  func(ctx context.Context, flags F) error
 	RunInteractive       func(ctx context.Context, flags F) error
 	Hidden, RequiresAuth bool
+
+	// Deprecated: try to avoid using this
+	NonInteractiveSubcommands []Command
 }
 
 func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
@@ -94,6 +97,14 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 		PreRunE: interactivity.GetMissingFlagsPreRun,
 		RunE:    run,
 		Hidden:  c.Hidden,
+	}
+
+	for _, subcommand := range c.NonInteractiveSubcommands {
+		subcmd, err := subcommand.Init()
+		if err != nil {
+			return nil, err
+		}
+		cmd.AddCommand(subcmd)
 	}
 
 	for _, flag := range c.Flags {

--- a/internal/model/flag.go
+++ b/internal/model/flag.go
@@ -1,0 +1,87 @@
+package model
+
+import (
+	"github.com/spf13/cobra"
+)
+
+type Flag interface {
+	init(cmd *cobra.Command) error
+	getName() string
+}
+
+type StringFlag struct {
+	Name, Shorthand, Description string
+	Required, Hidden             bool
+	DefaultValue                 string
+}
+
+func (f StringFlag) init(cmd *cobra.Command) error {
+	cmd.Flags().StringP(f.Name, f.Shorthand, f.DefaultValue, f.Description)
+	if err := setRequiredAndHidden(cmd, f.Name, f.Required, f.Hidden); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f StringFlag) getName() string {
+	return f.Name
+}
+
+type BooleanFlag struct {
+	Name, Shorthand, Description string
+	Required, Hidden             bool
+	DefaultValue                 bool
+}
+
+func (f BooleanFlag) init(cmd *cobra.Command) error {
+	cmd.Flags().BoolP(f.Name, f.Shorthand, f.DefaultValue, f.Description)
+	if err := setRequiredAndHidden(cmd, f.Name, f.Required, f.Hidden); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (f BooleanFlag) getName() string {
+	return f.Name
+}
+
+type IntFlag struct {
+	Name, Shorthand, Description string
+	Required, Hidden             bool
+	DefaultValue                 int
+}
+
+func (f IntFlag) init(cmd *cobra.Command) error {
+	cmd.Flags().IntP(f.Name, f.Shorthand, f.DefaultValue, f.Description)
+	if err := setRequiredAndHidden(cmd, f.Name, f.Required, f.Hidden); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (f IntFlag) getName() string {
+	return f.Name
+}
+
+func setRequiredAndHidden(cmd *cobra.Command, name string, required, hidden bool) error {
+	if required {
+		if err := cmd.MarkFlagRequired(name); err != nil {
+			return err
+		}
+	}
+	if hidden {
+		if err := cmd.Flags().MarkHidden(name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Verify that the flag types implement the Flag interface
+var _ = []Flag{
+	&StringFlag{},
+	&BooleanFlag{},
+	&IntFlag{},
+}


### PR DESCRIPTION
Goal here is to improve and standardize the way we define commands for the CLI
This allows us to make our commands more consistent with less boilerplate. For example, we now don't need to remember to add `PreRunE: interactivity.GetMissingFlagsPreRun` to every command