### PR TITLE
fix: support documents with unknown extensions

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -5,11 +5,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/iancoleman/strcase"
-	"github.com/speakeasy-api/speakeasy/internal/changes"
-	"github.com/speakeasy-api/speakeasy/internal/github"
-	"github.com/speakeasy-api/speakeasy/internal/reports"
-	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
 	"io"
 	"io/fs"
 	"math/rand"
@@ -19,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/iancoleman/strcase"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	sdkGenConfig "github.com/speakeasy-api/sdk-gen-config"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
@@ -31,17 +27,21 @@ import (
 	"github.com/speakeasy-api/speakeasy/registry"
 	"go.uber.org/zap"
 
+	"github.com/speakeasy-api/speakeasy/internal/changes"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/config"
 	"github.com/speakeasy-api/speakeasy/internal/download"
 	"github.com/speakeasy-api/speakeasy/internal/env"
 	"github.com/speakeasy-api/speakeasy/internal/git"
+	"github.com/speakeasy-api/speakeasy/internal/github"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/overlay"
+	"github.com/speakeasy-api/speakeasy/internal/reports"
 	"github.com/speakeasy-api/speakeasy/internal/sdkgen"
 	"github.com/speakeasy-api/speakeasy/internal/usagegen"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"github.com/speakeasy-api/speakeasy/internal/validation"
+	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
 	"github.com/speakeasy-api/speakeasy/pkg/merge"
 )
 
@@ -468,7 +468,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 	}
 
 	if !isSingleRegistrySource(source) {
-		err = w.snapshotSource(ctx, rootStep, sourceID, outputLocation)
+		err = w.snapshotSource(ctx, rootStep, sourceID, currentDocument)
 		if err != nil {
 			return "", nil, err
 		}
@@ -477,7 +477,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 	// If the source has a previous tracked revision, compute changes against it
 	if w.lockfileOld != nil {
 		if targetLockOld, ok := w.lockfileOld.Targets[targetID]; ok {
-			sourceRes.ChangeReport, err = computeChanges(ctx, rootStep, targetLockOld, outputLocation)
+			sourceRes.ChangeReport, err = computeChanges(ctx, rootStep, targetLockOld, currentDocument)
 			if err != nil {
 				// Don't fail the whole workflow if this fails
 				logger.Warnf("failed to compute OpenAPI changes: %s", err.Error())
@@ -485,7 +485,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 		}
 	}
 
-	sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, outputLocation, rulesetToUse, w.projectDir)
+	sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.projectDir)
 	if err != nil {
 		return "", nil, err
 	}
@@ -497,7 +497,7 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 		os.RemoveAll(workflow.GetTempDir())
 	}
 
-	return outputLocation, sourceRes, nil
+	return currentDocument, sourceRes, nil
 }
 
 func computeChanges(ctx context.Context, rootStep *workflowTracking.WorkflowStep, targetLock workflow.TargetLock, newDocPath string) (r *reports.ReportResult, err error) {
@@ -887,12 +887,6 @@ func resolveDocument(ctx context.Context, d workflow.Document, outputLocation *s
 }
 
 func resolveRemoteDocument(ctx context.Context, d workflow.Document, outPath string) (string, error) {
-	log.From(ctx).Infof("Downloading %s... to %s\n", d.Location, outPath)
-
-	if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
-		return "", err
-	}
-
 	var token, header string
 	if d.Auth != nil {
 		header = d.Auth.Header
@@ -905,9 +899,39 @@ func resolveRemoteDocument(ctx context.Context, d workflow.Document, outPath str
 		token = os.Getenv(strings.ToUpper(envVar))
 	}
 
-	if err := download.DownloadFile(d.Location, outPath, header, token); err != nil {
+	res, err := download.Fetch(d.Location, header, token)
+	if err != nil {
 		return "", err
 	}
+	defer res.Body.Close()
+
+	ext := filepath.Ext(outPath)
+	if !slices.Contains([]string{".yaml", ".yml", ".json"}, ext) {
+		ext, err := download.SniffDocumentExtension(res)
+		if errors.Is(err, download.ErrUnknownDocumentType) {
+			ext = ".yaml"
+		} else if err != nil {
+			return "", err
+		}
+
+		outPath += ext
+	}
+
+	if err := os.MkdirAll(filepath.Dir(outPath), os.ModePerm); err != nil {
+		return "", err
+	}
+
+	outFile, err := os.Create(outPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to create output file: %w", err)
+	}
+	defer outFile.Close()
+
+	if _, err := io.Copy(outFile, res.Body); err != nil {
+		return "", fmt.Errorf("failed to save response to location: %w", err)
+	}
+
+	log.From(ctx).Infof("Downloaded %s to %s\n", d.Location, outPath)
 
 	return outPath, nil
 }


### PR DESCRIPTION
This change updates the workflow runner to better determine the file extensions of documents. We'll attempt to:

- use the extensions of the output document if one is specified
- or, if it's a remote document
  - fallback to the extension of document's URL path if it's remote
  - or, fallback to sniffing the `content-type` header
- or, finally fallback to `.yaml`