### PR TITLE
fix: remove unnecessary filepath.Join call

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -476,7 +476,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *WorkflowStep, id s
 		registryStep.NewSubstep("Snapshotting OpenAPI Revision")
 
 		_, err := pl.Localize(ctx, memfs, bundler.LocalizeOptions{
-			DocumentPath: filepath.Join(w.projectDir, outputLocation),
+			DocumentPath: outputLocation,
 		})
 		if err != nil {
 			return "", nil, fmt.Errorf("error localizing openapi document: %w", err)


### PR DESCRIPTION
This change fixes an issue where document localization was failing because the document path, used as input to the localizer, was constructed incorrectly.