### PR TITLE
feat: add registry tagging to speakeasy run

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -256,6 +256,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		false,
 		!flags.SkipCompile,
 		false,
+		[]string{},
 	)
 	if err != nil {
 		return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,7 +31,7 @@ type RunFlags struct {
 	Force            bool              `json:"force"`
 	Output           string            `json:"output"`
 	Pinned           bool              `json:"pinned"`
-	BundleTag        []string          `json:"bundle-tag"`
+	RegistryTags     []string          `json:"registry-tags"`
 }
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
@@ -112,7 +112,7 @@ A full workflow is capable of running the following steps:
 			Hidden:      true,
 		},
 		flag.StringSliceFlag{
-			Name:        "bundle-tag",
+			Name:        "registry-tags",
 			Description: "tags to apply to the speakeasy registry bundle",
 		},
 	},
@@ -233,7 +233,7 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 		flags.Debug,
 		!flags.SkipCompile,
 		flags.Force,
-		flags.BundleTag,
+		flags.RegistryTags,
 	)
 	if err != nil {
 		return err
@@ -260,7 +260,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		flags.Debug,
 		!flags.SkipCompile,
 		flags.Force,
-		flags.BundleTag,
+		flags.RegistryTags,
 	)
 	if err != nil {
 		return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -31,6 +31,7 @@ type RunFlags struct {
 	Force            bool              `json:"force"`
 	Output           string            `json:"output"`
 	Pinned           bool              `json:"pinned"`
+	BundleTag        []string          `json:"bundle-tag"`
 }
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
@@ -109,6 +110,10 @@ A full workflow is capable of running the following steps:
 			Name:        "pinned",
 			Description: "Run using the current CLI version instead of the version specified in the workflow file",
 			Hidden:      true,
+		},
+		flag.StringSliceFlag{
+			Name:        "bundle-tag",
+			Description: "tags to apply to the speakeasy registry bundle",
 		},
 	},
 }
@@ -228,6 +233,7 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 		flags.Debug,
 		!flags.SkipCompile,
 		flags.Force,
