### PR TITLE
fix: HTTPMetadata namespace for http-enveloppe response format C#

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v0.0.1
-	github.com/speakeasy-api/openapi-generation/v2 v2.314.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.315.1
 	github.com/speakeasy-api/openapi-overlay v0.5.0
 	github.com/speakeasy-api/sdk-gen-config v1.14.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.5.9

--- a/go.sum
+++ b/go.sum
@@ -507,8 +507,8 @@ github.com/speakeasy-api/easytemplate v0.11.0 h1:B0DtyTwE6NTOLa020UNyATi1ebFVL5D
 github.com/speakeasy-api/easytemplate v0.11.0/go.mod h1:42jXuVIno2A24bQyVFK9K70kpG0tSufLEF4TiJ1kGvQ=
 github.com/speakeasy-api/huh v0.0.1 h1:zJuyql3bxkxkW8EN+xNuW6B6kmZZldtcKbLBx32SwwQ=
 github.com/speakeasy-api/huh v0.0.1/go.mod h1:JVIEq1tlJtFWZ4OACzN0Tj+I3+SdLiMznROo12ZJ1bQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.314.0 h1:HcVDiYTDnxf7nKgZWa05xRsgofPb6wSNWHjOegiXNRE=
-github.com/speakeasy-api/openapi-generation/v2 v2.314.0/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
+github.com/speakeasy-api/openapi-generation/v2 v2.315.1 h1:m0kzDK2CFyJMpdURcHgXGxBkZ0jBAqo8VwQ7jLYan6s=
+github.com/speakeasy-api/openapi-generation/v2 v2.315.1/go.mod h1:hVRNUWDpajfgd+ZQHX0aGsSQb1a8dquWyb173dVihj8=
 github.com/speakeasy-api/openapi-overlay v0.5.0 h1:nPBDoTZga4IivSx9c+HzQkC9e0qYR7GUfNgGQyvekJk=
 github.com/speakeasy-api/openapi-overlay v0.5.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.14.0 h1:4k9mG09pwE0bsKGNCTyqD+JutscDyC/sKxLEkG82BCk=


### PR DESCRIPTION
Addresses namespacing issues for `http-enveloppe` response format in C# [context](https://speakeasy-dev.slack.com/archives/C06LXJ63TH8/p1714064471160469)
https://github.com/speakeasy-api/openapi-generation/pull/1201