### PR TITLE
fix: don't error on missing source lock

### DIFF
--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -116,7 +116,7 @@ func TestGenerationWorkflows(t *testing.T) {
 			assert.NoError(t, err)
 			err = workflow.Save(".", workflowFile)
 			assert.NoError(t, err)
-			args := []string{"run", "-t", "all"}
+			args := []string{"run", "-t", "all", "--pinned"}
 			if tt.withForce {
 				args = append(args, "--force", "true")
 			}

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -228,7 +228,7 @@ func TestSpecWorkflows(t *testing.T) {
 			assert.NoError(t, err)
 			err = workflow.Save(".", workflowFile)
 			assert.NoError(t, err)
-			args := []string{"run", "-s", "all"}
+			args := []string{"run", "-s", "all", "--pinned"}
 			rootCmd.SetArgs(args)
 			cmdErr := rootCmd.Execute()
 			assert.NoError(t, cmdErr)

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -365,8 +365,6 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*sourceResult,
 			SourceBlobDigest:     sourceLock.SourceBlobDigest,
 			OutLocation:          outDir,
 		}
-	} else {
-		return nil, fmt.Errorf("source %s must be run before target", t.Source)
 	}
 
 	return sourceRes, nil


### PR DESCRIPTION
We don't need to error here. Might want to add back in when the registry flag is off
