### PR TITLE
feat: support legacy sdk configurations in configure

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -166,9 +166,15 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 		return err
 	}
 
+	existingSDK := prompts.HasExistingGeneration(workingDir)
+
 	var workflowFile *workflow.Workflow
 	if workflowFile, _, err = workflow.Load(workingDir); err != nil || workflowFile == nil || len(workflowFile.Sources) == 0 {
-		return errors.New("you must have a source to configure a target try speakeasy quickstart or speakeasy configure sources")
+		suggestion := "speakeasy quickstart"
+		if existingSDK {
+			suggestion = "speakeasy configure sources"
+		}
+		return errors.New(fmt.Sprintf("you must have a source to configure a target try %s", suggestion))
 	}
 
 	existingTarget := ""
@@ -185,7 +191,7 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 		targetOptions = append(existingTargets, "new target")
 	} else {
 		// To support legacy SDK configurations configure will detect an existing target setup in the current root directory
-		if prompts.HasExistingGeneration(workingDir) {
+		if existingSDK {
 			if cfg, err := config.Load(workingDir); err == nil && cfg.Config != nil && len(cfg.Config.Languages) > 0 {
 				var targetLanguage string
 				for lang := range cfg.Config.Languages {

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -168,7 +168,7 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 
 	var workflowFile *workflow.Workflow
 	if workflowFile, _, err = workflow.Load(workingDir); err != nil || workflowFile == nil || len(workflowFile.Sources) == 0 {
-		return errors.New("you must have a source to configure a target try speakeasy quickstart")
+		return errors.New("you must have a source to configure a target try speakeasy quickstart or speakeasy configure sources")
 	}
 
 	existingTarget := ""
@@ -176,11 +176,40 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 		existingTarget = flags.ID
 	}
 
+	var targetOptions []string
 	var existingTargets []string
-	for targetName := range workflowFile.Targets {
-		existingTargets = append(existingTargets, targetName)
+	if len(workflowFile.Targets) > 0 {
+		for targetName := range workflowFile.Targets {
+			existingTargets = append(existingTargets, targetName)
+		}
+		targetOptions = append(existingTargets, "new target")
+	} else {
+		// To support legacy SDK configurations configure will detect an existing target setup in the current root directory
+		if prompts.HasExistingGeneration(workingDir) {
+			if cfg, err := config.Load(workingDir); err == nil && cfg.Config != nil && len(cfg.Config.Languages) > 0 {
+				var targetLanguage string
+				for lang := range cfg.Config.Languages {
+					targetLanguage = lang
+					if lang == "docs" {
+						break
+					}
+				}
+
+				var firstSourceName string
+				for name := range workflowFile.Sources {
+					firstSourceName = name
+					break
+				}
+
+				workflowFile.Targets[targetLanguage] = workflow.Target{
+					Target: targetLanguage,
+					Source: firstSourceName,
+				}
+				existingTargets = append(existingTargets, targetLanguage)
+				targetOptions = existingTargets
+			}
+		}
 	}
-	targetOptions := append(existingTargets, "new target")
 
 	if !flags.New && existingTarget == "" {
 		prompt := charm.NewSelectPrompt("What target would you like to configure?", "You may choose an existing target or create a new target.", targetOptions, &existingTarget)

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -71,11 +71,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		return fmt.Errorf("you cannot run quickstart when a speakeasy workflow already exists, try speakeasy configure instead")
 	}
 
-	if _, err := os.Stat(workingDir + "/gen.yaml"); err == nil {
-		return fmt.Errorf("you cannot run quickstart when an existing sdk already exists, try speakeasy configure instead")
-	}
-
-	if _, err := os.Stat(workingDir + "/.speakeasy/gen.yaml"); err == nil {
+	if prompts.HasExistingGeneration(workingDir) {
 		return fmt.Errorf("you cannot run quickstart when an existing sdk already exists, try speakeasy configure instead")
 	}
 

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -252,6 +252,29 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		currentSource.Overlays = append(currentSource.Overlays, *document)
 	}
 
+	outputLocation := ""
+	if currentSource.Output != nil {
+		outputLocation = *currentSource.Output
+
+	}
+
+	previousOutputLocation := outputLocation
+	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+		huh.NewGroup(
+			charm_internal.NewInput().
+				Title("Optionally provide an output location for your build source file:").
+				Value(&outputLocation).
+				Suggestions(schemaFilesInCurrentDir()),
+		)),
+		fmt.Sprintf("Let's modify the source %s", name))).
+		Run(); err != nil {
+		return nil, err
+	}
+
+	if previousOutputLocation != outputLocation {
+		currentSource.Output = &outputLocation
+	}
+
 	return currentSource, nil
 }
 
@@ -301,10 +324,6 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	if outputLocation != "" {
 		source.Output = &outputLocation
-	}
-
-	if err := source.Validate(); err != nil {
-		return "", nil, errors.Wrap(err, "failed to validate source")
 	}
 
 	return sourceName, source, nil

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -252,27 +252,32 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		currentSource.Overlays = append(currentSource.Overlays, *document)
 	}
 
