### PR TITLE
feat: add integration tests to CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -44,10 +44,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up Go 1.x
-        uses: actions/setup-go@v2
+      - name: Set up Go
+        uses: actions/setup-go@v3
         with:
-          go-version: ^1.20
+          go-version: ">=1.20.0"
 
       - name: Set up Python
         uses: actions/setup-python@v4
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-go-
 
       - name: Build
-        run: go build -v ./...
+        run: go build ./...
 
       - name: ${{ matrix.test-group }}
         run: |

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -86,3 +86,5 @@ jobs:
         run: |
           set -euo pipefail
           go test -json -v -p 1 -run ${{ matrix.test-pattern }} ./integration/... | gotestfmt
+        env:
+          SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -37,7 +37,7 @@ jobs:
       matrix:
         include:
           - test-group: 'Test 1'
-            test-pattern: 'TestGenerationWorkflows|TestCodeSampleGenerationWorkflows'
+            test-pattern: 'TestCodeSampleGenerationWorkflows'
           - test-group: 'Test 2'
             test-pattern: 'TestSpecWorkflows'
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,9 +36,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - test-group: 'Test 1'
-            test-pattern: 'TestCodeSampleGenerationWorkflows'
-          - test-group: 'Test 2'
+          - test-group: 'Test Generations'
+            test-pattern: 'TestGenerationWorkflows'
+          - test-group: 'Test Spec Operations'
             test-pattern: 'TestSpecWorkflows'
 
     steps:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -23,20 +23,66 @@ jobs:
           preset: conventional-changelog-conventionalcommits@latest
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  compile:
-    name: Compile Project
+  build-test:
+    name: Build & Test
     runs-on: ubuntu-latest
+    if: ${{ github.event.pull_request.draft == false }}
+    permissions:
+      contents: read
+      id-token: write
+      actions: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - test-group: 'Test 1'
+            test-pattern: 'TestGenerationWorkflows|TestCodeSampleGenerationWorkflows'
+          - test-group: 'Test 2'
+            test-pattern: 'TestSpecWorkflows'
+
     steps:
       - uses: actions/checkout@v2
-      - name: Set up Go
-        uses: actions/setup-go@v3
+
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v2
         with:
-          go-version: ">=1.20.0"
+          go-version: ^1.20
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.8"
+
+      - name: Set up Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.x"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up gotestfmt
+        run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
+
       - name: Configure git for private modules
         env:
           GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
         run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
