### PR TITLE
chore: remove overlay extends

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/speakeasy-api/huh v0.0.1
 	github.com/speakeasy-api/openapi-changes v1.0.3
 	github.com/speakeasy-api/openapi-generation/v2 v2.312.0
-	github.com/speakeasy-api/openapi-overlay v0.4.0
+	github.com/speakeasy-api/openapi-overlay v0.5.0
 	github.com/speakeasy-api/sdk-gen-config v1.11.2
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.7-beta
 	github.com/speakeasy-api/speakeasy-core v0.5.3

--- a/go.sum
+++ b/go.sum
@@ -505,12 +505,10 @@ github.com/speakeasy-api/huh v0.0.1 h1:zJuyql3bxkxkW8EN+xNuW6B6kmZZldtcKbLBx32Sw
 github.com/speakeasy-api/huh v0.0.1/go.mod h1:JVIEq1tlJtFWZ4OACzN0Tj+I3+SdLiMznROo12ZJ1bQ=
 github.com/speakeasy-api/openapi-changes v1.0.3 h1:4y0ar2qElQBTSgY957IRTngTntwCgcpTInNo3BE3e6g=
 github.com/speakeasy-api/openapi-changes v1.0.3/go.mod h1:dg89cIGQRjrXTytVaWHMRtZmJ5KLrWPdoLh05A+VFXc=
-github.com/speakeasy-api/openapi-generation/v2 v2.311.1 h1:xZYBV05nF+f+5ML6OIANeIobsARmUEilFwYuvCa4smY=
-github.com/speakeasy-api/openapi-generation/v2 v2.311.1/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-generation/v2 v2.312.0 h1:ZbY3B7A0U1N2Y3PJLQwE+w/tPnij96Y0EcsW4RjZOsk=
 github.com/speakeasy-api/openapi-generation/v2 v2.312.0/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
-github.com/speakeasy-api/openapi-overlay v0.4.0 h1:FKxopZDhlAIzPS2lKl2X7pfworNvlsxTYjaDwvlY+gw=
-github.com/speakeasy-api/openapi-overlay v0.4.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
+github.com/speakeasy-api/openapi-overlay v0.5.0 h1:nPBDoTZga4IivSx9c+HzQkC9e0qYR7GUfNgGQyvekJk=
+github.com/speakeasy-api/openapi-overlay v0.5.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.11.2 h1:g46aIBw3M6EXxCYaY3IH1iu06mr9bre6a5D8kwSILpw=
 github.com/speakeasy-api/sdk-gen-config v1.11.2/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.7-beta h1:HvgkAJPxhyK7qBgZqsiT9J5DOJwm5xBPBZ19vwo9kvA=

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -36,7 +36,7 @@ func Compare(schemas []string) error {
 
 	title := fmt.Sprintf("Overlay %s => %s", schemas[0], schemas[1])
 
-	o, err := overlay.Compare(title, schemas[0], y1, *y2)
+	o, err := overlay.Compare(title, y1, *y2)
 	if err != nil {
 		return fmt.Errorf("failed to compare spec files %q and %q: %w", schemas[0], schemas[1], err)
 	}

--- a/internal/suggestions/example_experiment.go
+++ b/internal/suggestions/example_experiment.go
@@ -245,7 +245,7 @@ func handleUpdate(ctx context.Context, cacheFolder string, shard Shard) error {
 	//
 	//title := fmt.Sprintf("Overlay %s => %s", schemas[0], schemas[1])
 	//
-	o, err := overlay.Compare("LLM", originalFile, y1, *y2)
+	o, err := overlay.Compare("LLM", y1, *y2)
 	if err != nil {
 		return fmt.Errorf("failed to compare spec files %q and %q: %w", originalFile, adjustedFile, err)
 	}

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -560,7 +560,7 @@ func isEquivalent(a YAMLComparable, b YAMLComparable) error {
 
 	aNode := aInner.(*yaml.Node)
 	bNode := bInner.(*yaml.Node)
-	nodeOverlay, err := overlay.Compare("comparison between yaml nodes", "", aNode, *bNode)
+	nodeOverlay, err := overlay.Compare("comparison between yaml nodes", aNode, *bNode)
 	if err != nil {
 		return fmt.Errorf("error comparing %#v and %#v: %w", a, b, err)
 	}


### PR DESCRIPTION
When producing an overlay by Compare, we no longer generate an `extends` line that references the original file's location.

This is because it's never actually being useful, as we always pass in a specific file location for an overlay to run against