-	outputLocation := ""
-	if currentSource.Output != nil {
-		outputLocation = *currentSource.Output
+	if len(currentSource.Inputs)+len(currentSource.Overlays) > 1 {
+		outputLocation := ""
+		if currentSource.Output != nil {
+			outputLocation = *currentSource.Output
+		}
 
+		previousOutputLocation := outputLocation
+		if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+			huh.NewGroup(
+				charm_internal.NewInput().
+					Title("Optionally provide an output location for your build source file:").
+					Value(&outputLocation).
+					Suggestions(schemaFilesInCurrentDir()),
+			)),
+			fmt.Sprintf("Let's modify the source %s", name))).
+			Run(); err != nil {
+			return nil, err
+		}
+
+		if previousOutputLocation != outputLocation {
+			currentSource.Output = &outputLocation
+		}
 	}
 
-	previousOutputLocation := outputLocation
-	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
-		huh.NewGroup(
-			charm_internal.NewInput().
-				Title("Optionally provide an output location for your build source file:").
-				Value(&outputLocation).
-				Suggestions(schemaFilesInCurrentDir()),
-		)),
-		fmt.Sprintf("Let's modify the source %s", name))).
-		Run(); err != nil {
-		return nil, err
-	}
-
-	if previousOutputLocation != outputLocation {
-		currentSource.Output = &outputLocation
+	if err := currentSource.Validate(); err != nil {
+		return nil, errors.Wrap(err, "failed to validate source")
 	}
 
 	return currentSource, nil
@@ -295,7 +300,7 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 			Suggestions(schemaFilesInCurrentDir()),
 	).WithHideFunc(
 		func() bool {
-			return len(currentWorkflow.Sources) == 0
+			return overlayFileLocation == ""
 		}))
 
 	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
@@ -324,6 +329,10 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	if outputLocation != "" {
 		source.Output = &outputLocation
+	}
+
+	if err := source.Validate(); err != nil {
+		return "", nil, errors.Wrap(err, "failed to validate source")
 	}
 
 	return sourceName, source, nil

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -48,7 +48,13 @@ func getBaseTargetPrompts(currentWorkflow *workflow.Workflow, sourceName, target
 			charm.NewInput().
 				Title("What is a good output directory for your generation target?").
 				Validate(func(s string) error {
-					if currentDir(s) {
+					var enforceNewDir bool
+					if newTarget {
+						enforceNewDir = len(currentWorkflow.Targets) > 0
+					} else {
+						enforceNewDir = len(currentWorkflow.Targets) > 1
+					}
+					if enforceNewDir && currentDir(s) {
 						return fmt.Errorf("the output dir must not be the root directory")
 					}
 
@@ -107,7 +113,7 @@ func PromptForNewTarget(currentWorkflow *workflow.Workflow, targetName, targetTy
 	}
 
 	if err := target.Validate(generate.GetSupportedLanguages(), currentWorkflow.Sources); err != nil {
-		return "", nil, errors.Wrap(err, "failed to validate source")
+		return "", nil, errors.Wrap(err, "failed to validate target")
 	}
 
 	return targetName, &target, nil
@@ -140,7 +146,7 @@ func PromptForExistingTarget(currentWorkflow *workflow.Workflow, targetName stri
 	}
 
 	if err := newTarget.Validate(generate.GetSupportedLanguages(), currentWorkflow.Sources); err != nil {
-		return "", nil, errors.Wrap(err, "failed to validate source")
+		return "", nil, errors.Wrap(err, "failed to validate target")
 	}
 
 	if originalDir != outDir {

--- a/prompts/utils.go
+++ b/prompts/utils.go
@@ -1,6 +1,7 @@
 package prompts
 
 import (
+	"os"
 	"strings"
 
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -58,4 +59,16 @@ func getCurrentSources(currentSource *workflow.Source) []string {
 		}
 	}
 	return sources
+}
+
+func HasExistingGeneration(dir string) bool {
+	if _, err := os.Stat(dir + "/gen.yaml"); err == nil {
+		return true
+	}
+
+	if _, err := os.Stat(dir + "/.speakeasy/gen.yaml"); err == nil {
+		return true
+	}
+
+	return false
 }


### PR DESCRIPTION
We will allow speakeasy configure to support legacy SDK targets that do not have a workflow file. As part of running speakeasy configure on these repos we will build up a workflow file.