### PR TITLE
feat: offer sample OpenAPI Document

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -71,16 +71,16 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 
 	if workflowFile, _, _ := workflow.Load(workingDir); workflowFile != nil {
 		return fmt.Errorf("You cannot run quickstart when a speakeasy workflow already exists. \n" +
-			"To create a brand new SDK directory: cd .. and run `speakeasy quickstart`. \n" +
-			"To add an additional SDK to this workflow: run `speakeasy configure`. \n" +
-			"To regenerate the current workflow: run `speakeasy run`.")
+			"To create a brand new SDK directory: `cd ..` and then `speakeasy quickstart`. \n" +
+			"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
+			"To regenerate the current workflow: `speakeasy run`.")
 	}
 
 	if prompts.HasExistingGeneration(workingDir) {
 		return fmt.Errorf("You cannot run quickstart when a speakeasy workflow already exists. \n" +
-			"To create a brand new SDK directory: cd .. and run `speakeasy quickstart`. \n" +
-			"To add an additional SDK to this workflow: run `speakeasy configure`. \n" +
-			"To regenerate the current workflow: run `speakeasy run`.")
+			"To create a brand new SDK directory: cd .. and then `speakeasy quickstart`. \n" +
+			"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
+			"To regenerate the current workflow: `speakeasy run`.")
 	}
 
 	fmt.Println(charm.FormatCommandTitle("Welcome to the Speakeasy!",

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 
 	"github.com/speakeasy-api/huh"
@@ -210,7 +211,14 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 				return errors.Wrapf(err, "failed to write sample OpenAPI spec")
 			}
 		}
