### PR TITLE
chore: show absolute path in run visualization

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -149,7 +149,11 @@ func (w *Workflow) RunWithVisualization(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-		tOut := "the current directory"
+		workingDirectory, err := os.Getwd()
+		if err != nil {
+			return err
+		}
+		tOut := workingDirectory
 		if t.Output != nil && *t.Output != "" && *t.Output != "." {
 			tOut = *t.Output
 		}


### PR DESCRIPTION
During quickstart "the current directory" is not helpful as we set the working directory to be the outDir inside quickstart.go, rather be explicit especially as all the history of responses of the forms are cleared from the buffer. 