### PR TITLE
fix: stolen cursor in charm usage

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -3,11 +3,11 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"os"
 	"slices"
 
-	tea "github.com/charmbracelet/bubbletea"
+	"github.com/speakeasy-api/speakeasy/internal/model/flag"
+
 	"github.com/charmbracelet/huh"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/pkg/errors"
@@ -109,9 +109,8 @@ func configureSources(ctx context.Context, flags ConfigureSourcesFlags) error {
 
 	if !flags.New && existingSource == nil {
 		prompt := charm.NewSelectPrompt("What source would you like to configure?", "You may choose an existing source or create a new source.", sourceOptions, &existingSourceName)
-		if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(prompt),
-			"Let's configure a source for your workflow.")).
-			Run(); err != nil {
+		if _, err := charm.NewForm(huh.NewForm(prompt),
+			"Let's configure a source for your workflow.").ExecuteForm(); err != nil {
 			return err
 		}
 		if existingSourceName == "new source" {
@@ -207,9 +206,9 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 
 	if !flags.New && existingTarget == "" {
 		prompt := charm.NewSelectPrompt("What target would you like to configure?", "You may choose an existing target or create a new target.", targetOptions, &existingTarget)
-		if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(prompt),
-			"Let's configure a target for your workflow.")).
-			Run(); err != nil {
+		if _, err := charm.NewForm(huh.NewForm(prompt),
+			"Let's configure a target for your workflow.").
+			ExecuteForm(); err != nil {
 			return err
 		}
 		if existingTarget == "new target" {

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -4,12 +4,12 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"os"
 	"path/filepath"
 	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
+	"github.com/speakeasy-api/speakeasy/internal/model/flag"
+
 	"github.com/charmbracelet/huh"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 
@@ -138,7 +138,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 			description = "Terraform providers must be placed in a directory structured in the following format terraform-provider-*."
 		}
 
-		if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(huh.NewGroup(charm.NewInput().
+		if _, err := charm.NewForm(huh.NewForm(huh.NewGroup(charm.NewInput().
 			Title("What directory should quickstart files be written too?").
 			Description(description+"\n").
 			Validate(func(s string) error {
@@ -150,8 +150,8 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 				return nil
 			}).
 			Inline(false).Prompt("").Value(&promptedDir))),
-			"Let's pick an output directory for your newly created files.")).
-			Run(); err != nil {
+			"Let's pick an output directory for your newly created files.").
+			ExecuteForm(); err != nil {
 			return err
 		}
 		outDir = filepath.Join(workingDir, promptedDir)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
-	tea "github.com/charmbracelet/bubbletea"
+
 	"github.com/charmbracelet/huh"
 	"github.com/sethvargo/go-githubactions"
 	"github.com/speakeasy-api/speakeasy/internal/charm"
@@ -176,9 +176,9 @@ func askForTarget(targets []string) (string, error) {
 	target := ""
 
 	prompt := charm.NewSelectPrompt("What target would you like to run?", "You may choose an individual target or 'all'.", targetOptions, &target)
-	if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(prompt),
-		"Let's configure a target for your workflow.")).
-		Run(); err != nil {
+	if _, err := charm.NewForm(huh.NewForm(prompt),
+		"Let's configure a target for your workflow.").
+		ExecuteForm(); err != nil {
 		return "", err
 	}
 

--- a/internal/charm/formModel.go
+++ b/internal/charm/formModel.go
@@ -14,6 +14,7 @@ type Model struct {
 	title       string
 	description string
 	form        *huh.Form // huh.Form is just a tea.Model
+	signalExit  bool
 }
 
 func NewForm(form *huh.Form, args ...string) Model {
@@ -42,7 +43,8 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "esc", "ctrl+c":
-			os.Exit(0)
+			m.signalExit = true
+			return m, tea.Quit
 		}
 	}
 
@@ -82,4 +84,18 @@ func (m Model) View() string {
 	}
 
 	return content
+}
+
+func (m Model) ExecuteForm(opts ...tea.ProgramOption) (tea.Model, error) {
+	mResult, err := tea.NewProgram(m, opts...).Run()
+	if err != nil {
+		return mResult, err
+	}
+	if m, ok := mResult.(Model); ok {
+		if m.signalExit {
+			os.Exit(0)
+		}
+	}
+
+	return mResult, nil
 }

--- a/internal/interactivity/listSelect.go
+++ b/internal/interactivity/listSelect.go
@@ -25,8 +25,9 @@ func (i item) Description() string { return i.desc }
 func (i item) FilterValue() string { return i.title }
 
 type ListSelect struct {
-	list     list.Model
-	selected *cobra.Command
+	list       list.Model
+	selected   *cobra.Command
+	signalExit bool
 }
 
 func (m ListSelect) Init() tea.Cmd {
@@ -38,7 +39,7 @@ func (m ListSelect) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch keypress := msg.String(); keypress {
 		case "ctrl+c", "esc":
-			os.Exit(0)
+			m.signalExit = true
 			return m, tea.Quit
 		case "enter":
 			selected, ok := m.list.SelectedItem().(item)
@@ -124,7 +125,14 @@ func getSelectionFromList(label string, options []*cobra.Command) *cobra.Command
 		os.Exit(1)
 	}
 
-	if m, ok := mResult.(ListSelect); ok && m.selected != nil {
+	if m, ok := mResult.(ListSelect); ok {
+		if m.signalExit {
+			os.Exit(0)
+		}
+
+		if m.selected != nil {
+			return m.selected
+		}
 		return m.selected
 	}
 

--- a/internal/interactivity/multiInput.go
+++ b/internal/interactivity/multiInput.go
@@ -37,6 +37,7 @@ type MultiInput struct {
 	cursorMode cursor.Mode
 	focusIndex int
 	done       bool
+	signalExit bool
 }
 
 type InputField struct {
@@ -83,7 +84,7 @@ func (m MultiInput) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	case tea.KeyMsg:
 		switch msg.String() {
 		case "ctrl+c", "esc":
-			os.Exit(0)
+			m.signalExit = true
 			return m, tea.Quit
 
 		// Set focus to next input
@@ -244,6 +245,9 @@ func (m MultiInput) Run() map[string]string {
 	}
 
 	resultingModel := newM.(MultiInput)
+	if resultingModel.signalExit {
+		os.Exit(0)
+	}
 
 	return resultingModel.getFilledValues()
 }

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -123,11 +122,11 @@ func PromptForTargetConfig(targetName string, target *workflow.Target, existingC
 	if !isQuickstart {
 		descriptionMessage = "Default config values have been provided. You only need to edit values that you want to modify."
 	}
-	if _, err := tea.NewProgram(charm.NewForm(form,
+	if _, err := charm.NewForm(form,
 		fmt.Sprintf("Let's configure your %s target (%s)", target.Target, targetName),
 		"This will configure a config file that defines parameters for how your SDK is generated. \n"+
-			descriptionMessage)).
-		Run(); err != nil {
+			descriptionMessage).
+		ExecuteForm(); err != nil {
 		return nil, err
 	}
 

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"strings"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
@@ -120,11 +119,11 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 		fileLocation = *quickstart.Defaults.SchemaPath
 	}
 
-	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+	if _, err := charm_internal.NewForm(huh.NewForm(
 		getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),
 		"Let's setup a new source for your workflow.",
-		"A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.")).
-		Run(); err != nil {
+		"A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.").
+		ExecuteForm(); err != nil {
 		return nil, err
 	}
 
@@ -155,10 +154,10 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 	inputOptions = append(inputOptions, huh.NewOption(charm_internal.FormatNewOption("New Document"), "new document"))
 	selectedDoc := ""
 	prompt := charm_internal.NewSelectPrompt("Would you like to modify the location of an existing OpenAPI document or add a new one?", "", inputOptions, &selectedDoc)
-	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+	if _, err := charm_internal.NewForm(huh.NewForm(
 		prompt),
-		fmt.Sprintf("Let's modify the source %s", name))).
-		Run(); err != nil {
+		fmt.Sprintf("Let's modify the source %s", name)).
+		ExecuteForm(); err != nil {
 		return nil, err
 	}
 
@@ -176,10 +175,10 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 			),
 		}
 		groups = append(groups, getRemoteAuthenticationPrompts(&fileLocation, &authHeader, &authSecret)...)
-		if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's modify the source %s", name))).
-			Run(); err != nil {
+			fmt.Sprintf("Let's modify the source %s", name)).
+			ExecuteForm(); err != nil {
 			return nil, err
 		}
 
@@ -212,10 +211,10 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		}
 		groups = append(groups, getRemoteAuthenticationPrompts(&fileLocation, &authHeader, &authSecret)...)
 		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another openapi file to this source?", &addOpenAPIFile))
