### PR TITLE
feat: natively support monorepo mode in configure github

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -539,7 +539,11 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 			return errors.Wrapf(err, "failed to write github workflow file")
 		}
 	} else {
-		for name := range workflowFile.Targets {
+		for name, target := range workflowFile.Targets {
+			if target.Target == "postman" || target.Target == "docs" {
+				continue
+			}
+
 			generationWorkflowFilePath := filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_generation.yaml", name))
 			generationWorkflow := &config.GenerateWorkflow{}
 			prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -457,16 +457,16 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 	if len(publishPaths) > 0 {
 		status = append(status, "GitHub action (generate) written to:")
 		for _, path := range generationWorkflowFilePaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 		status = append(status, "GitHub action (publish) written to:")
 		for _, path := range publishPaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 	} else {
 		status = append(status, "GitHub action (generate+publish) written to:")
 		for _, path := range generationWorkflowFilePaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 	}
 
@@ -661,16 +661,16 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	if len(publishPaths) > 0 {
 		status = append(status, "GitHub action (generate) written to:")
 		for _, path := range generationWorkflowFilePaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 		status = append(status, "GitHub action (publish) written to:")
 		for _, path := range publishPaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 	} else {
 		status = append(status, "GitHub action (generate+publish) written to:")
 		for _, path := range generationWorkflowFilePaths {
-			status = append(status, fmt.Sprintf("\t◦ %s", path))
+			status = append(status, fmt.Sprintf("\t- %s", path))
 		}
 	}
 

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -348,16 +348,9 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		return err
 	}
 
-	generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
-
 	workflowFile, _, _ := workflow.Load(workingDir)
 	if workflowFile == nil {
 		return fmt.Errorf("you cannot run configure when a speakeasy workflow does not exist, try speakeasy quickstart")
-	}
-
-	generationWorkflow := &config.GenerateWorkflow{}
-	if err := prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
-		return fmt.Errorf("you cannot run configure publishing when a github workflow file %s does not exist, try speakeasy configure github", generationWorkflowFilePath)
 	}
 
 	var publishingOptions []huh.Option[string]
@@ -385,16 +378,58 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		workflowFile.Targets[name] = *modifiedTarget
 	}
 
-	var publishPath string
-	if len(chosenTargets) > 0 {
-		generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir)
+	secrets := make(map[string]string)
+	var publishPaths, generationWorkflowFilePaths []string
+	if len(chosenTargets) == 1 {
+		var publishPath string
+		generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
+		generationWorkflow := &config.GenerateWorkflow{}
+		if err := prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+			return fmt.Errorf("you cannot run configure publishing when a github workflow file %s does not exist, try speakeasy configure github", generationWorkflowFilePath)
+		}
+
+		generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, nil, nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to write publishing configs")
 		}
-	}
 