+		flags.BundleTag,
 	)
 	if err != nil {
 		return err
@@ -254,6 +260,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		flags.Debug,
 		!flags.SkipCompile,
 		flags.Force,
+		flags.BundleTag,
 	)
 	if err != nil {
 		return err

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -809,7 +809,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string, error) {
 	tags := []string{"latest"}
 	for _, tag := range w.RegistryTags {
-		var tagVal string
+		var parsedTag string
 		tag = strings.Trim(tag, " ")
 		if len(tag) > 0 {
 			// TODO: We could add more tag validation here
@@ -820,14 +820,14 @@ func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string
 			if strings.Contains(tag, ":") {
 				tagSplit := strings.Split(tag, ":")
 				if sourceID == tagSplit[0] {
-					tagVal = strings.Trim(tagSplit[1], " ")
+					parsedTag = strings.Trim(tagSplit[1], " ")
 				}
 			} else {
-				tagVal = tag
+				parsedTag = tag
 			}
 
-			if len(tagVal) > 0 && !slices.Contains(tags, tagVal) {
-				tags = append(tags, tagVal)
+			if len(parsedTag) > 0 && !slices.Contains(tags, parsedTag) {
+				tags = append(tags, parsedTag)
 			}
 		}
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -809,6 +809,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string, error) {
 	tags := []string{"latest"}
 	for _, tag := range w.RegistryTags {
+		var tagVal string
 		tag = strings.Trim(tag, " ")
 		if len(tag) > 0 {
 			// TODO: We could add more tag validation here
@@ -818,12 +819,15 @@ func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string
 
 			if strings.Contains(tag, ":") {
 				tagSplit := strings.Split(tag, ":")
-				tagVal := strings.Trim(tagSplit[1], " ")
-				if len(tagVal) > 0 && sourceID == tagSplit[0] {
-					tags = append(tags, tagVal)
+				if sourceID == tagSplit[0] {
+					tagVal = strings.Trim(tagSplit[1], " ")
 				}
 			} else {
-				tags = append(tags, tag)
+				tagVal = tag
+			}
+
+			if len(tagVal) > 0 && !slices.Contains(tags, tagVal) {
+				tags = append(tags, tagVal)
 			}
 		}
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -695,7 +695,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 		namespaceName = name
 	}
 
-	tags, err := w.getBundleTags(ctx, sourceID)
+	tags, err := w.getRegistryTags(ctx, sourceID)
 	if err != nil {
 		return err
 	}
@@ -806,7 +806,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	return nil
 }
 
-func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string, error) {
+func (w *Workflow) getRegistryTags(ctx context.Context, sourceID string) ([]string, error) {
 	tags := []string{"latest"}
 	for _, tag := range w.RegistryTags {
 		var parsedTag string

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -811,6 +811,7 @@ func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string
 	for _, tag := range w.BundleTags {
 		tag = strings.Trim(tag, " ")
 		if len(tag) > 0 {
+			// TODO: We could add more tag validation here
 			if strings.Count(tag, ":") > 1 {
 				return tags, fmt.Errorf("invalid tag format: %s", tag)
 			}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -56,7 +56,7 @@ type Workflow struct {
 	Debug            bool
 	ShouldCompile    bool
 	ForceGeneration  bool
-	BundleTags       []string
+	RegistryTags     []string
 
 	RootStep           *workflowTracking.WorkflowStep
 	workflow           workflow.Workflow
@@ -80,7 +80,7 @@ func NewWorkflow(
 	name, target, source, repo string,
 	repoSubDirs, installationURLs map[string]string,
 	debug, shouldCompile, forceGeneration bool,
-	bundleTags []string,
+	registryTags []string,
 ) (*Workflow, error) {
 	wf, projectDir, err := utils.GetWorkflowAndDir()
 	if err != nil || wf == nil {
@@ -110,7 +110,7 @@ func NewWorkflow(
 		InstallationURLs: installationURLs,
 		Debug:            debug,
 		ShouldCompile:    shouldCompile,
-		BundleTags:       bundleTags,
+		RegistryTags:     registryTags,
 		workflow:         *wf,
 		projectDir:       projectDir,
 		RootStep:         rootStep,
@@ -808,7 +808,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 
 func (w *Workflow) getBundleTags(ctx context.Context, sourceID string) ([]string, error) {
 	tags := []string{"latest"}
-	for _, tag := range w.BundleTags {
+	for _, tag := range w.RegistryTags {
 		tag = strings.Trim(tag, " ")
 		if len(tag) > 0 {
 			// TODO: We could add more tag validation here

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+
 	"github.com/iancoleman/strcase"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	sdkGenConfig "github.com/speakeasy-api/sdk-gen-config"
@@ -27,7 +28,7 @@ import (
 	"github.com/speakeasy-api/speakeasy/registry"
 	"go.uber.org/zap"
 
-  "github.com/speakeasy-api/speakeasy/internal/ask"
+	"github.com/speakeasy-api/speakeasy/internal/ask"
 	"github.com/speakeasy-api/speakeasy/internal/changes"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/config"
@@ -46,7 +47,6 @@ import (
 	"github.com/speakeasy-api/speakeasy/pkg/merge"
 )
 
-
 type Workflow struct {
 	Target           string
 	Source           string
@@ -56,6 +56,7 @@ type Workflow struct {
 	Debug            bool
 	ShouldCompile    bool
 	ForceGeneration  bool
+	BundleTags       []string
 
 	RootStep           *workflowTracking.WorkflowStep
 	workflow           workflow.Workflow
@@ -79,6 +80,7 @@ func NewWorkflow(
 	name, target, source, repo string,
 	repoSubDirs, installationURLs map[string]string,
 	debug, shouldCompile, forceGeneration bool,
+	bundleTags []string,
 ) (*Workflow, error) {
 	wf, projectDir, err := utils.GetWorkflowAndDir()
 	if err != nil || wf == nil {
@@ -108,6 +110,7 @@ func NewWorkflow(
 		InstallationURLs: installationURLs,
 		Debug:            debug,
 		ShouldCompile:    shouldCompile,
+		BundleTags:       bundleTags,
 		workflow:         *wf,
 		projectDir:       projectDir,
 		RootStep:         rootStep,


### PR DESCRIPTION
Adds the ability to apply tags to speakeasy registry bundles

Example:

speakeasy run --bundle-tag latest --bundle-tag "my-source:main"  
speakeasy run --bundle-tag "latest,release-cut"