### PR TITLE
fix: named servers handling in Ruby (x-speakeasy-server-id)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pb33f/libopenapi v0.15.10
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.275.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.275.4
 	github.com/speakeasy-api/openapi-overlay v0.3.0
 	github.com/speakeasy-api/sdk-gen-config v1.7.5
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.3.10

--- a/go.sum
+++ b/go.sum
@@ -617,6 +617,8 @@ github.com/speakeasy-api/easytemplate v0.9.0 h1:DQlwptBkzjpnsolRgu2HVOB4sX3vElzo
 github.com/speakeasy-api/easytemplate v0.9.0/go.mod h1:qKFg1/iCb/9BGlYYnnTE7wZFKzVnv0PYWOl2tg5i2hY=
 github.com/speakeasy-api/openapi-generation/v2 v2.275.2 h1:AsScrsVcdNDDJCfQisvC8mdNxxNMeFdyJdEbC9CrcQw=
 github.com/speakeasy-api/openapi-generation/v2 v2.275.2/go.mod h1:TKL5kdpOd0CCTadvTOMK8CT8fkqXdDimQlQmbdoA3aA=
+github.com/speakeasy-api/openapi-generation/v2 v2.275.4 h1:QL8Vlsy/MDlyeHfzUcRbT/awfc9blrkHBLvFhWr2JnA=
+github.com/speakeasy-api/openapi-generation/v2 v2.275.4/go.mod h1:TKL5kdpOd0CCTadvTOMK8CT8fkqXdDimQlQmbdoA3aA=
 github.com/speakeasy-api/openapi-overlay v0.3.0 h1:+5hIbDzyO7rD0ix9num8Y0bxbhwzRF28QluZ+dCuugA=
 github.com/speakeasy-api/openapi-overlay v0.3.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.7.5 h1:wzcBOJ5AYXSO5EBMTGYE0aAhAHRPKJ/0XtfMNFnS3Z4=


### PR DESCRIPTION
[SPE-2919](https://linear.app/speakeasy/issue/SPE-2919/issue-with-ruby-sdk-generation-in-speakeasy-due-to-mixup-between)
[PR#1058](https://github.com/speakeasy-api/openapi-generation/pull/1058)

This PR allows the use of`x-speakeasy-server-id` to name servers as well as server variables in Ruby