-	if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
-		return errors.Wrapf(err, "failed to write github workflow file")
+		for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+			secrets[key] = val
+		}
+
+		publishPaths = append(publishPaths, publishPath)
+		generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
+
+		if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+			return errors.Wrapf(err, "failed to write github workflow file")
+		}
+	} else if len(chosenTargets) > 1 {
+		for _, name := range chosenTargets {
+			var publishPath string
+			generationWorkflowFilePath := filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_generation.yaml", name))
+			generationWorkflow := &config.GenerateWorkflow{}
+			if err := prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+				return fmt.Errorf("you cannot run configure publishing when a github workflow file %s does not exist, try speakeasy configure github", generationWorkflowFilePath)
+			}
+
+			target := workflowFile.Targets[name]
+
+			generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, &name, target.Output)
+			if err != nil {
+				return errors.Wrapf(err, "failed to write publishing configs")
+			}
+
+			for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+				secrets[key] = val
+			}
+
+			publishPaths = append(publishPaths, publishPath)
+			generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
+
+			if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+				return errors.Wrapf(err, "failed to write github workflow file")
+			}
+		}
 	}
 
 	if err := workflow.Save(workingDir, workflowFile); err != nil {
@@ -419,15 +454,24 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 	status := []string{
 		fmt.Sprintf("Speakeasy workflow written to - %s", workflowFilePath),
 	}
-	if publishPath != "" {
-		status = append(status, fmt.Sprintf("GitHub action (generate) written to - %s", generationWorkflowFilePath))
-		status = append(status, fmt.Sprintf("GitHub action (publish) written to - %s", publishPath))
+	if len(publishPaths) > 0 {
+		status = append(status, "GitHub action (generate) written to:")
+		for _, path := range generationWorkflowFilePaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
+		status = append(status, "GitHub action (publish) written to:")
+		for _, path := range publishPaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
 	} else {
-		status = append(status, fmt.Sprintf("GitHub action (generate+publish) written to - %s", generationWorkflowFilePath))
+		status = append(status, "GitHub action (generate+publish) written to:")
+		for _, path := range generationWorkflowFilePaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
 	}
 
 	var agenda []string
-	for key := range generationWorkflow.Jobs.Generate.Secrets {
+	for key := range secrets {
 		if key != config.GithubAccessToken {
 			agenda = append(agenda, fmt.Sprintf("\t◦ Provide a secret with name %s", styles.MakeBold(strings.ToUpper(key))))
 		}
@@ -465,8 +509,6 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		return err
 	}
 
-	generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
-
 	workflowFile, _, _ := workflow.Load(workingDir)
 	if workflowFile == nil {
 		return fmt.Errorf("you cannot run configure when a speakeasy workflow does not exist, try speakeasy quickstart")
@@ -474,12 +516,49 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 
 	ctx = events.SetTargetInContext(ctx, workingDir)
 
-	generationWorkflow := &config.GenerateWorkflow{}
-	prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
+	secrets := make(map[string]string)
+	var generationWorkflowFilePaths []string
 
-	generationWorkflow, err = prompts.ConfigureGithub(generationWorkflow, workflowFile)
-	if err != nil {
-		return err
+	if numberOfLanguageTargets(workflowFile) <= 1 {
+		generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
+		generationWorkflow := &config.GenerateWorkflow{}
+		prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
+
+		generationWorkflow, err = prompts.ConfigureGithub(generationWorkflow, workflowFile, nil)
+		if err != nil {
+			return err
+		}
+
+		for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+			secrets[key] = val
+		}
+
+		generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
+
+		if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+			return errors.Wrapf(err, "failed to write github workflow file")
+		}
+	} else {
+		for name := range workflowFile.Targets {
+			generationWorkflowFilePath := filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_generation.yaml", name))
+			generationWorkflow := &config.GenerateWorkflow{}
+			prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
+
+			generationWorkflow, err = prompts.ConfigureGithub(generationWorkflow, workflowFile, &name)
+			if err != nil {
+				return err
+			}
+
+			for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+				secrets[key] = val
+			}
+
+			generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
+
+			if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+				return errors.Wrapf(err, "failed to write github workflow file")
+			}
+		}
 	}
 
 	var publishingOptions []huh.Option[string]
@@ -506,23 +585,55 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		workflowFile.Targets[name] = *modifiedTarget
 	}
 
-	if _, err := os.Stat(workingDir + "/" + ".github/workflows"); os.IsNotExist(err) {
-		err = os.MkdirAll(workingDir+"/"+".github/workflows", 0o755)
-		if err != nil {
-			return err
+	var publishPaths []string
+	if len(chosenTargets) == 1 {
+		var publishPath string
+		generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
+		generationWorkflow := &config.GenerateWorkflow{}
+		if err := prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+			return fmt.Errorf("no github action file found at %s ", generationWorkflowFilePath)
 		}
-	}
 
-	var publishPath string
-	if len(chosenTargets) > 0 {
-		generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir)
+		generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, nil, nil)
 		if err != nil {
 			return errors.Wrapf(err, "failed to write publishing configs")
 		}
