### PR TITLE
fix: regex match for usage snippets

### DIFF
--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -184,7 +184,7 @@ func parseOperationInfoAndCodeSample(lang, usageOutputSection string) (*UsageSni
 	}
 
 	// Define a regular expression to capture the API name, method, and endpoint
-	apiDetailsRegex := regexp.MustCompile(`(\w+)\s+\((\w+)\s+(.*)\)`)
+	apiDetailsRegex := regexp.MustCompile(`([/\w{}_]+)\s+\((\w+)\s+(.*)\)`)
 
 	// Find and extract the API details
 	matches := apiDetailsRegex.FindStringSubmatch(parts[0])


### PR DESCRIPTION
Usage snippets like the following were not working

# Usage snippet provided for delete_/a/b/c/{d} (delete /a/b/c/{d})