### PR TITLE
chore: smaller openapi change bundles

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.5.0
 	github.com/speakeasy-api/sdk-gen-config v1.12.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9
-	github.com/speakeasy-api/speakeasy-core v0.7.10
+	github.com/speakeasy-api/speakeasy-core v0.8.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/speakeasy-sdks/openai-go-sdk/v4 v4.2.1
 	github.com/spf13/cobra v1.8.0

--- a/go.sum
+++ b/go.sum
@@ -515,8 +515,8 @@ github.com/speakeasy-api/sdk-gen-config v1.12.0 h1:mQDSyJsIP90DW4uqt4g1m6V8+AywK
 github.com/speakeasy-api/sdk-gen-config v1.12.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9 h1:APSrbtcqgstzNEzjX+cQieCfkfagoRZU2CmaU53dQ8w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.7.10 h1:xvUz/LUNVwphpC9DQKKZAxqWK3Kq0ChGyJNVZjDVMME=
-github.com/speakeasy-api/speakeasy-core v0.7.10/go.mod h1:or2BDiHbluUhOgiM0pbwZ3b6wbdz0afhbugHR+nqWFA=
+github.com/speakeasy-api/speakeasy-core v0.8.0 h1:oRdDPndPRps9UPmk9uSiY9e5YpVuHbQoR1g6FmMBcdk=
+github.com/speakeasy-api/speakeasy-core v0.8.0/go.mod h1:or2BDiHbluUhOgiM0pbwZ3b6wbdz0afhbugHR+nqWFA=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/changes/openapiChanges.go
+++ b/internal/changes/openapiChanges.go
@@ -35,7 +35,7 @@ func GetChanges(ctx context.Context, oldLocation, newLocation string) (Changes, 
 
 func (c Changes) GetHTMLReport() []byte {
 	generator := html_report.NewHTMLReport(false, time.Now(), c)
-	return generator.GenerateReport(false, false, false)
+	return generator.GenerateReport(false)
 }
 
 func (c Changes) WriteHTMLReport(out string) error {


### PR DESCRIPTION
Puts JS / CSS for change report into CDN such that the openapi change bundles are now much, much smaller.

<img width="1081" alt="Screenshot 2024-04-24 at 16 42 17" src="https://github.com/speakeasy-api/speakeasy/assets/2904857/8ab1aaf6-1ebb-453f-9454-dc412fa4f265">