-	}
 
-	if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
-		return errors.Wrapf(err, "failed to write github workflow file")
+		for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+			secrets[key] = val
+		}
+
+		publishPaths = append(publishPaths, publishPath)
+
+		if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+			return errors.Wrapf(err, "failed to write github workflow file")
+		}
+	} else if len(chosenTargets) > 1 {
+		for _, name := range chosenTargets {
+			var publishPath string
+			generationWorkflowFilePath := filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_generation.yaml", name))
+			generationWorkflow := &config.GenerateWorkflow{}
+			if err := prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+				return fmt.Errorf("no github action file found at %s ", generationWorkflowFilePath)
+			}
+
+			target := workflowFile.Targets[name]
+
+			generationWorkflow, publishPath, err = prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, &name, target.Output)
+			if err != nil {
+				return errors.Wrapf(err, "failed to write publishing configs")
+			}
+
+			for key, val := range generationWorkflow.Jobs.Generate.Secrets {
+				secrets[key] = val
+			}
+
+			publishPaths = append(publishPaths, publishPath)
+
+			if err = prompts.WriteGenerationFile(generationWorkflow, generationWorkflowFilePath); err != nil {
+				return errors.Wrapf(err, "failed to write github workflow file")
+			}
+		}
 	}
 
 	if err := workflow.Save(workingDir, workflowFile); err != nil {
@@ -547,11 +658,20 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	status := []string{
 		fmt.Sprintf("Speakeasy workflow written to - %s", workflowFilePath),
 	}
-	if publishPath != "" {
-		status = append(status, fmt.Sprintf("GitHub action (generate) written to - %s", generationWorkflowFilePath))
-		status = append(status, fmt.Sprintf("GitHub action (publish) written to - %s", publishPath))
+	if len(publishPaths) > 0 {
+		status = append(status, "GitHub action (generate) written to:")
+		for _, path := range generationWorkflowFilePaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
+		status = append(status, "GitHub action (publish) written to:")
+		for _, path := range publishPaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
 	} else {
-		status = append(status, fmt.Sprintf("GitHub action (generate+publish) written to - %s", generationWorkflowFilePath))
+		status = append(status, "GitHub action (generate+publish) written to:")
+		for _, path := range generationWorkflowFilePaths {
+			status = append(status, fmt.Sprintf("\t◦ %s", path))
+		}
 	}
 
 	agenda := []string{}
@@ -576,7 +696,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	agenda = append(agenda, fmt.Sprintf("• Setup a Speakeasy API Key as a GitHub Secret - %s/workspaces/%s/apikeys", core.GetServerURL(), workspaceID))
 	agenda = append(agenda, fmt.Sprintf("• In your repo navigate to %s and setup the following repository secrets:", secretPath))
 
-	for key := range generationWorkflow.Jobs.Generate.Secrets {
+	for key := range secrets {
 		if key != config.GithubAccessToken {
 			agenda = append(agenda, fmt.Sprintf("\t◦ Provide a secret with name %s", styles.MakeBold(strings.ToUpper(key))))
 		}
@@ -628,4 +748,15 @@ func handleLegacySDKTarget(workingDir string, workflowFile *workflow.Workflow) (
 	}
 
 	return []string{}, []huh.Option[string]{huh.NewOption(charm.FormatNewOption("New Target"), "new target")}
+}
+
+func numberOfLanguageTargets(wf *workflow.Workflow) int {
+	languageTargetCount := 0
+	for _, target := range wf.Targets {
+		if target.Target != "postman" && target.Target != "docs" {
+			languageTargetCount += 1
+		}
+	}
+
+	return languageTargetCount
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -519,7 +519,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	secrets := make(map[string]string)
 	var generationWorkflowFilePaths []string
 
-	if numberOfLanguageTargets(workflowFile) <= 1 {
+	if len(workflowFile.Targets) <= 1 {
 		generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
 		generationWorkflow := &config.GenerateWorkflow{}
 		prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
@@ -539,11 +539,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 			return errors.Wrapf(err, "failed to write github workflow file")
 		}
 	} else {
-		for name, target := range workflowFile.Targets {
-			if target.Target == "postman" || target.Target == "docs" {
-				continue
-			}
-
+		for name := range workflowFile.Targets {
 			generationWorkflowFilePath := filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_generation.yaml", name))
 			generationWorkflow := &config.GenerateWorkflow{}
 			prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
@@ -752,15 +748,4 @@ func handleLegacySDKTarget(workingDir string, workflowFile *workflow.Workflow) (
 	}
 
 	return []string{}, []huh.Option[string]{huh.NewOption(charm.FormatNewOption("New Target"), "new target")}
-}
-
-func numberOfLanguageTargets(wf *workflow.Workflow) int {
-	languageTargetCount := 0
-	for _, target := range wf.Targets {
-		if target.Target != "postman" && target.Target != "docs" {
-			languageTargetCount += 1
-		}
-	}
-
-	return languageTargetCount
 }

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -445,8 +445,8 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 			return genWorkflow, "", errors.Wrapf(err, "failed to encode workflow file")
 		}
 
-		if _, err := os.Stat(filePath); os.IsNotExist(err) {
-			err = os.MkdirAll(filePath, 0o755)
+		if _, err := os.Stat(strings.TrimSuffix(filePath, "/sdk_publish.yaml")); os.IsNotExist(err) {
+			err = os.MkdirAll(strings.TrimSuffix(filePath, "/sdk_publish.yaml"), 0o755)
 			if err != nil {
 				return nil, "", err
 			}
@@ -470,8 +470,8 @@ func WriteGenerationFile(generationWorkflow *config.GenerateWorkflow, generation
 		return errors.Wrapf(err, "failed to encode workflow file")
 	}
 
-	if _, err := os.Stat(generationWorkflowFilePath); os.IsNotExist(err) {
-		err = os.MkdirAll(generationWorkflowFilePath, 0o755)
+	if _, err := os.Stat(strings.TrimSuffix(generationWorkflowFilePath, "/sdk_generation.yaml")); os.IsNotExist(err) {
+		err = os.MkdirAll(strings.TrimSuffix(generationWorkflowFilePath, "/sdk_generation.yaml"), 0o755)
 		if err != nil {
 			return err
 		}

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -41,9 +41,13 @@ var SupportedPublishingTargets = []string{
 	"go",
 }
 
-func ConfigureGithub(githubWorkflow *config.GenerateWorkflow, workflow *workflow.Workflow) (*config.GenerateWorkflow, error) {
+func ConfigureGithub(githubWorkflow *config.GenerateWorkflow, workflow *workflow.Workflow, target *string) (*config.GenerateWorkflow, error) {
 	if githubWorkflow == nil || githubWorkflow.Jobs.Generate.Uses == "" {
 		githubWorkflow = defaultGenerationFile()
+	}
+
+	if target != nil {
+		githubWorkflow.Name = fmt.Sprintf("Generate %s", strings.ToUpper(*target))
 	}
 
 	secrets := githubWorkflow.Jobs.Generate.Secrets
@@ -59,6 +63,9 @@ func ConfigureGithub(githubWorkflow *config.GenerateWorkflow, workflow *workflow
 				secrets[formatGithubSecret(overlay.Auth.Secret)] = formatGithubSecretName(overlay.Auth.Secret)
 			}
 		}
+	}
+	if target != nil {
+		githubWorkflow.Jobs.Generate.With["target"] = *target
 	}
 	githubWorkflow.Jobs.Generate.Secrets = secrets
 	return githubWorkflow, nil
@@ -389,7 +396,7 @@ func getSecretsValuesFromPublishing(publishing workflow.Publishing) []string {
 	return secrets
 }
 
-func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflow.Workflow, workingDir string) (*config.GenerateWorkflow, string, error) {
+func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflow.Workflow, workingDir string, target, outputPath *string) (*config.GenerateWorkflow, string, error) {
 	secrets := make(map[string]string)
 	secrets[config.GithubAccessToken] = formatGithubSecretName(defaultGithubTokenSecretName)
 	secrets[config.SpeakeasyApiKey] = formatGithubSecretName(defaultSpeakeasyAPIKeySecretName)
@@ -410,9 +417,20 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 	mode := genWorkflow.Jobs.Generate.With[config.Mode].(string)
 	if mode == "pr" {
 		filePath := filepath.Join(workingDir, ".github/workflows/sdk_publish.yaml")
+		if target != nil {
+			filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_publish.yaml", *target))
+		}
 		publishingFile := &config.PublishWorkflow{}
 		if err := readPublishingFile(publishingFile, filePath); err != nil {
 			publishingFile = defaultPublishingFile()
+		}
+
+		if target != nil {
+			publishingFile.Name = fmt.Sprintf("Publish %s", strings.ToUpper(*target))
+		}
+
+		if outputPath != nil {
+			publishingFile.On.Push.Paths = []string{fmt.Sprintf("%s/RELEASES.md", *outputPath)}
 		}
 
 		for name, value := range secrets {
@@ -425,6 +443,13 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 		yamlEncoder.SetIndent(2)
 		if err := yamlEncoder.Encode(publishingFile); err != nil {
 			return genWorkflow, "", errors.Wrapf(err, "failed to encode workflow file")
+		}
+
+		if _, err := os.Stat(filePath); os.IsNotExist(err) {
+			err = os.MkdirAll(filePath, 0o755)
+			if err != nil {
+				return nil, "", err
+			}
 		}
 
 		if err := os.WriteFile(filePath, publishingWorkflowBuf.Bytes(), 0o644); err != nil {
@@ -443,6 +468,13 @@ func WriteGenerationFile(generationWorkflow *config.GenerateWorkflow, generation
 	yamlEncoder.SetIndent(2)
 	if err := yamlEncoder.Encode(generationWorkflow); err != nil {
 		return errors.Wrapf(err, "failed to encode workflow file")
+	}
+
+	if _, err := os.Stat(generationWorkflowFilePath); os.IsNotExist(err) {
+		err = os.MkdirAll(generationWorkflowFilePath, 0o755)
+		if err != nil {
+			return err
+		}
 	}
 
 	if err := os.WriteFile(generationWorkflowFilePath, genWorkflowBuf.Bytes(), 0o644); err != nil {

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -418,7 +418,7 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 	if mode == "pr" {
 		filePath := filepath.Join(workingDir, ".github/workflows/sdk_publish.yaml")
 		if target != nil {
-			filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_publish.yaml", *target))
+			filePath = filepath.Join(workingDir, fmt.Sprintf(".github/workflows/%s/sdk_publish.yaml", *target))
 		}
 		publishingFile := &config.PublishWorkflow{}
 		if err := readPublishingFile(publishingFile, filePath); err != nil {

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -400,9 +400,13 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 	secrets := make(map[string]string)
 	secrets[config.GithubAccessToken] = formatGithubSecretName(defaultGithubTokenSecretName)
 	secrets[config.SpeakeasyApiKey] = formatGithubSecretName(defaultSpeakeasyAPIKeySecretName)
-	for _, target := range workflowFile.Targets {
-		if target.Publishing != nil {
-			for _, secret := range getSecretsValuesFromPublishing(*target.Publishing) {
+	for name, t := range workflowFile.Targets {
+		if target != nil && *target != name {
+			continue
+		}
+
+		if t.Publishing != nil {
+			for _, secret := range getSecretsValuesFromPublishing(*t.Publishing) {
 				secrets[formatGithubSecret(secret)] = formatGithubSecretName(secret)
 			}
 		}


### PR DESCRIPTION
Allows us to support monorepo mode natively in configure github. Typically when you have multiple different targets in the same repo we want to generate and publishing in separate runs and PRs for each target. We separate their files into their own subdirectory of github workflows.