-      - name: Build project
-        env:
-          GOPRIVATE: github.com/speakeasy-api/*
-        run: go build ./...
+
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+            ~/Library/Caches/go-build
+            ~\AppData\Local\go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Build
+        run: go build -v ./...
+
+      - name: ${{ matrix.test-group }}
+        run: |
+          set -euo pipefail
+          go test -json -v -p 1 -run ${{ matrix.test-pattern }} ./integration/... | gotestfmt

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -50,6 +50,6 @@ func setupTestDir(t *testing.T) string {
 func registerCleanup(t *testing.T, workingDir string, temp string) {
 	t.Cleanup(func() {
 		os.Chdir(workingDir)
-		os.RemoveAll(temp)
+		// os.RemoveAll(temp)
 	})
 }

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -50,6 +50,6 @@ func setupTestDir(t *testing.T) string {
 func registerCleanup(t *testing.T, workingDir string, temp string) {
 	t.Cleanup(func() {
 		os.Chdir(workingDir)
-		// os.RemoveAll(temp)
+		os.RemoveAll(temp)
 	})
 }

--- a/integration/resources/codeSamples-JSON.yaml
+++ b/integration/resources/codeSamples-JSON.yaml
@@ -1,0 +1,93 @@
+overlay: 1.0.0
+info:
+  title: CodeSamples overlay for go target
+  version: 0.0.0
+actions:
+  - target: $["paths"]["/pets"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "go"
+          "label": "listPets"
+          "source": |-
+            package main
+
+            import(
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New()
+
+
+                var limit *int = openapi.Int(21453)
+
+                ctx := context.Background()
+                res, err := s.ListPets(ctx, limit)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pets != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pets"]["post"]
+    update:
+      "x-codeSamples":
+        - "lang": "go"
+          "label": "createPets"
+          "source": |-
+            package main
+
+            import(
+            	"openapi"
+            	"context"
+            	"openapi/models/components"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New()
+
+                ctx := context.Background()
+                res, err := s.CreatePets(ctx, components.Pet{
+                    ID: 596804,
+                    Name: "<value>",
+                })
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res != nil {
+                    // handle response
+                }
+            }
+  - target: $["paths"]["/pets/{petId}"]["get"]
+    update:
+      "x-codeSamples":
+        - "lang": "go"
+          "label": "showPetById"
+          "source": |-
+            package main
+
+            import(
+            	"openapi"
+            	"context"
+            	"log"
+            )
+
+            func main() {
+                s := openapi.New()
+
+
+                var petID string = "<value>"
+
+                ctx := context.Background()
+                res, err := s.ShowPetByID(ctx, petID)
+                if err != nil {
+                    log.Fatal(err)
+                }
+                if res.Pet != nil {
+                    // handle response
+                }
+            }

--- a/integration/resources/part1.yaml
+++ b/integration/resources/part1.yaml
@@ -1,0 +1,451 @@
+openapi: 3.1.0
+info:
+  title: Petstore - OpenAPI 3.1
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.1 specification.
+
+    Some useful links:
+    - [OpenAPI Reference](https://www.speakeasyapi.dev/openapi)
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: support@speakeasyapi.dev
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+security:
+  - api_key: []
+servers:
+  - url: https://{environment}.petstore.io
+    description: A per-environment API.
+    variables:
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  "/pet":
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      requestBody:
+        description: Update an existent pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      requestBody:
+        description: Create a new pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '405':
+          description: Invalid input
+
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+      - name: status
+        in: query
+        description: Status values that need to be considered for filter
+        required: false
+        explode: true
+        schema:
+          type: string
+          default: available
+          enum:
+          - available
+          - pending
+          - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/findByTags":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by tags
+      description: Multiple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      operationId: findPetsByTags
+      parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}":
+    get:
+      tags:
+      - pet
+      summary: Find pet by ID
+      description: Returns a single pet
+      operationId: getPetById
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+    delete:
+      tags:
+      - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+      - name: api_key
+        in: header
+        description: ''
+        required: false
+        schema:
+          type: string
+      - name: petId
+        in: path
+        description: Pet id to delete
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Pet deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Pet'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+      - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to update
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: additionalMetadata
+        in: query
+        description: Additional Metadata
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+          - placed
+          - approved
+          - delivered
+        complete:
+          type: boolean
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+      - name
+      - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          "$ref": "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    ApiErrorInvalidInput:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 400
+        error:
+          type: string
+          example: Bad request
+    ApiErrorNotFound:
+      type: object
+      required:
+        - status
+        - error
+        - code
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 404
+        error:
+          type: string
+          example: Not Found
+        code:
+          type: string
+          example: object_not_found
+    ApiErrorUnauthorized:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 401
+        error:
+          type: string
+          example: Unauthorized
+  responses:
+    Unauthorized:
+      description: Unauthorized error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorUnauthorized'
+    NotFound:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorNotFound'
+    InvalidInput:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorInvalidInput'
+

--- a/integration/resources/part2.yaml
+++ b/integration/resources/part2.yaml
@@ -1,0 +1,508 @@
+openapi: 3.1.0
+info:
+  title: Petstore - OpenAPI 3.1
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.1 specification.
+
+    Some useful links:
+    - [OpenAPI Reference](https://www.speakeasyapi.dev/openapi)
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: support@speakeasyapi.dev
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  version: 1.0.0
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+security:
+  - api_key: []
+servers:
+  - url: https://{environment}.petstore.io
+    description: A per-environment API.
+    variables:
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      description: Find out more
+      url: http://swagger.io
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      description: Find out more about our store
+      url: http://swagger.io
+  - name: user
+    description: Operations about user
+paths:
+  "/store/inventory":
+    get:
+      tags:
+      - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  "/store/order":
+    post:
+      tags:
+      - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '405':
+          description: Invalid input
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/store/order/{orderId}":
+    get:
+      tags:
+      - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other
+        values will generate exceptions.
+      operationId: getOrderById
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of order that needs to be fetched
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    delete:
+      tags:
+      - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything
+        above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of the order that needs to be deleted
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Order deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Order'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user":
+    post:
+      tags:
+      - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/createWithList":
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/login":
+    get:
+      tags:
+      - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+      - name: username
+        in: query
+        description: The user name for login
+        required: false
+        schema:
+          type: string
+      - name: password
+        in: query
+        description: The password for login in clear text
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/json:
+              schema:
+                type: string
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+  "/user/logout":
+    get:
+      tags:
+      - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        '200':
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+      - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+      - name: username
+        in: path
+        description: 'The name that needs to be fetched. Use user1 for testing. '
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+    put:
+      tags:
+      - user
+      summary: Update user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+      - name: username
+        in: path
+        description: name that needs to be updated
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: successful operation
+    delete:
+      tags:
+      - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+      - name: username
+        in: path
+        description: The name that needs to be deleted
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: User deleted
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/User'
+        '400':
+          $ref: '#/components/responses/InvalidInput'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '404':
+          $ref: '#/components/responses/NotFound'
+components:
+  securitySchemes:
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+          - placed
+          - approved
+          - delivered
+        complete:
+          type: boolean
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+    Pet:
+      required:
+      - name
+      - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          "$ref": "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          items:
+            type: string
+        tags:
+          type: array
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+    ApiErrorInvalidInput:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 400
+        error:
+          type: string
+          example: Bad request
+    ApiErrorNotFound:
+      type: object
+      required:
+        - status
+        - error
+        - code
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 404
+        error:
+          type: string
+          example: Not Found
+        code:
+          type: string
+          example: object_not_found
+    ApiErrorUnauthorized:
+      type: object
+      required:
+        - status
+        - error
+      properties:
+        status:
+          type: integer
+          format: int32
+          example: 401
+        error:
+          type: string
+          example: Unauthorized
+  responses:
+    Unauthorized:
+      description: Unauthorized error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorUnauthorized'
+    NotFound:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorNotFound'
+    InvalidInput:
+      description: Not Found error
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ApiErrorInvalidInput'
+

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -12,7 +12,9 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-// All tests must be run as individual test functions in serial.
+// These integration tests MUST be run in serial because we deal with changing working directories during the test.
+// If running locally make sure you are running test functions individually TestGenerationWorkflows, TestSpecWorkflows, etc.
+// If all test groups are run at the same time you will see test failures.
 
 func TestGenerationWorkflows(t *testing.T) {
 	tests := []struct {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -156,6 +156,16 @@ func TestSpecWorkflows(t *testing.T) {
 			},
 			out: "output.yaml",
 		},
+		{
+			name: "overlay with json document",
+			inputDocs: []string{
+				"https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json",
+			},
+			overlays: []string{
+				"codeSamples-JSON.yaml",
+			},
+			out: "output.json",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -211,7 +221,7 @@ func TestSpecWorkflows(t *testing.T) {
 			assert.NoError(t, err, "No readable file %s exists", tt.out)
 
 			if len(tt.overlays) > 0 {
-				if !strings.Contains(string(content), " x-codeSample") {
+				if !strings.Contains(string(content), "x-codeSamples") {
 					t.Errorf("overlay not successfully applied to output document")
 				}
 			}

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -141,10 +141,11 @@ func TestGenerationWorkflows(t *testing.T) {
 
 func TestSpecWorkflows(t *testing.T) {
 	tests := []struct {
-		name      string
-		inputDocs []string
-		overlays  []string
-		out       string
+		name          string
+		inputDocs     []string
+		overlays      []string
+		out           string
+		expectedPaths []string
 	}{
 		{
 			name: "overlay with local document",
@@ -165,6 +166,19 @@ func TestSpecWorkflows(t *testing.T) {
 				"codeSamples-JSON.yaml",
 			},
 			out: "output.json",
+		},
+		{
+			name: "test merging documents",
+			inputDocs: []string{
+				"part1.yaml",
+				"part2.yaml",
+			},
+			out: "output.yaml",
+			expectedPaths: []string{
+				"/pet/findByStatus",
+				"/store/inventory",
+				"/user/login",
+			},
 		},
 	}
 	for _, tt := range tests {
@@ -223,6 +237,14 @@ func TestSpecWorkflows(t *testing.T) {
 			if len(tt.overlays) > 0 {
 				if !strings.Contains(string(content), "x-codeSamples") {
 					t.Errorf("overlay not successfully applied to output document")
+				}
+			}
+
+			if len(tt.expectedPaths) > 0 {
+				for _, path := range tt.expectedPaths {
+					if !strings.Contains(string(content), path) {
+						t.Errorf("Expected path %s not found in output document", path)
+					}
 				}
 			}
 		})

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -16,10 +16,12 @@ import (
 
 func TestGenerationWorkflows(t *testing.T) {
 	tests := []struct {
-		name        string
-		targetTypes []string
-		outdirs     []string
-		inputDoc    string
+		name            string
+		targetTypes     []string
+		outdirs         []string
+		inputDoc        string
+		withForce       bool
+		withCodeSamples bool
 	}{
 		{
 			name: "generation with remote document",
@@ -32,17 +34,7 @@ func TestGenerationWorkflows(t *testing.T) {
 			inputDoc: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml",
 		},
 		{
-			name: "generation with local document",
-			targetTypes: []string{
-				"go",
-			},
-			outdirs: []string{
-				"go",
-			},
-			inputDoc: "spec.yaml",
-		},
-		{
-			name: "multi-target generation",
+			name: "multi-target generation with local document",
 			targetTypes: []string{
 				"go",
 				"typescript",
@@ -52,6 +44,29 @@ func TestGenerationWorkflows(t *testing.T) {
 				"ts",
 			},
 			inputDoc: "spec.yaml",
+		},
+		{
+			name: "code samples with json output",
+			targetTypes: []string{
+				"go",
+			},
+			outdirs: []string{
+				"go",
+			},
+			inputDoc:        "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json",
+			withCodeSamples: true,
+		},
+		{
+			name: "code samples with force",
+			targetTypes: []string{
+				"go",
+			},
+			outdirs: []string{
+				"go",
+			},
+			inputDoc:        "spec.yaml",
+			withCodeSamples: true,
+			withForce:       true,
 		},
 	}
 	for _, tt := range tests {
@@ -73,11 +88,17 @@ func TestGenerationWorkflows(t *testing.T) {
 			}
 
 			for i := range tt.targetTypes {
-				workflowFile.Targets[fmt.Sprintf("%d-target", i)] = workflow.Target{
+				target := workflow.Target{
 					Target: tt.targetTypes[i],
 					Source: "first-source",
 					Output: &tt.outdirs[i],
 				}
+				if tt.withCodeSamples {
+					target.CodeSamples = &workflow.CodeSamples{
+						Output: "codeSamples.yaml",
+					}
+				}
+				workflowFile.Targets[fmt.Sprintf("%d-target", i)] = target
 			}
 
 			if isLocalFileReference(tt.inputDoc) {
@@ -94,9 +115,22 @@ func TestGenerationWorkflows(t *testing.T) {
 			err = workflow.Save(".", workflowFile)
 			assert.NoError(t, err)
 			args := []string{"run", "-t", "all"}
+			if tt.withForce {
+				args = append(args, "--force", "true")
+			}
 			rootCmd.SetArgs(args)
 			cmdErr := rootCmd.Execute()
 			assert.NoError(t, cmdErr)
+
+			if tt.withCodeSamples {
+				codeSamplesPath := filepath.Join(tt.outdirs[0], "codeSamples.yaml")
+				content, err := os.ReadFile(codeSamplesPath)
+				assert.NoError(t, err, "No readable file %s exists", codeSamplesPath)
+
+				if !strings.Contains(string(content), "update") {
+					t.Errorf("Update actions do not exist in the codeSamples file")
+				}
+			}
 
 			for i, targetType := range tt.targetTypes {
 				checkForExpectedFiles(t, tt.outdirs[i], expectedFilesByLanguage(targetType))
@@ -181,100 +215,6 @@ func TestSpecWorkflows(t *testing.T) {
 					t.Errorf("overlay not successfully applied to output document")
 				}
 			}
-		})
-	}
-}
-
-func TestCodeSampleGenerationWorkflows(t *testing.T) {
-	tests := []struct {
-		name       string
-		targetType string
-		outdir     string
-		inputDoc   string
-		withForce  bool
-	}{
-		{
-			name:       "codeSamples with remote document",
-			targetType: "go",
-			outdir:     "go",
-			inputDoc:   "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml",
-		},
-		{
-			name:       "codeSamples with local document",
-			targetType: "typescript",
-			outdir:     "ts",
-			inputDoc:   "spec.yaml",
-		},
-		{
-			name:       "codeSamples with json output",
-			targetType: "typescript",
-			outdir:     "ts",
-			inputDoc:   "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json",
-		},
-		{
-			name:       "codeSamples with force generate",
-			targetType: "go",
-			outdir:     "go",
-			inputDoc:   "spec.yaml",
-			withForce:  true,
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			temp := setupTestDir(t)
-
-			// Create workflow file and associated resources
-			workflowFile := &workflow.Workflow{
-				Version: workflow.WorkflowVersion,
-				Sources: make(map[string]workflow.Source),
-				Targets: make(map[string]workflow.Target),
-			}
-			workflowFile.Sources["first-source"] = workflow.Source{
-				Inputs: []workflow.Document{
-					{
-						Location: tt.inputDoc,
-					},
-				},
-			}
-			workflowFile.Targets["first-target"] = workflow.Target{
-				Target: tt.targetType,
-				Source: "first-source",
-				Output: &tt.outdir,
-				CodeSamples: &workflow.CodeSamples{
-					Output: "codeSamples.yaml",
-				},
-			}
-
-			if isLocalFileReference(tt.inputDoc) {
-				err := copyFile("resources/spec.yaml", fmt.Sprintf("%s/%s", temp, tt.inputDoc))
-				assert.NoError(t, err)
-			}
-
-			// Execute commands from the temporary directory
-			os.Chdir(temp)
-			err := workflowFile.Validate(generate.GetSupportedLanguages())
-			assert.NoError(t, err)
-			err = os.MkdirAll(".speakeasy", 0o755)
-			assert.NoError(t, err)
-			err = workflow.Save(".", workflowFile)
-			assert.NoError(t, err)
-			args := []string{"run", "-t", "all"}
-			if tt.withForce {
-				args = append(args, "--force", "true")
-			}
-			rootCmd.SetArgs(args)
-			cmdErr := rootCmd.Execute()
-			assert.NoError(t, cmdErr)
-
-			codeSamplesPath := filepath.Join(tt.outdir, "codeSamples.yaml")
-			content, err := os.ReadFile(codeSamplesPath)
-			assert.NoError(t, err, "No readable file %s exists", codeSamplesPath)
-
-			if !strings.Contains(string(content), "update") {
-				t.Errorf("Update actions do not exist in the codeSamples file")
-			}
-
-			checkForExpectedFiles(t, tt.outdir, expectedFilesByLanguage(tt.targetType))
 		})
 	}
 }


### PR DESCRIPTION
Adds basic CLI integration testing to PRs
- Sets up Integration tests run on PR operations
- Adds some additional tests to cover merging, JSON specs
- Creates the basic framework for splitting up tests across multiple jobs to ensure fast speeds (remember tests must be run in serial for each runner). Right now we have two test groups.