### PR TITLE
fix: Open API changes CLI events data

### DIFF
--- a/cmd/openapi.go
+++ b/cmd/openapi.go
@@ -184,7 +184,7 @@ func diffOpenapiInteractive(ctx context.Context, flags OpenAPIDiffFlags) error {
 		defer os.RemoveAll(workflow.GetTempDir())
 	}
 
-	changes, err := changes.GetChanges(oldSchema, newSchema)
+	changes, err := changes.GetChanges(ctx, oldSchema, newSchema)
 	if err != nil {
 		return err
 	}

--- a/go.mod
+++ b/go.mod
@@ -23,9 +23,9 @@ require (
 	github.com/speakeasy-api/huh v0.0.1
 	github.com/speakeasy-api/openapi-generation/v2 v2.312.1
 	github.com/speakeasy-api/openapi-overlay v0.5.0
-	github.com/speakeasy-api/sdk-gen-config v1.11.7
+	github.com/speakeasy-api/sdk-gen-config v1.12.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9
-	github.com/speakeasy-api/speakeasy-core v0.7.9
+	github.com/speakeasy-api/speakeasy-core v0.7.10
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/speakeasy-sdks/openai-go-sdk/v4 v4.2.1
 	github.com/spf13/cobra v1.8.0
@@ -40,6 +40,7 @@ require (
 )
 
 require (
+	github.com/inkeep/ai-api-go v0.3.1
 	github.com/pb33f/openapi-changes v0.0.61
 	github.com/stoewer/go-strcase v1.3.0
 )
@@ -127,7 +128,6 @@ require (
 	github.com/huandu/xstrings v1.4.0 // indirect
 	github.com/imdario/mergo v0.3.15 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/inkeep/ai-api-go v0.3.1 // indirect
 	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -511,12 +511,12 @@ github.com/speakeasy-api/openapi-generation/v2 v2.312.1 h1:PD5GZXJt4PtDcg+YNVlOc
 github.com/speakeasy-api/openapi-generation/v2 v2.312.1/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-overlay v0.5.0 h1:nPBDoTZga4IivSx9c+HzQkC9e0qYR7GUfNgGQyvekJk=
 github.com/speakeasy-api/openapi-overlay v0.5.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.11.7 h1:R7p4tA9N5cwf6yC0jkhClIPPrNiaEJFmGewOSlTf384=
-github.com/speakeasy-api/sdk-gen-config v1.11.7/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
+github.com/speakeasy-api/sdk-gen-config v1.12.0 h1:mQDSyJsIP90DW4uqt4g1m6V8+AywKsHzNEDTKEQDrfY=
+github.com/speakeasy-api/sdk-gen-config v1.12.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9 h1:APSrbtcqgstzNEzjX+cQieCfkfagoRZU2CmaU53dQ8w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.7.9 h1:xta586vcG2K2OeXiG63Fo3ccu18mgSs6SaIGHbSj+OM=
-github.com/speakeasy-api/speakeasy-core v0.7.9/go.mod h1:or2BDiHbluUhOgiM0pbwZ3b6wbdz0afhbugHR+nqWFA=
+github.com/speakeasy-api/speakeasy-core v0.7.10 h1:xvUz/LUNVwphpC9DQKKZAxqWK3Kq0ChGyJNVZjDVMME=
+github.com/speakeasy-api/speakeasy-core v0.7.10/go.mod h1:or2BDiHbluUhOgiM0pbwZ3b6wbdz0afhbugHR+nqWFA=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/changes/openapiChanges.go
+++ b/internal/changes/openapiChanges.go
@@ -1,13 +1,15 @@
 package changes
 
 import (
+	"context"
 	"errors"
-	changesModel "github.com/pb33f/openapi-changes/model"
-	"github.com/speakeasy-api/speakeasy-core/changes"
-	html_report "github.com/speakeasy-api/speakeasy-core/changes/html-report"
 	"os"
 	"strings"
 	"time"
+
+	changesModel "github.com/pb33f/openapi-changes/model"
+	"github.com/speakeasy-api/speakeasy-core/changes"
+	html_report "github.com/speakeasy-api/speakeasy-core/changes/html-report"
 )
 
 type Changes []*changesModel.Commit
@@ -26,8 +28,8 @@ var (
 	None  VersionBump = "none"
 )
 
-func GetChanges(oldLocation, newLocation string) (Changes, error) {
-	c, errs := changes.GetChanges(oldLocation, newLocation, changes.SummaryOptions{})
+func GetChanges(ctx context.Context, oldLocation, newLocation string) (Changes, error) {
+	c, errs := changes.GetChanges(ctx, oldLocation, newLocation, changes.SummaryOptions{})
 	return c, errors.Join(errs...)
 }
 

--- a/internal/reports/reports.go
+++ b/internal/reports/reports.go
@@ -5,14 +5,15 @@ import (
 	"crypto/md5"
 	"encoding/hex"
 	"fmt"
+	"os"
+	"path/filepath"
+
 	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/operations"
 	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
 	"github.com/speakeasy-api/speakeasy-core/events"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/sdk"
 	"github.com/stoewer/go-strcase"
-	"os"
-	"path/filepath"
 )
 
 type ReportResult struct {
@@ -51,7 +52,12 @@ func UploadReport(ctx context.Context, reportBytes []byte, reportType shared.Typ
 
 	cliEvent := events.GetTelemetryEventFromContext(ctx)
 	if cliEvent != nil {
-		cliEvent.OpenapiDiffReportDigest = &digest
+		switch reportType {
+		case shared.TypeLinting:
+			cliEvent.OpenapiDiffReportDigest = &digest
+		case shared.TypeChanges:
+			cliEvent.LintReportDigest = &digest
+		}
 	}
 
 	url := uploadRes.UploadedReport.GetURL()

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -14,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"time"
+
 	"github.com/iancoleman/strcase"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	sdkGenConfig "github.com/speakeasy-api/sdk-gen-config"
@@ -27,7 +28,7 @@ import (
 	"github.com/speakeasy-api/speakeasy/registry"
 	"go.uber.org/zap"
 
-  "github.com/speakeasy-api/speakeasy/internal/ask"
+	"github.com/speakeasy-api/speakeasy/internal/ask"
 	"github.com/speakeasy-api/speakeasy/internal/changes"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/config"
@@ -45,7 +46,6 @@ import (
 	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
 	"github.com/speakeasy-api/speakeasy/pkg/merge"
 )
-
 
 type Workflow struct {
 	Target           string
@@ -539,7 +539,7 @@ func computeChanges(ctx context.Context, rootStep *workflowTracking.WorkflowStep
 
 	changesStep.NewSubstep("Computing changes")
 
-	c, err := changes.GetChanges(oldDocPath.LocalFilePath, newDocPath)
+	c, err := changes.GetChanges(ctx, oldDocPath.LocalFilePath, newDocPath)
 	if err != nil {
 		return r, fmt.Errorf("error computing changes: %w", err)
 	}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -517,9 +517,13 @@ func computeChanges(ctx context.Context, rootStep *workflowTracking.WorkflowStep
 		}
 	}()
 
+	orgSlug := auth.GetOrgSlugFromContext(ctx)
+	workspaceSlug := auth.GetWorkspaceSlugFromContext(ctx)
+
 	oldRegistryLocation := ""
 	if targetLock.SourceRevisionDigest != "" && targetLock.SourceNamespace != "" {
-		oldRegistryLocation = fmt.Sprintf("%s/%s@%s", "registry.speakeasyapi.dev", targetLock.SourceNamespace, targetLock.SourceRevisionDigest)
+		oldRegistryLocation = fmt.Sprintf("%s/%s/%s/%s@%s", "registry.speakeasyapi.dev", orgSlug, workspaceSlug,
+			targetLock.SourceNamespace, targetLock.SourceRevisionDigest)
 	} else {
 		changesStep.Skip("no previous revision found")
 		return

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -3,9 +3,10 @@ package validation
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/reports"
 	"io"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/reports"
 
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -321,7 +322,6 @@ func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schem
 		cliEvent.LintReportInfoCount = &infoCount
 		cliEvent.LintReportWarningCount = &warnCount
 		cliEvent.LintReportErrorCount = &errCount
-		cliEvent.LintReportDigest = &report.Digest
 	}
 
 	return &ValidationResult{

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -8,7 +8,7 @@ import (
 
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
-	"github.com/speakeasy-api/speakeasy-core/auth"
+	core "github.com/speakeasy-api/speakeasy-core/auth"
 	"github.com/speakeasy-api/speakeasy/internal/download"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 )
@@ -20,15 +20,29 @@ func ResolveSpeakeasyRegistryBundle(ctx context.Context, d workflow.Document, ou
 		return nil, err
 	}
 
+	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
+	organizationSlug := core.GetOrgSlugFromContext(ctx)
+	if workspaceSlug == "" || organizationSlug == "" {
+		return nil, fmt.Errorf("unable to use speakeasy registry reference without authenticating")
+	}
+
 	registryBreakdown := workflow.ParseSpeakeasyRegistryReference(d.Location)
 	if registryBreakdown == nil {
 		return nil, fmt.Errorf("failed to parse speakeasy registry reference %s", d.Location)
 	}
 
-	return download.DownloadRegistryOpenAPIBundle(ctx, registryBreakdown.NamespaceID, registryBreakdown.Reference, outPath)
+	if registryBreakdown.OrganizationSlug != organizationSlug {
+		return nil, fmt.Errorf("organization mismatch: %s != %s", registryBreakdown.OrganizationSlug, organizationSlug)
+	}
+
+	if registryBreakdown.WorkspaceSlug != workspaceSlug {
+		return nil, fmt.Errorf("workspace mismatch: %s != %s", registryBreakdown.WorkspaceSlug, workspaceSlug)
+	}
+
+	return download.DownloadRegistryOpenAPIBundle(ctx, registryBreakdown.NamespaceName, registryBreakdown.Reference, outPath)
 }
 
 func IsRegistryEnabled(ctx context.Context) bool {
-	hasSchemaRegistry, _ := auth.HasWorkspaceFeatureFlag(ctx, shared.FeatureFlagsSchemaRegistry)
+	hasSchemaRegistry, _ := core.HasWorkspaceFeatureFlag(ctx, shared.FeatureFlagsSchemaRegistry)
 	return hasSchemaRegistry
 }


### PR DESCRIPTION
* Upgrade SDK-gen-config - safely parses registry URLs correctly
* Checks if the workspace of registry URL matches the currently authenticated workspace
* Fixes OpenAPIDiffReportDigest being written even for linting reports
* Fixes report digests are only set if upload succeeded
* Upgrade core: populates CLI Event field OpenAPIDifBreakingChangesCount