### PR TITLE
feat: hide from interactive without hiding from help

### DIFF
--- a/cmd/proxy.go
+++ b/cmd/proxy.go
@@ -10,11 +10,13 @@ import (
 )
 
 var proxyCmd = &cobra.Command{
-	Use:    "proxy",
-	Short:  "Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities",
-	Long:   `Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities`,
-	RunE:   proxyExec,
-	Hidden: true,
+	Use:   "proxy",
+	Short: "Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities",
+	Long:  `Proxy provides a reverse-proxy for debugging and testing Speakeasy's Traffic Capture capabilities`,
+	RunE:  proxyExec,
+	Annotations: map[string]string{
+		"hide": "true",
+	},
 }
 
 func proxyInit() {

--- a/cmd/suggest.go
+++ b/cmd/suggest.go
@@ -3,13 +3,14 @@ package cmd
 import (
 	goerr "errors"
 	"fmt"
+	"os"
+	"strings"
+
 	"github.com/manifoldco/promptui"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
 	"github.com/speakeasy-api/speakeasy/internal/suggestions"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/slices"
-	"os"
-	"strings"
 )
 
 var suggestCmd = &cobra.Command{
@@ -19,6 +20,9 @@ var suggestCmd = &cobra.Command{
 You can use the Speakeasy OpenAI key within our platform limits, or you may set your own using the OPENAI_API_KEY environment variable. You will also need to authenticate with the Speakeasy API,
 you must first create an API key via https://app.speakeasyapi.dev and then set the SPEAKEASY_API_KEY environment variable to the value of the API key.`,
 	RunE: suggestFixesOpenAPI,
+	Annotations: map[string]string{
+		"hide": "true",
+	},
 }
 
 var severities = fmt.Sprintf("%s, %s, or %s", errors.SeverityError, errors.SeverityWarn, errors.SeverityHint)

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -13,6 +13,9 @@ func updateInit(version, artifactArch string) {
 		Short: "Update the Speakeasy CLI to the latest version",
 		Long:  `Updates the Speakeasy CLI in-place to the latest version available by downloading from Github and replacing the current binary`,
 		RunE:  update(version, artifactArch),
+		Annotations: map[string]string{
+			"hide": "true",
+		},
 	}
 
 	updateCmd.Flags().IntP("timeout", "t", 30, "timeout in seconds for the update to complete")

--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -222,5 +222,6 @@ func isCommandRunnable(cmd *cobra.Command) bool {
 }
 
 func isHidden(cmd *cobra.Command) bool {
-	return cmd.Hidden || cmd.Name() == "completion"
+	_, hasHiddenAnnotation := cmd.Annotations["hide"]
+	return cmd.Hidden || hasHiddenAnnotation || cmd.Name() == "completion" || cmd.Name() == "help"
 }


### PR DESCRIPTION
Allows us to use annotations to hide commands from interactive mode without removing them from automated docs and help.

We will probably wrap cobra eventually to provide this functionality, annotations will work for now.