### PR TITLE
feat: introduce conventional namespaces C#/Unity

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v0.0.1
 	github.com/speakeasy-api/openapi-changes v1.0.3
-	github.com/speakeasy-api/openapi-generation/v2 v2.291.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.292.0
 	github.com/speakeasy-api/openapi-overlay v0.4.0
 	github.com/speakeasy-api/sdk-gen-config v1.9.1
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.4.3

--- a/go.sum
+++ b/go.sum
@@ -634,8 +634,8 @@ github.com/speakeasy-api/huh v0.0.1 h1:zJuyql3bxkxkW8EN+xNuW6B6kmZZldtcKbLBx32Sw
 github.com/speakeasy-api/huh v0.0.1/go.mod h1:JVIEq1tlJtFWZ4OACzN0Tj+I3+SdLiMznROo12ZJ1bQ=
 github.com/speakeasy-api/openapi-changes v1.0.3 h1:4y0ar2qElQBTSgY957IRTngTntwCgcpTInNo3BE3e6g=
 github.com/speakeasy-api/openapi-changes v1.0.3/go.mod h1:dg89cIGQRjrXTytVaWHMRtZmJ5KLrWPdoLh05A+VFXc=
-github.com/speakeasy-api/openapi-generation/v2 v2.291.0 h1:yu3z8EugCBK5rdlYCQ4ROzLNGt9im1d5F/IQcgJof64=
-github.com/speakeasy-api/openapi-generation/v2 v2.291.0/go.mod h1:xx4/IO1hq75cscsmAOSEG6lPL47ProG4pxO7Q5A1QkQ=
+github.com/speakeasy-api/openapi-generation/v2 v2.292.0 h1:BLviCOz8ca9z0sMws9VX6eQ2bJNsgkzEoAipVoMUchg=
+github.com/speakeasy-api/openapi-generation/v2 v2.292.0/go.mod h1:xx4/IO1hq75cscsmAOSEG6lPL47ProG4pxO7Q5A1QkQ=
 github.com/speakeasy-api/openapi-overlay v0.4.0 h1:FKxopZDhlAIzPS2lKl2X7pfworNvlsxTYjaDwvlY+gw=
 github.com/speakeasy-api/openapi-overlay v0.4.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.9.1 h1:MK9bMhAicbdSKC3VmRs/slvsXUyUZeOBiYUXuLLBDJE=


### PR DESCRIPTION
Addresses SPE-3039 + SPE-3163

This PR introduces conventional namespaces in C#/Unity following [microsoft's guidelines](https://learn.microsoft.com/en-us/dotnet/standard/design-guidelines/names-of-namespaces).

For example, when setting the following parameters in your `gen.yaml`: 
```
company: Company
product: Product
packageName: My.Company.Product
```
the root namespace will be set to `Company.Product` and the NuGet PackageID to `My.Company.Product`.
If `packageName` is not provided, the PackageID will match the root namespace instead.