### PR TITLE
feat: find root openapi file from annotation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -27,7 +27,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.5.0
 	github.com/speakeasy-api/sdk-gen-config v1.11.4
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.7-beta
-	github.com/speakeasy-api/speakeasy-core v0.7.2
+	github.com/speakeasy-api/speakeasy-core v0.7.4
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/speakeasy-sdks/openai-go-sdk/v4 v4.2.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/speakeasy-api/sdk-gen-config v1.11.4 h1:ua33BRaQSC1nzc32JVE1w76LUHktE
 github.com/speakeasy-api/sdk-gen-config v1.11.4/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.7-beta h1:HvgkAJPxhyK7qBgZqsiT9J5DOJwm5xBPBZ19vwo9kvA=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.7-beta/go.mod h1:G9tcHa9/waEJXGLvCKQxp7Oj14OjWK3ErUcMR+bIpDQ=
-github.com/speakeasy-api/speakeasy-core v0.7.2 h1:nynu7gTTbTSO2HAnv6GItXLoilX5FVO9jBh13Yy78Ik=
-github.com/speakeasy-api/speakeasy-core v0.7.2/go.mod h1:xrFh7oBFy6Bl+XI0dgIdnSmRPmz5cuiyoK3HsgYxQg0=
+github.com/speakeasy-api/speakeasy-core v0.7.4 h1:3zc+q1B9ctpxS21QHKZsVsf6RavF7grwLk8hJx5X094=
+github.com/speakeasy-api/speakeasy-core v0.7.4/go.mod h1:xrFh7oBFy6Bl+XI0dgIdnSmRPmz5cuiyoK3HsgYxQg0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -117,19 +117,11 @@ func DownloadRegistryOpenAPIBundle(ctx context.Context, namespaceID, reference, 
 		return "", err
 	}
 
-	outputFileName := ""
-	for _, file := range zipReader.File {
-		if strings.Contains(file.Name, ".yaml") { // TODO: this is not going to fly
-			cleanName := filepath.Clean(file.Name)
-			outputFileName = filepath.Join(outPath, cleanName)
-			if !strings.HasPrefix(outputFileName, filepath.Clean(outPath)+string(os.PathSeparator)) {
-				return "", fmt.Errorf("illegal file path: %s", outputFileName)
-			}
-			break
-		}
-	}
-
-	if outputFileName == "" {
+	var outputFileName string
+	if fileName, _ := bundleResult.BundleAnnotations[ocicommon.AnnotationBundleRoot]; fileName != "" {
+		cleanName := filepath.Clean(fileName)
+		outputFileName = filepath.Join(outPath, cleanName)
+	} else {
 		return "", fmt.Errorf("no root openapi file found in bundle")
 	}
 


### PR DESCRIPTION
Finds the root openapi file for workflows correctly via the annotation that was set during bundling.

Before we were just doing a best effort thing that wouldn't always work. One caveat of this is that registry bundles before this annotation started being [set](https://github.com/speakeasy-api/speakeasy/pull/641) won't work. I think that is fine, since the product hasn't been released yet.