### PR TITLE
feat: clarify run and generate descriptions

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -81,8 +81,8 @@ var (
 
 var GenerateCmd = &model.CommandGroup{
 	Usage:          "generate",
-	Short:          "Generate client SDKs, docsites, and more",
-	Long:           `The "generate" command provides a set of commands for generating client SDKs and Terraform providers`,
+	Short:          "One off Generations for client SDKs, docsites, and more",
+	Long:           `The "generate" command provides a set of commands for one off generations of client SDKs and Terraform providers`,
 	InteractiveMsg: "What do you want to generate?",
 	Commands:       []model.Command{genSDKCmd, genSDKDocsCmd, genUsageSnippetCmd, codeSamplesCmd, genSDKVersionCmd, genSDKChangelogCmd},
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,7 @@ type RunFlags struct {
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
 	Usage: "run",
-	Short: "generate an SDK, compile sources, and more from a defined workflow.yaml file",
+	Short: "generate an SDK, compile OpenAPI sources, and much more from a defined workflow.yaml file",
 	Long: "run the workflow(s) defined in your `.speakeasy/workflow.yaml` file." + `
 A workflow can consist of multiple targets that define a source OpenAPI document that can be downloaded from a URL, exist as a local file, or be created via merging multiple OpenAPI documents together and/or overlaying them with an OpenAPI overlay document.
 A full workflow is capable of running the following steps:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,7 @@ type RunFlags struct {
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
 	Usage: "run",
-	Short: "generate an SDK off of a defined workflow.yaml file",
+	Short: "generate an SDK, compile sources, and more from a defined workflow.yaml file",
 	Long: "run the workflow(s) defined in your `.speakeasy/workflow.yaml` file." + `
 A workflow can consist of multiple targets that define a source OpenAPI document that can be downloaded from a URL, exist as a local file, or be created via merging multiple OpenAPI documents together and/or overlaying them with an OpenAPI overlay document.
 A full workflow is capable of running the following steps:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 
 	"github.com/speakeasy-api/speakeasy/internal/utils"
@@ -34,7 +35,7 @@ type RunFlags struct {
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
 	Usage: "run",
-	Short: "run the workflow defined in your workflow.yaml file",
+	Short: "generate an SDK off of a defined workflow.yaml file",
 	Long: "run the workflow(s) defined in your `.speakeasy/workflow.yaml` file." + `
 A workflow can consist of multiple targets that define a source OpenAPI document that can be downloaded from a URL, exist as a local file, or be created via merging multiple OpenAPI documents together and/or overlaying them with an OpenAPI overlay document.
 A full workflow is capable of running the following steps:

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -35,7 +35,7 @@ type RunFlags struct {
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
 	Usage: "run",
-	Short: "generate an SDK, compile OpenAPI sources, and much more from a defined workflow.yaml file",
+	Short: "generate an SDK, compile OpenAPI sources, and much more from a workflow.yaml file",
 	Long: "run the workflow(s) defined in your `.speakeasy/workflow.yaml` file." + `
 A workflow can consist of multiple targets that define a source OpenAPI document that can be downloaded from a URL, exist as a local file, or be created via merging multiple OpenAPI documents together and/or overlaying them with an OpenAPI overlay document.
 A full workflow is capable of running the following steps:


### PR DESCRIPTION
Even though run does more than just generate SDKs I think new users looking at our CLI through help or interactive mode miss the point that they should be using this to generate.