### PR TITLE
fix: capture overlay output path as final doc path

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -465,6 +465,8 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 		if err := overlayDocument(ctx, currentDocument, overlaySchemas, overlayLocation); err != nil {
 			return "", nil, err
 		}
+
+		currentDocument = overlayLocation
 	}
 
 	if !isSingleRegistrySource(source) {


### PR DESCRIPTION
This change fixes a regression that result in the workflow executor ignoring the final result of applying overlays in subsequent workflow steps including SDK generation.