### PR TITLE
fix: support spaces in target names

### DIFF
--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -4,11 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
-	"slices"
-	"strings"
-
 	"github.com/fatih/structs"
 	"github.com/hashicorp/go-version"
 	"github.com/sethvargo/go-githubactions"
@@ -26,6 +21,9 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 	"gopkg.in/yaml.v3"
+	"os"
+	"os/exec"
+	"slices"
 )
 
 type Command interface {
@@ -293,16 +291,18 @@ func runWithVersion(cmd *cobra.Command, artifactArch, desiredVersion string) err
 		return err
 	}
 
-	cmdString := utils.GetFullCommandString(cmd)
-	cmdString = strings.TrimPrefix(cmdString, "speakeasy ")
+	cmdParts := utils.GetCommandParts(cmd)
+	if cmdParts[0] == "speakeasy" {
+		cmdParts = cmdParts[1:]
+	}
 
 	// The pinned flag was introduced in 1.256.0
 	// For earlier versions, it isn't necessary because we don't try auto-upgrading
 	if ok, _ := pinningWasReleased(desiredVersion); ok {
-		cmdString += " --pinned"
+		cmdParts = append(cmdParts, "--pinned")
 	}
 
-	newCmd := exec.Command(vLocation, strings.Split(cmdString, " ")...)
+	newCmd := exec.Command(vLocation, cmdParts...)
 	newCmd.Stdin = os.Stdin
 	newCmd.Stdout = os.Stdout
 	newCmd.Stderr = os.Stderr

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -145,11 +145,15 @@ func GetWorkflowAndDir() (*workflow.Workflow, string, error) {
 }
 
 func GetFullCommandString(cmd *cobra.Command) string {
-	flagString := ""
+	return strings.Join(GetCommandParts(cmd), " ")
+}
+
+func GetCommandParts(cmd *cobra.Command) []string {
+	parts := strings.Split(cmd.CommandPath(), " ")
 	for _, f := range getSetFlags(cmd.Flags()) {
-		flagString += fmt.Sprintf(" --%s=%s", f.Name, f.Value.String())
+		parts = append(parts, fmt.Sprintf("--%s=%s", f.Name, f.Value.String()))
 	}
-	return fmt.Sprintf(`%s%s`, cmd.CommandPath(), flagString)
+	return parts
 }
 
 func getSetFlags(flags *pflag.FlagSet) []*pflag.Flag {


### PR DESCRIPTION
There is a bug in version pinnning that would cause failures if the target id had a space in it. This fixes that