### PR TITLE
fix: json-encode zap fields in log messages

### DIFF
--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -394,7 +394,12 @@ func fieldsToJSON(fields []zapcore.Field) string {
 			}
 			jsonObj[field.Key] = err.Error()
 		default:
-			panic("not yet implemented")
+			bs, err := json.Marshal(field.Interface)
+			if err != nil {
+				jsonObj[field.Key] = "<skipped>"
+				continue
+			}
+			jsonObj[field.Key] = json.RawMessage(bs)
 		}
 	}
 


### PR DESCRIPTION
This change replaces an explicit `panic()` in the custom logger when serializing zap fields of unknown type with an attempt at json-encoding the underlying value. If this fails then the log field is set to the string `"<skipped>"`.

Fixes SPE-3090