### PR TITLE
feat: fixes for source applies

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -194,7 +194,7 @@ func (w *Workflow) Run(ctx context.Context) error {
 		}
 	} else if w.Source == "all" {
 		for id := range w.workflow.Sources {
-			_, err := w.runSource(ctx, w.RootStep, id)
+			_, err := w.runSource(ctx, w.RootStep, id, true)
 			if err != nil {
 				return err
 			}
@@ -213,7 +213,7 @@ func (w *Workflow) Run(ctx context.Context) error {
 			return fmt.Errorf("source %s not found", w.Source)
 		}
 
-		_, err := w.runSource(ctx, w.RootStep, w.Source)
+		_, err := w.runSource(ctx, w.RootStep, w.Source, true)
 		if err != nil {
 			return err
 		}
@@ -244,7 +244,7 @@ func (w *Workflow) runTarget(ctx context.Context, target string) error {
 	}
 
 	if source != nil {
-		sourcePath, err = w.runSource(ctx, rootStep, t.Source)
+		sourcePath, err = w.runSource(ctx, rootStep, t.Source, false)
 		if err != nil {
 			return err
 		}
@@ -336,7 +336,7 @@ func (w *Workflow) runTarget(ctx context.Context, target string) error {
 	return nil
 }
 
-func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id string) (string, error) {
+func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id string, cleanUp bool) (string, error) {
 	rootStep := parentStep.NewSubstep(fmt.Sprintf("Source: %s", id))
 	source := w.workflow.Sources[id]
 
@@ -437,10 +437,12 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id s
 
 	rootStep.SucceedWorkflow()
 
-	rootStep.NewSubstep("Cleaning up")
+	if cleanUp {
+		rootStep.NewSubstep("Cleaning up")
 
-	// Clean up temp files on success
-	os.RemoveAll(workflow.GetTempDir())
+		// Clean up temp files on success
+		os.RemoveAll(workflow.GetTempDir())
+	}
 
 	return outputLocation, nil
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -411,7 +411,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id s
 			if overlay.IsRemote() {
 				overlayStep.NewSubstep(fmt.Sprintf("Download document from %s", overlay.Location))
 
-				downloadedPath, err := resolveRemoteDocument(ctx, overlay, workflow.GetTempDir())
+				downloadedPath, err := resolveRemoteDocument(ctx, overlay, overlay.GetTempDownloadPath(workflow.GetTempDir()))
 				if err != nil {
 					return "", err
 				}
@@ -434,6 +434,11 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id s
 	}
 
 	rootStep.SucceedWorkflow()
+
+	rootStep.NewSubstep("Cleaning up")
+
+	// Clean up temp files on success
+	os.RemoveAll(workflow.GetTempDir())
 
 	return outputLocation, nil
 }


### PR DESCRIPTION
Fixes two issues with running workflow for sources only

- We were not able to handle remote overlay files
- We were not cleaning up the temp dir on success when running sources only


We were not supporting applying multiple overlays for 1 source in a workflow. This would always fail. That's because we need to write each overlay apply to a temporary document and then use that as an input for the next Apply. We were trying to keep a running document which was not working.