-		if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's add to the source %s", name))).
-			Run(); err != nil {
+			fmt.Sprintf("Let's add to the source %s", name)).
+			ExecuteForm(); err != nil {
 			return nil, err
 		}
 		document, err := formatDocument(fileLocation, authHeader, authSecret, true)
@@ -227,10 +226,10 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 	}
 
 	addOverlayFile := false
-	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+	if _, err := charm_internal.NewForm(huh.NewForm(
 		charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", &addOverlayFile)),
-		fmt.Sprintf("Let's add to the source %s", name))).
-		Run(); err != nil {
+		fmt.Sprintf("Let's add to the source %s", name)).
+		ExecuteForm(); err != nil {
 		return nil, err
 	}
 
@@ -240,10 +239,10 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		trueVal := true
 		groups := getOverlayPrompts(&trueVal, &fileLocation, &authHeader, &authSecret)
 		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another overlay file to this source?", &addOverlayFile))
-		if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's add to the source %s", name))).
-			Run(); err != nil {
+			fmt.Sprintf("Let's add to the source %s", name)).
+			ExecuteForm(); err != nil {
 			return nil, err
 		}
 		document, err := formatDocument(fileLocation, authHeader, authSecret, true)
@@ -261,15 +260,15 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		}
 
 		previousOutputLocation := outputLocation