-		fmt.Printf("The OpenAPI sample document will be used.\nIt can be found here, you can edit it at anytime:\n\n  %s\n\n", absSchemaPath)
+
+		fmt.Println(
+			styles.RenderInfoMessage(
+				"The OpenAPI sample document will be used",
+				"It can be found here, you can edit it at anytime:",
+				absSchemaPath,
+			),
+		)
 
 		referencePath, err := filepath.Rel(outDir, absSchemaPath)
 		if err != nil {

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -202,14 +202,9 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	}
 
 	if quickstartObj.IsUsingSampleOpenAPISpec {
-		// Try writing the sample spec to the parent of the outDir, fallback to outDir
-		outDirParent := filepath.Dir(outDir)
-		absSchemaPath := filepath.Join(outDirParent, "openapi.yaml")
+		absSchemaPath := filepath.Join(outDir, "openapi.yaml")
 		if err := os.WriteFile(absSchemaPath, []byte(sampleSpec), 0o644); err != nil {
-			absSchemaPath = filepath.Join(outDir, "openapi.yaml")
-			if err := os.WriteFile(absSchemaPath, []byte(sampleSpec), 0o644); err != nil {
-				return errors.Wrapf(err, "failed to write sample OpenAPI spec")
-			}
+			return errors.Wrapf(err, "failed to write sample OpenAPI spec")
 		}
 
 		fmt.Println(

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -13,6 +13,7 @@ import (
 	"github.com/speakeasy-api/huh"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 
+	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	config "github.com/speakeasy-api/sdk-gen-config"
@@ -122,12 +123,19 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		outDir = flags.OutDir
 	}
 	var targetType string
+	var sdkClassName string
+	// Assume just one language possible during quickstart
 	for _, target := range quickstartObj.WorkflowFile.Targets {
 		targetType = target.Target
+		for _, config := range quickstartObj.LanguageConfigs {
+			sdkClassName = config.Generation.SDKClassName
+			break
+		}
+
 		break
 	}
 
-	promptedDir := filepath.Join(workingDir, targetType)
+	promptedDir := filepath.Join(workingDir, strcase.ToKebab(sdkClassName)+"-"+targetType)
 	if outDir != workingDir {
 		promptedDir = outDir
 	}

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -122,16 +122,17 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	if flags.OutDir != "" {
 		outDir = flags.OutDir
 	}
+
+	// Pull the target type and sdk class name from the first target
+	// Assume just one target possible during quickstart
 	var targetType string
 	var sdkClassName string
-	// Assume just one language possible during quickstart
 	for _, target := range quickstartObj.WorkflowFile.Targets {
 		targetType = target.Target
-		for _, config := range quickstartObj.LanguageConfigs {
-			sdkClassName = config.Generation.SDKClassName
-			break
-		}
-
+		break
+	}
+	for _, config := range quickstartObj.LanguageConfigs {
+		sdkClassName = config.Generation.SDKClassName
 		break
 	}
 

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -140,7 +140,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	if outDir != workingDir {
 		promptedDir = outDir
 	}
-	description := "We recommend a directory per target type. eg my-sdk-go, my-sdk-python. To use the current directory, leave empty."
+	description := "We recommend a git repo per SDK. To use the current directory, leave empty."
 	if targetType == "terraform" {
 		description = "Terraform providers must be placed in a directory named in the following format terraform-provider-*. according to Hashicorp conventions"
 		outDir = "terraform-provider"

--- a/cmd/sample_openapi.yaml
+++ b/cmd/sample_openapi.yaml
@@ -1,0 +1,727 @@
+openapi: 3.1.0
+info:
+  title: Petstore - OpenAPI 3.1
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.1 specification.
+
+    Some useful links:
+    - [OpenAPI Reference](https://www.speakeasyapi.dev/openapi)
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: support@speakeasyapi.dev
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+security:
+  - api_key: []
+servers:
+  - url: https://{environment}.petstore.io
+    description: A per-environment API.
+    variables:
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  "/pet":
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      requestBody:
+        description: Update an existent pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      requestBody:
+        description: Create a new pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '405':
+          description: Invalid input
+
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: false
+        explode: true
+        schema:
+          type: string
+          default: available
+          enum:
+          - available
+          - pending
+          - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/findByTags":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by tags
+      description: Multiple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags:
+      - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+      - name: api_key
+        in: header
+        description: ''
+        required: false
+        schema:
+          type: string
+      - name: petId
+        in: path
+        description: Pet id to delete
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Pet deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+      - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to update
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: additionalMetadata
+        in: query
+        description: Additional Metadata
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+
+  "/store/inventory":
+    get:
+      tags:
+      - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/store/order":
+    post:
+      tags:
+      - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '405':
+          description: Invalid input
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/store/order/{orderId}":
+    get:
+      tags:
+      - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other
+        values will generate exceptions.
+      operationId: getOrderById
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of order that needs to be fetched
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+      - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything
+        above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of the order that needs to be deleted
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Order deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user":
+    post:
+      tags:
+      - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/createWithList":
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/login":
+    get:
+      tags:
+      - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+      - name: username
+        in: query
+        description: The user name for login
+        required: false
+        schema:
+          type: string
+      - name: password
+        in: query
+        description: The password for login in clear text
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user/logout":
+    get:
+      tags:
+      - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+      - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+      - name: username
+        in: path
+        description: 'The name that needs to be fetched. Use user1 for testing. '
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+      - user
+      summary: Update user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+      - name: username
+        in: path
+        description: name that needs to be updated
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: successful operation
+    delete:
+      tags:
+      - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+      - name: username
+        in: path
+        description: The name that needs to be deleted
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+          - placed
+          - approved
+          - delivered
+        complete:
+          type: boolean
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+      - name
+      - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          "$ref": "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    ApiErrorInvalidInput:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 400
+        error:
+          type: string
+          example: Bad request
+    ApiErrorNotFound:
+      type: object
+      required:
+        - status
+        - error
+        - code
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 404
+        error:
+          type: string
+          example: Not Found
+        code:
+          type: string
+          example: object_not_found
+    ApiErrorUnauthorized:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 401
+        error:
+          type: string
+          example: Unauthorized
+  responses:
+    Unauthorized:
+      description: Unauthorized error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorUnauthorized'
+    NotFound:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorNotFound'
+    InvalidInput:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorInvalidInput'
+

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hexops/gotextdiff v1.0.3
 	github.com/iancoleman/orderedmap v0.3.0
+	github.com/iancoleman/strcase v0.3.0
 	github.com/manifoldco/promptui v0.9.0
 	github.com/pb33f/libopenapi v0.15.14
 	github.com/pkg/errors v0.9.1
@@ -121,7 +122,6 @@ require (
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/hashicorp/hcl/v2 v2.17.0 // indirect
 	github.com/huandu/xstrings v1.4.0 // indirect
-	github.com/iancoleman/strcase v0.3.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -149,12 +149,7 @@ func (w *Workflow) RunWithVisualization(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		workingDirectory, err := os.Getwd()
-		if err != nil {
-			return err
-		}
-
-		tOut := workingDirectory
+		tOut := "the current directory"
 		if t.Output != nil && *t.Output != "" && *t.Output != "." {
 			tOut = *t.Output
 		}
@@ -164,12 +159,12 @@ func (w *Workflow) RunWithVisualization(ctx context.Context) error {
 
 		titleMsg := " SDK Generated Successfully"
 		additionalLines := []string{
-			fmt.Sprintf("⏲ Generated in %.1f Seconds", endDuration.Seconds()),
 			"✎ Output written to " + tOut,
+			fmt.Sprintf("⏲ Generated in %.1f Seconds", endDuration.Seconds()),
 		}
 
 		if w.FromQuickstart {
-			additionalLines = append(additionalLines, "Execute `speakeasy run` to regenerate your SDK!")
+			additionalLines = append(additionalLines, "Execute speakeasy run to regenerate your SDK!")
 		}
 
 		if t.CodeSamples != nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -149,7 +149,12 @@ func (w *Workflow) RunWithVisualization(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		tOut := "the current directory"
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+
+		tOut := workingDirectory
 		if t.Output != nil && *t.Output != "" && *t.Output != "." {
 			tOut = *t.Output
 		}
@@ -159,12 +164,12 @@ func (w *Workflow) RunWithVisualization(ctx context.Context) error {
 
 		titleMsg := " SDK Generated Successfully"
 		additionalLines := []string{
-			"✎ Output written to " + tOut,
 			fmt.Sprintf("⏲ Generated in %.1f Seconds", endDuration.Seconds()),
+			"✎ Output written to " + tOut,
 		}
 
 		if w.FromQuickstart {
-			additionalLines = append(additionalLines, "Execute speakeasy run to regenerate your SDK!")
+			additionalLines = append(additionalLines, "Execute `speakeasy run` to regenerate your SDK!")
 		}
 
 		if t.CodeSamples != nil {

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -142,7 +142,7 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 		// Other parts of the code make assumptions that the workflow has a valid source
 		// This is a hack to satisfy those assumptions, we will overwrite this with a proper
 		// file location when we have written the sample spec to disk when we know the SDK output directory
-		fileLocation = "OVERWRITE_WHEN_SAMPLE_SPEC_IS_WRITTEN"
+		fileLocation = "https://example.com/OVERWRITE_WHEN_SAMPLE_SPEC_IS_WRITTEN"
 	} else {
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -123,11 +123,13 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 	useSampleSpec := false
 	_, err := charm_internal.NewForm(huh.NewForm(
 		huh.NewGroup(
-			huh.NewConfirm().
+			huh.NewSelect[bool]().
 				Title("Do you have an existing OpenAPI spec?").
-				Description("You can provide a local file path or a remote file reference to your OpenAPI spec.").
-				Affirmative("No, use a sample OpenAPI spec").
-				Negative("Yes").
+				Description("You can provide a local file path or a remote file URL to your OpenAPI spec.").
+				Options(
+					huh.NewOption("Yes", false),
+					huh.NewOption("No, use a sample OpenAPI spec", true),
+				).
 				Value(&useSampleSpec),
 		),
 	)).ExecuteForm()
@@ -137,7 +139,7 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 
 	if useSampleSpec {
 		quickstart.IsUsingSampleOpenAPISpec = true
-		fileLocation = "openapi.yaml"
+		fileLocation = "https://example.com" // This is a placeholder it will be filled in properly later
 	} else {
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -139,7 +139,8 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 
 	if useSampleSpec {
 		quickstart.IsUsingSampleOpenAPISpec = true
-		fileLocation = "https://example.com" // This is a placeholder it will be filled in properly later
+		// This is a placeholder to pass document validation, it will be overwritten when we know where the output directory is
+		fileLocation = "https://example.com/placeholder"
 	} else {
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -139,8 +139,10 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 
 	if useSampleSpec {
 		quickstart.IsUsingSampleOpenAPISpec = true
-		nextState := TargetBase
-		return &nextState, nil
+		// Other parts of the code make assumptions that the workflow has a valid source
+		// This is a hack to satisfy those assumptions, we will overwrite this with a proper
+		// file location when we have written the sample spec to disk when we know the SDK output directory
+		fileLocation = "OVERWRITE_WHEN_SAMPLE_SPEC_IS_WRITTEN"
 	} else {
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -139,8 +139,8 @@ func sourceBaseForm(quickstart *Quickstart) (*QuickstartState, error) {
 
 	if useSampleSpec {
 		quickstart.IsUsingSampleOpenAPISpec = true
-		// This is a placeholder to pass document validation, it will be overwritten when we know where the output directory is
-		fileLocation = "https://example.com/placeholder"
+		nextState := TargetBase
+		return &nextState, nil
 	} else {
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			getBaseSourcePrompts(quickstart.WorkflowFile, &sourceName, &fileLocation, &authHeader, &authSecret)...),

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -15,7 +15,6 @@ type Quickstart struct {
 	LanguageConfigs          map[string]*config.Configuration
 	Defaults                 Defaults
 	IsUsingSampleOpenAPISpec bool
-	SDKClassName             string
 }
 
 type Defaults struct {

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -11,9 +11,10 @@ type (
 )
 
 type Quickstart struct {
-	WorkflowFile    *workflow.Workflow
-	LanguageConfigs map[string]*config.Configuration
-	Defaults        Defaults
+	WorkflowFile             *workflow.Workflow
+	LanguageConfigs          map[string]*config.Configuration
+	Defaults                 Defaults
+	IsUsingSampleOpenAPISpec bool
 }
 
 type Defaults struct {

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -15,6 +15,7 @@ type Quickstart struct {
 	LanguageConfigs          map[string]*config.Configuration
 	Defaults                 Defaults
 	IsUsingSampleOpenAPISpec bool
+	SDKClassName             string
 }
 
 type Defaults struct {


### PR DESCRIPTION
* Offer to use a hand curated Petstore Open API spec which produces a nice looking SDK
* Writes the sample openapi spec in the parent directory of the new target (fallsback to inside the target directory if that fails)
* Defaults new target directory name to `{{kebab-sdk-name}}-{{targetName}}`


https://github.com/speakeasy-api/speakeasy/assets/1690659/d27dbc04-2735-4c84-be56-2b734f0ea838

