### PR TITLE
fix: quickstart not used on existing SDK + fix ctrl-c

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -71,6 +71,14 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		return fmt.Errorf("you cannot run quickstart when a speakeasy workflow already exists, try speakeasy configure instead")
 	}
 
+	if _, err := os.Stat(workingDir + "/gen.yaml"); err == nil {
+		return fmt.Errorf("you cannot run quickstart when an existing sdk already exists, try speakeasy configure instead")
+	}
+
+	if _, err := os.Stat(workingDir + "/.speakeasy/gen.yaml"); err == nil {
+		return fmt.Errorf("you cannot run quickstart when an existing sdk already exists, try speakeasy configure instead")
+	}
+
 	fmt.Println(charm.FormatCommandTitle("Welcome to the Speakeasy!",
 		"Speakeasy Quickstart guides you to build a generation workflow for any combination of sources and targets. \n"+
 			"After completing these steps you will be ready to start customizing and generating your SDKs.") + "\n\n\n")

--- a/internal/charm/formModel.go
+++ b/internal/charm/formModel.go
@@ -41,9 +41,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "esc", "ctrl+c":
+		case "esc", "ctrl+c", "q":
 			os.Exit(0)
-			return m, tea.Quit
 		}
 	}
 

--- a/internal/charm/formModel.go
+++ b/internal/charm/formModel.go
@@ -41,7 +41,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "esc", "ctrl+c", "q":
+		case "esc", "ctrl+c":
 			os.Exit(0)
 		}
 	}

--- a/internal/charm/formModel.go
+++ b/internal/charm/formModel.go
@@ -1,6 +1,8 @@
 package charm
 
 import (
+	"os"
+
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
@@ -39,7 +41,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	switch msg := msg.(type) {
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "esc", "ctrl+c", "q":
+		case "esc", "ctrl+c":
+			os.Exit(0)
 			return m, tea.Quit
 		}
 	}


### PR DESCRIPTION
1. Quickstart cannot be used on an existing legacy SDK
2. Fixes ctrl-c so it always fully exits the program from huh form

Context Here
https://speakeasyapi.slack.com/archives/C0698C9K4NL/p1707240014263139