-		if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+		if _, err := charm_internal.NewForm(huh.NewForm(
 			huh.NewGroup(
 				charm_internal.NewInput().
 					Title("Optionally provide an output location for your build source file:").
 					Value(&outputLocation).
 					Suggestions(schemaFilesInCurrentDir()),
 			)),
-			fmt.Sprintf("Let's modify the source %s", name))).
-			Run(); err != nil {
+			fmt.Sprintf("Let's modify the source %s", name)).
+			ExecuteForm(); err != nil {
 			return nil, err
 		}
 
@@ -305,11 +304,11 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 			return overlayFileLocation == ""
 		}))
 
-	if _, err := tea.NewProgram(charm_internal.NewForm(huh.NewForm(
+	if _, err := charm_internal.NewForm(huh.NewForm(
 		groups...),
 		"Let's setup a new source for your workflow.",
-		"A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.")).
-		Run(); err != nil {
+		"A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.").
+		ExecuteForm(); err != nil {
 		return "", nil, err
 	}
 

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 
-	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/huh"
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -97,10 +96,10 @@ func targetBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 func PromptForNewTarget(currentWorkflow *workflow.Workflow, targetName, targetType, outDir string) (string, *workflow.Target, error) {
 	sourceName := getSourcesFromWorkflow(currentWorkflow)[0]
 	prompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, true)
-	if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(prompts),
+	if _, err := charm.NewForm(huh.NewForm(prompts),
 		"Let's setup a new target for your workflow.",
-		"A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.")).
-		Run(); err != nil {
+		"A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.").
+		ExecuteForm(); err != nil {
 		return "", nil, err
 	}
 
@@ -130,10 +129,9 @@ func PromptForExistingTarget(currentWorkflow *workflow.Workflow, targetName stri
 	originalDir := outDir
 
 	prompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, false)
-	if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(prompts),
+	if _, err := charm.NewForm(huh.NewForm(prompts),
 		"Let's setup a new target for your workflow.",
-		"A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.")).
-		Run(); err != nil {
+		"A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.").ExecuteForm(); err != nil {
 		return "", nil, err
 	}
 
@@ -167,7 +165,7 @@ func PromptForOutDirMigration(currentWorkflow *workflow.Workflow, existingTarget
 			}
 			originalDir := outDir
 
-			if _, err := tea.NewProgram(charm.NewForm(huh.NewForm(
+			if _, err := charm.NewForm(huh.NewForm(
 				huh.NewGroup(charm.NewInput().
 					Title("Provide an output directory for your generation target.").
 					Validate(func(s string) error {
@@ -178,8 +176,7 @@ func PromptForOutDirMigration(currentWorkflow *workflow.Workflow, existingTarget
 						return nil
 					}).
 					Value(&outDir))),
-				"To setup multiple targets you must select an output directory not in the root folder.")).
-				Run(); err != nil {
+				"To setup multiple targets you must select an output directory not in the root folder.").ExecuteForm(); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
We were seeing some instances of a stolen cursor when using ctrl+c in terminals like iterm. I believe this is because we were exiting early from the tea model. By default these models do not return an error on ctrl+c and they don't exit the program. The sort of swallow ctrl+c leaving you to implement intended behavior.


Rather than using using os.exit(0) immediately when we read the keystroke we need to gracefully exit the tea model and then exit the program.

Look at this change for the most simple example
https://github.com/speakeasy-api/speakeasy/pull/491/files#diff-18db6ef98884f0795575414883005156de964fe5d2a7231a15b09fe132a32015