### PR TITLE
feat: automatically migrate registry users to source registry location

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/speakeasy-api/huh v0.0.1
 	github.com/speakeasy-api/openapi-generation/v2 v2.314.0
 	github.com/speakeasy-api/openapi-overlay v0.5.0
-	github.com/speakeasy-api/sdk-gen-config v1.12.0
+	github.com/speakeasy-api/sdk-gen-config v1.13.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9
 	github.com/speakeasy-api/speakeasy-core v0.8.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/speakeasy-api/huh v0.0.1
 	github.com/speakeasy-api/openapi-generation/v2 v2.314.0
 	github.com/speakeasy-api/openapi-overlay v0.5.0
-	github.com/speakeasy-api/sdk-gen-config v1.13.0
+	github.com/speakeasy-api/sdk-gen-config v1.14.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9
 	github.com/speakeasy-api/speakeasy-core v0.8.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -507,14 +507,12 @@ github.com/speakeasy-api/easytemplate v0.11.0 h1:B0DtyTwE6NTOLa020UNyATi1ebFVL5D
 github.com/speakeasy-api/easytemplate v0.11.0/go.mod h1:42jXuVIno2A24bQyVFK9K70kpG0tSufLEF4TiJ1kGvQ=
 github.com/speakeasy-api/huh v0.0.1 h1:zJuyql3bxkxkW8EN+xNuW6B6kmZZldtcKbLBx32SwwQ=
 github.com/speakeasy-api/huh v0.0.1/go.mod h1:JVIEq1tlJtFWZ4OACzN0Tj+I3+SdLiMznROo12ZJ1bQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.312.1 h1:PD5GZXJt4PtDcg+YNVlOcAyEqRD5ASmhHYlnGnSE/4E=
-github.com/speakeasy-api/openapi-generation/v2 v2.312.1/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-generation/v2 v2.314.0 h1:HcVDiYTDnxf7nKgZWa05xRsgofPb6wSNWHjOegiXNRE=
 github.com/speakeasy-api/openapi-generation/v2 v2.314.0/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-overlay v0.5.0 h1:nPBDoTZga4IivSx9c+HzQkC9e0qYR7GUfNgGQyvekJk=
 github.com/speakeasy-api/openapi-overlay v0.5.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.12.0 h1:mQDSyJsIP90DW4uqt4g1m6V8+AywKsHzNEDTKEQDrfY=
-github.com/speakeasy-api/sdk-gen-config v1.12.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
+github.com/speakeasy-api/sdk-gen-config v1.13.0 h1:/nlELjA43A2roCHcTlQ42uLvvhNZ6q2Hoez+EV99X8w=
+github.com/speakeasy-api/sdk-gen-config v1.13.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9 h1:APSrbtcqgstzNEzjX+cQieCfkfagoRZU2CmaU53dQ8w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.8.0 h1:oRdDPndPRps9UPmk9uSiY9e5YpVuHbQoR1g6FmMBcdk=

--- a/go.sum
+++ b/go.sum
@@ -511,8 +511,8 @@ github.com/speakeasy-api/openapi-generation/v2 v2.314.0 h1:HcVDiYTDnxf7nKgZWa05x
 github.com/speakeasy-api/openapi-generation/v2 v2.314.0/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-overlay v0.5.0 h1:nPBDoTZga4IivSx9c+HzQkC9e0qYR7GUfNgGQyvekJk=
 github.com/speakeasy-api/openapi-overlay v0.5.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.13.0 h1:/nlELjA43A2roCHcTlQ42uLvvhNZ6q2Hoez+EV99X8w=
-github.com/speakeasy-api/sdk-gen-config v1.13.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
+github.com/speakeasy-api/sdk-gen-config v1.14.0 h1:4k9mG09pwE0bsKGNCTyqD+JutscDyC/sKxLEkG82BCk=
+github.com/speakeasy-api/sdk-gen-config v1.14.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9 h1:APSrbtcqgstzNEzjX+cQieCfkfagoRZU2CmaU53dQ8w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.8.0 h1:oRdDPndPRps9UPmk9uSiY9e5YpVuHbQoR1g6FmMBcdk=

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -268,7 +268,13 @@ func buildNewPublishingWorkflow(pubWorkflow string) (*config.PublishWorkflow, er
 
 	newPublishingWorkflow := &config.PublishWorkflow{
 		Name: publishingWorkflow.Name,
-		On:   publishingWorkflow.On,
+		Permissions: config.Permissions{
+			Checks:       config.GithubWritePermission,
+			Statuses:     config.GithubWritePermission,
+			Contents:     config.GithubWritePermission,
+			PullRequests: config.GithubWritePermission,
+		},
+		On: publishingWorkflow.On,
 		Jobs: config.Jobs{
 			Publish: config.Job{
 				Uses:    "speakeasy-api/sdk-generation-action/.github/workflows/sdk-publish.yaml@v15",

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -530,6 +530,12 @@ func defaultGenerationFile() *config.GenerateWorkflow {
 func defaultPublishingFile() *config.PublishWorkflow {
 	return &config.PublishWorkflow{
 		Name: "Publish",
+		Permissions: config.Permissions{
+			Checks:       config.GithubWritePermission,
+			Statuses:     config.GithubWritePermission,
+			Contents:     config.GithubWritePermission,
+			PullRequests: config.GithubWritePermission,
+		},
 		On: config.PublishOn{
 			Push: config.Push{
 				Paths: []string{

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -173,11 +173,11 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 	source.Inputs = append(source.Inputs, *document)
 
 	if registry.IsRegistryEnabled(ctx) && auth.GetOrgSlugFromContext(ctx) != "" && auth.GetWorkspaceSlugFromContext(ctx) != "" {
-		publishing := &workflow.SourcePublishing{}
-		if err := publishing.SetNamespace(fmt.Sprintf("%s/%s/%s", auth.GetOrgSlugFromContext(ctx), auth.GetWorkspaceSlugFromContext(ctx), strcase.ToKebab(sourceName))); err != nil {
+		registryEntry := &workflow.SourceRegistry{}
+		if err := registryEntry.SetNamespace(fmt.Sprintf("%s/%s/%s", auth.GetOrgSlugFromContext(ctx), auth.GetWorkspaceSlugFromContext(ctx), strcase.ToKebab(sourceName))); err != nil {
 			return nil, err
 		}
-		source.Publish = publishing
+		source.Registry = registryEntry
 	}
 
 	if err := source.Validate(); err != nil {


### PR DESCRIPTION
- When a publishing location isn't provided make sourceID kebab case to make it more likely to succeed
- Backfill a publishing location into the workflow file