### PR TITLE
feat: sample integration testing cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/
 *.iml
 summary.md
 .speakeasy/
+integration/temp

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -80,7 +80,23 @@ func addCommand(cmd *cobra.Command, command model.Command) {
 	cmd.AddCommand(c)
 }
 
+func CmdForTest(version, artifactArch string) *cobra.Command {
+	setupRootCmd(version, artifactArch)
+
+	return rootCmd
+}
+
 func Execute(version, artifactArch string) {
+	setupRootCmd(version, artifactArch)
+
+	if err := rootCmd.Execute(); err != nil {
+		l.Error("", zap.Error(err))
+		l.WithInteractiveOnly().PrintfStyled(styles.DimmedItalic, "Run '%s --help' for usage.\n", rootCmd.CommandPath())
+		os.Exit(1)
+	}
+}
+
+func setupRootCmd(version, artifactArch string) {
 	rootCmd.Version = version + "\n" + artifactArch
 	rootCmd.SilenceErrors = true
 	rootCmd.SilenceUsage = true
@@ -97,12 +113,7 @@ func Execute(version, artifactArch string) {
 	}
 
 	Init(version, artifactArch)
-
-	if err := rootCmd.Execute(); err != nil {
-		l.Error("", zap.Error(err))
-		l.WithInteractiveOnly().PrintfStyled(styles.DimmedItalic, "Run '%s --help' for usage.\n", rootCmd.CommandPath())
-		os.Exit(1)
-	}
+	return
 }
 
 func GetRootCommand() *cobra.Command {

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -1,0 +1,55 @@
+package integration_tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/speakeasy/cmd"
+	"github.com/spf13/cobra"
+	"github.com/stretchr/testify/assert"
+)
+
+var rootCmd *cobra.Command
+
+// Entrypoint for CLI integration tests
+func TestMain(m *testing.M) {
+	// Create a temporary directory
+	if _, err := os.Stat(tempDir); err == nil {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := os.Mkdir(tempDir, 0o755); err != nil {
+		panic(err)
+	}
+
+	// Defer the removal of the temp directory
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	rootCmd = cmd.CmdForTest(version, artifactArch)
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func setupTestDir(t *testing.T) string {
+	workingDir, err := os.Getwd()
+	assert.NoError(t, err)
+	temp, err := createTempDir()
+	assert.NoError(t, err)
+	registerCleanup(t, workingDir, temp)
+
+	return temp
+}
+
+func registerCleanup(t *testing.T, workingDir string, temp string) {
+	t.Cleanup(func() {
+		os.Chdir(workingDir)
+		os.RemoveAll(temp)
+	})
+}

--- a/integration/resources/codeSamples.yaml
+++ b/integration/resources/codeSamples.yaml
@@ -1,0 +1,619 @@
+overlay: 1.0.0
+info:
+  title: CodeSamples overlay for go target
+  version: 0.0.0
+actions:
+  - target: $["paths"]["/pet"]["put"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: updatePet
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.UpdatePet(ctx, components.Pet{
+                    ID: openapi.Int64(10),
+                    Name: "doggie",
+                    PhotoUrls: []string{
+                        "<value>",
+                    },
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pet != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet/{petId}"]["delete"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: deletePet
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var petID int64 = 441876
+
+                var apiKey *string = openapi.String("<value>")
+
+                ctx := context.Background()
+                res, err := s.DeletePet(ctx, petID, apiKey)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pet != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/store/order/{orderId}"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: getOrderById
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var orderID int64 = 614993
+
+                ctx := context.Background()
+                res, err := s.GetOrderByID(ctx, orderID)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Order != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/{username}"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: getUserByName
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var username string = "<value>"
+
+                ctx := context.Background()
+                res, err := s.GetUserByName(ctx, username)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.User != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet/findByStatus"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: findPetsByStatus
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"openapi/models/operations"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var status *operations.Status = operations.StatusAvailable.ToPointer()
+
+                ctx := context.Background()
+                res, err := s.FindPetsByStatus(ctx, status)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pets != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet/{petId}"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: getPetById
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var petID int64 = 504151
+
+                ctx := context.Background()
+                res, err := s.GetPetByID(ctx, petID)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pet != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/store/order"]["post"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: placeOrder
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.PlaceOrder(ctx, &components.Order{
+                    ID: openapi.Int64(10),
+                    PetID: openapi.Int64(198772),
+                    Quantity: openapi.Int(7),
+                    Status: components.OrderStatusApproved.ToPointer(),
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Order != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/logout"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: logoutUser
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.LogoutUser(ctx)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet"]["post"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: addPet
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.AddPet(ctx, components.Pet{
+                    ID: openapi.Int64(10),
+                    Name: "doggie",
+                    PhotoUrls: []string{
+                        "<value>",
+                    },
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pet != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet/{petId}/uploadImage"]["post"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: uploadFile
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var petID int64 = 565380
+
+                var additionalMetadata *string = openapi.String("<value>")
+
+                var requestBody []byte = []byte("0x7cca7F47Dd")
+
+                ctx := context.Background()
+                res, err := s.UploadFile(ctx, petID, additionalMetadata, requestBody)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.APIResponse != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/store/inventory"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: getInventory
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.GetInventory(ctx)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Object != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user"]["post"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: createUser
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.CreateUser(ctx, &components.User{
+                    ID: openapi.Int64(10),
+                    Username: openapi.String("theUser"),
+                    FirstName: openapi.String("John"),
+                    LastName: openapi.String("James"),
+                    Email: openapi.String("john@email.com"),
+                    Password: openapi.String("12345"),
+                    Phone: openapi.String("12345"),
+                    UserStatus: openapi.Int(1),
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.User != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/{username}"]["delete"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: deleteUser
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var username string = "<value>"
+
+                ctx := context.Background()
+                res, err := s.DeleteUser(ctx, username)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.User != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pet/findByTags"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: findPetsByTags
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                tags := []string{
+                    "<value>",
+                }
+
+                ctx := context.Background()
+                res, err := s.FindPetsByTags(ctx, tags)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pets != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/store/order/{orderId}"]["delete"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: deleteOrder
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var orderID int64 = 127902
+
+                ctx := context.Background()
+                res, err := s.DeleteOrder(ctx, orderID)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Order != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/createWithList"]["post"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: createUsersWithListInput
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+                ctx := context.Background()
+                res, err := s.CreateUsersWithListInput(ctx, []components.User{
+                    components.User{
+                        ID: openapi.Int64(10),
+                        Username: openapi.String("theUser"),
+                        FirstName: openapi.String("John"),
+                        LastName: openapi.String("James"),
+                        Email: openapi.String("john@email.com"),
+                        Password: openapi.String("12345"),
+                        Phone: openapi.String("12345"),
+                        UserStatus: openapi.Int(1),
+                    },
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.User != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/login"]["get"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: loginUser
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var username *string = openapi.String("<value>")
+
+                var password *string = openapi.String("<value>")
+
+                ctx := context.Background()
+                res, err := s.LoginUser(ctx, username, password)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.String != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/user/{username}"]["put"]
+    update:
+      x-codeSamples:
+        - lang: go
+          label: updateUser
+          source: |-
+            package main
+
+            import(
+            	"openapi/models/components"
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New(
+                    openapi.WithSecurity("<YOUR_API_KEY_HERE>"),
+                )
+
+
+                var username string = "<value>"
+
+                user := &components.User{
+                    ID: openapi.Int64(10),
+                    Username: openapi.String("theUser"),
+                    FirstName: openapi.String("John"),
+                    LastName: openapi.String("James"),
+                    Email: openapi.String("john@email.com"),
+                    Password: openapi.String("12345"),
+                    Phone: openapi.String("12345"),
+                    UserStatus: openapi.Int(1),
+                }
+
+                ctx := context.Background()
+                res, err := s.UpdateUser(ctx, username, user)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res != nil {
+                    // handle response
+                }
+            }

--- a/integration/resources/spec.yaml
+++ b/integration/resources/spec.yaml
@@ -1,0 +1,727 @@
+openapi: 3.1.0
+info:
+  title: Petstore - OpenAPI 3.1
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.1 specification.
+
+    Some useful links:
+    - [OpenAPI Reference](https://www.speakeasyapi.dev/openapi)
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: support@speakeasyapi.dev
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+security:
+  - api_key: []
+servers:
+  - url: https://{environment}.petstore.io
+    description: A per-environment API.
+    variables:
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  "/pet":
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      requestBody:
+        description: Update an existent pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      requestBody:
+        description: Create a new pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '405':
+          description: Invalid input
+
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: false
+        explode: true
+        schema:
+          type: string
+          default: available
+          enum:
+          - available
+          - pending
+          - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/findByTags":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by tags
+      description: Multiple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags:
+      - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+      - name: api_key
+        in: header
+        description: ''
+        required: false
+        schema:
+          type: string
+      - name: petId
+        in: path
+        description: Pet id to delete
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Pet deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+      - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to update
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: additionalMetadata
+        in: query
+        description: Additional Metadata
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+
+  "/store/inventory":
+    get:
+      tags:
+      - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/store/order":
+    post:
+      tags:
+      - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '405':
+          description: Invalid input
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/store/order/{orderId}":
+    get:
+      tags:
+      - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other
+        values will generate exceptions.
+      operationId: getOrderById
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of order that needs to be fetched
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+      - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything
+        above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of the order that needs to be deleted
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Order deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user":
+    post:
+      tags:
+      - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/createWithList":
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/login":
+    get:
+      tags:
+      - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+      - name: username
+        in: query
+        description: The user name for login
+        required: false
+        schema:
+          type: string
+      - name: password
+        in: query
+        description: The password for login in clear text
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user/logout":
+    get:
+      tags:
+      - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+      - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+      - name: username
+        in: path
+        description: 'The name that needs to be fetched. Use user1 for testing. '
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+      - user
+      summary: Update user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+      - name: username
+        in: path
+        description: name that needs to be updated
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: successful operation
+    delete:
+      tags:
+      - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+      - name: username
+        in: path
+        description: The name that needs to be deleted
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+          - placed
+          - approved
+          - delivered
+        complete:
+          type: boolean
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+      - name
+      - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          "$ref": "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    ApiErrorInvalidInput:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 400
+        error:
+          type: string
+          example: Bad request
+    ApiErrorNotFound:
+      type: object
+      required:
+        - status
+        - error
+        - code
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 404
+        error:
+          type: string
+          example: Not Found
+        code:
+          type: string
+          example: object_not_found
+    ApiErrorUnauthorized:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 401
+        error:
+          type: string
+          example: Unauthorized
+  responses:
+    Unauthorized:
+      description: Unauthorized error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorUnauthorized'
+    NotFound:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorNotFound'
+    InvalidInput:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorInvalidInput'
+

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -1,0 +1,89 @@
+package integration_tests
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+const (
+	tempDir      = "temp"
+	letterBytes  = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+	version      = "0.0.1"
+	artifactArch = "linux_amd64"
+)
+
+func createTempDir() (string, error) {
+	temp := fmt.Sprintf("%s/%s", tempDir, randStringBytes(7))
+	if err := os.Mkdir(temp, 0o755); err != nil {
+		return "", err
+	}
+
+	return temp, nil
+}
+
+func isLocalFileReference(filePath string) bool {
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return true
+	}
+
+	return u.Scheme == "" || u.Scheme == "file"
+}
+
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	_, err = io.Copy(destinationFile, sourceFile)
+	return err
+}
+
+var randStringBytes = func(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}
+
+func expectedFilesByLanguage(language string) []string {
+	switch language {
+	case "go":
+		return []string{"README.md", "sdk.go", "go.mod"}
+	case "typescript":
+		return []string{"README.md", "package.json", "tsconfig.json"}
+	case "python":
+		return []string{"README.md", "setup.py"}
+	default:
+		return []string{}
+	}
+}
+
+func checkForExpectedFiles(t *testing.T, outdir string, files []string) {
+	for _, fileName := range files {
+		filePath := filepath.Join(outdir, fileName)
+		fileInfo, err := os.Stat(filePath)
+		if err != nil {
+			t.Errorf("Error checking file %s in directory %s: %v", fileName, outdir, err)
+			continue
+		}
+
+		if fileInfo.Size() == 0 {
+			t.Errorf("Expected file %s in directory %s is empty.", fileName, outdir)
+		}
+	}
+}

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -12,7 +12,180 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestCodeSampleWorkflows(t *testing.T) {
+// All tests must be run as individual test functions in serial.
+
+func TestGenerationWorkflows(t *testing.T) {
+	tests := []struct {
+		name        string
+		targetTypes []string
+		outdirs     []string
+		inputDoc    string
+	}{
+		{
+			name: "generation with remote document",
+			targetTypes: []string{
+				"go",
+			},
+			outdirs: []string{
+				"go",
+			},
+			inputDoc: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml",
+		},
+		{
+			name: "generation with local document",
+			targetTypes: []string{
+				"go",
+			},
+			outdirs: []string{
+				"go",
+			},
+			inputDoc: "spec.yaml",
+		},
+		{
+			name: "multi-target generation",
+			targetTypes: []string{
+				"go",
+				"typescript",
+			},
+			outdirs: []string{
+				"go",
+				"ts",
+			},
+			inputDoc: "spec.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			temp := setupTestDir(t)
+
+			// Create workflow file and associated resources
+			workflowFile := &workflow.Workflow{
+				Version: workflow.WorkflowVersion,
+				Sources: make(map[string]workflow.Source),
+				Targets: make(map[string]workflow.Target),
+			}
+			workflowFile.Sources["first-source"] = workflow.Source{
+				Inputs: []workflow.Document{
+					{
+						Location: tt.inputDoc,
+					},
+				},
+			}
+
+			for i := range tt.targetTypes {
+				workflowFile.Targets[fmt.Sprintf("%d-target", i)] = workflow.Target{
+					Target: tt.targetTypes[i],
+					Source: "first-source",
+					Output: &tt.outdirs[i],
+				}
+			}
+
+			if isLocalFileReference(tt.inputDoc) {
+				err := copyFile("resources/spec.yaml", fmt.Sprintf("%s/%s", temp, tt.inputDoc))
+				assert.NoError(t, err)
+			}
+
+			// Execute commands from the temporary directory
+			os.Chdir(temp)
+			err := workflowFile.Validate(generate.GetSupportedLanguages())
+			assert.NoError(t, err)
+			err = os.MkdirAll(".speakeasy", 0o755)
+			assert.NoError(t, err)
+			err = workflow.Save(".", workflowFile)
+			assert.NoError(t, err)
+			args := []string{"run", "-t", "all"}
+			rootCmd.SetArgs(args)
+			cmdErr := rootCmd.Execute()
+			assert.NoError(t, cmdErr)
+
+			for i, targetType := range tt.targetTypes {
+				checkForExpectedFiles(t, tt.outdirs[i], expectedFilesByLanguage(targetType))
+			}
+		})
+	}
+}
+
+func TestSpecWorkflows(t *testing.T) {
+	tests := []struct {
+		name      string
+		inputDocs []string
+		overlays  []string
+		out       string
+	}{
+		{
+			name: "overlay with local document",
+			inputDocs: []string{
+				"spec.yaml",
+			},
+			overlays: []string{
+				"codeSamples.yaml",
+			},
+			out: "output.yaml",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			temp := setupTestDir(t)
+
+			// Create workflow file and associated resources
+			workflowFile := &workflow.Workflow{
+				Version: workflow.WorkflowVersion,
+				Sources: make(map[string]workflow.Source),
+				Targets: make(map[string]workflow.Target),
+			}
+
+			var inputs []workflow.Document
+			for _, inputDoc := range tt.inputDocs {
+				if isLocalFileReference(inputDoc) {
+					err := copyFile(fmt.Sprintf("resources/%s", inputDoc), fmt.Sprintf("%s/%s", temp, inputDoc))
+					assert.NoError(t, err)
+				}
+				inputs = append(inputs, workflow.Document{
+					Location: inputDoc,
+				})
+			}
+			var overlays []workflow.Document
+			for _, overlay := range tt.overlays {
+				if isLocalFileReference(overlay) {
+					err := copyFile(fmt.Sprintf("resources/%s", overlay), fmt.Sprintf("%s/%s", temp, overlay))
+					assert.NoError(t, err)
+				}
+				overlays = append(overlays, workflow.Document{
+					Location: overlay,
+				})
+			}
+			workflowFile.Sources["first-source"] = workflow.Source{
+				Inputs:   inputs,
+				Overlays: overlays,
+				Output:   &tt.out,
+			}
+
+			// Execute commands from the temporary directory
+			os.Chdir(temp)
+			err := workflowFile.Validate(generate.GetSupportedLanguages())
+			assert.NoError(t, err)
+			err = os.MkdirAll(".speakeasy", 0o755)
+			assert.NoError(t, err)
+			err = workflow.Save(".", workflowFile)
+			assert.NoError(t, err)
+			args := []string{"run", "-s", "all"}
+			rootCmd.SetArgs(args)
+			cmdErr := rootCmd.Execute()
+			assert.NoError(t, cmdErr)
+
+			content, err := os.ReadFile(tt.out)
+			assert.NoError(t, err, "No readable file %s exists", tt.out)
+
+			if len(tt.overlays) > 0 {
+				if !strings.Contains(string(content), " x-codeSample") {
+					t.Errorf("overlay not successfully applied to output document")
+				}
+			}
+		})
+	}
+}
+
+func TestCodeSampleGenerationWorkflows(t *testing.T) {
 	tests := []struct {
 		name       string
 		targetType string

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -1,0 +1,165 @@
+package integration_tests
+
+import (
+	"fmt"
+	"io"
+	"math/rand"
+	"net/url"
+	"os"
+	"testing"
+
+	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/stretchr/testify/assert"
+)
+
+const (
+	tempDir     = "temp"
+	letterBytes = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
+)
+
+func TestMain(m *testing.M) {
+	// Create a temporary directory
+	if _, err := os.Stat(tempDir); err == nil {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}
+
+	if err := os.Mkdir(tempDir, 0o755); err != nil {
+		panic(err)
+	}
+
+	// Defer the removal of the temp directory
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			panic(err)
+		}
+	}()
+
+	code := m.Run()
+	os.Exit(code)
+}
+
+func TestCodeSampleWorkflows(t *testing.T) {
+	tests := []struct {
+		name       string
+		targetType string
+		outdir     string
+		inputDoc   string
+		withForce  bool
+	}{
+		{
+			name:       "codeSamples with remote document",
+			targetType: "go",
+			outdir:     "go",
+			inputDoc:   "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml",
+		},
+		{
+			name:       "codeSamples with local document",
+			targetType: "go",
+			outdir:     "go",
+			inputDoc:   "spec.yaml",
+		},
+		{
+			name:       "codeSamples with json output",
+			targetType: "go",
+			outdir:     "go",
+			inputDoc:   "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json",
+		},
+		{
+			name:       "codeSamples with force generate",
+			targetType: "go",
+			outdir:     "go",
+			inputDoc:   "spec.yaml",
+			withForce:  true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			temp, err := createTempDir()
+			assert.NoError(t, err)
+
+			workflowFile := &workflow.Workflow{
+				Version: workflow.WorkflowVersion,
+				Sources: make(map[string]workflow.Source),
+				Targets: make(map[string]workflow.Target),
+			}
+			workflowFile.Sources["first-source"] = workflow.Source{
+				Inputs: []workflow.Document{
+					{
+						Location: tt.inputDoc,
+					},
+				},
+			}
+			workflowFile.Targets["first-target"] = workflow.Target{
+				Target: tt.targetType,
+				Source: "first-source",
+				Output: &tt.outdir,
+				CodeSamples: &workflow.CodeSamples{
+					Output: "codeSamples.yaml",
+				},
+			}
+
+			if isLocalFileReference(tt.inputDoc) {
+				err := copyFile("resources/spec.yaml", fmt.Sprintf("%s/%s", temp, tt.inputDoc))
+				assert.NoError(t, err)
+			}
+
+			err = workflowFile.Validate(generate.GetSupportedLanguages())
+			assert.NoError(t, err)
+			err = os.MkdirAll(fmt.Sprintf("%s/.speakeasy", temp), 0o755)
+			assert.NoError(t, err)
+			workflow.Save("temp", workflowFile)
+			assert.NoError(t, err)
+			// cleanupTempDir(temp)
+		})
+	}
+}
+
+func createTempDir() (string, error) {
+	temp := fmt.Sprintf("%s/%s", tempDir, randStringBytes(7))
+	if err := os.Mkdir(temp, 0o755); err != nil {
+		return "", err
+	}
+
+	return temp, nil
+}
+
+func isLocalFileReference(filePath string) bool {
+	u, err := url.Parse(filePath)
+	if err != nil {
+		return true
+	}
+
+	return u.Scheme == "" || u.Scheme == "file"
+}
+
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destinationFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destinationFile.Close()
+
+	_, err = io.Copy(destinationFile, sourceFile)
+	return err
+}
+
+func cleanupTempDir(temp string) error {
+	return os.RemoveAll(temp)
+}
+
+var randStringBytes = func(n int) string {
+	b := make([]byte, n)
+	for i := range b {
+		b[i] = letterBytes[rand.Intn(len(letterBytes))]
+	}
+	return string(b)
+}


### PR DESCRIPTION
This could be a fairly easy way to write integration tests for the CLI. We basically execute CLI commands directly from the root level with each command going in it's own temp subdirectory. Writing tests this way would be very easy.

There's one largish drawback here. These tests have to executed in serial because we have to deal with changing the working directory. I'm not sure if there's a great way around this if we want to really test the CLI as if we are executing individual commands.

There are options to mock os operations, such as [aefro](https://github.com/spf13/afero). The problem is you have to replace usage of the os package with it. We use that not just in the CLI but also in all of this underlying separate modules sdk-gen-config, openapi-generation, etc. I'm just not sure doing that wide of a refactor is worth it right now.