### PR TITLE
fix: check for duplicate changes summary

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -535,8 +535,6 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 	// If the source has a previous tracked revision, compute changes against it
 	if w.lockfileOld != nil {
 		if targetLockOld, ok := w.lockfileOld.Targets[targetID]; ok {
-			fmt.Println("CURRENT DOCUMENT")
-			fmt.Println(currentDocument)
 			sourceRes.ChangeReport, err = w.computeChanges(ctx, rootStep, targetLockOld, currentDocument)
 			if err != nil {
 				// Don't fail the whole workflow if this fails


### PR DESCRIPTION
If we have a workflow file that has multiple targets generated which all read from the same source we can end up seeing duplicate change summary entries in github. Like [this](https://github.com/speakeasy-api/speakeasy-registry/pull/2210).



This check should allow us to see if we've already computed a changeSummary for this source. If we wanted to get more specific we could do source -> previous revision combination, but I think this could end up getting more confusing.