### PR TITLE
fix: switch to amannn/action-semantic-pull-request

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,20 +9,15 @@ on:
       - synchronize
 
 jobs:
-  # build:
-  #   name: Conventional Commits
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v2
-  #     - uses: webiny/action-conventional-commits@v1.1.0
-  #     - uses: aslafy-z/conventional-pr-title-action@v3
-  #       with:
-  #         success-state: Title follows the specification.
-  #         failure-state: Title does not follow the specification.
-  #         context-name: conventional-pr-title
-  #         preset: conventional-changelog-conventionalcommits@latest
-  #       env:
-  #         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: webiny/action-conventional-commits@v1.1.0
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   build-test:
     name: Build & Test
     runs-on: ubuntu-latest


### PR DESCRIPTION
This change switches the conventional commit PR title check to use the `amannn/action-semantic-pull-request@v5` action since the current one we use is no longer maintained and in a broken state.