### PR TITLE
feat: directly link CLI to UX overview

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -5,11 +5,10 @@ import (
 	_ "embed"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
+	"github.com/pkg/browser"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 
@@ -287,7 +286,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	// There should only be one target after quickstart
 	if len(wf.SDKOverviewURLs) == 1 {
 		overviewURL := wf.SDKOverviewURLs[initialTarget]
-		openURLInBrowser(overviewURL)
+		browser.OpenURL(overviewURL)
 	}
 
 	return nil
@@ -350,7 +349,7 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 	// There should only be one target after quickstart
 	if err == nil && len(wf.SDKOverviewURLs) == 1 {
 		overviewURL := wf.SDKOverviewURLs[initialTarget]
-		openURLInBrowser(overviewURL)
+		browser.OpenURL(overviewURL)
 	}
 
 	return true, err
@@ -367,22 +366,4 @@ func setDefaultOutDir(workingDir string, sdkClassName string, targetType string)
 	}
 
 	return filepath.Join(workingDir, subDirectory)
-}
-
-func openURLInBrowser(url string) error {
-	var cmd *exec.Cmd
-	switch runtime.GOOS {
-	case "linux":
-		cmd = exec.Command("xdg-open", url)
-	case "windows":
-		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
-	case "darwin":
-		cmd = exec.Command("open", url)
-	default:
-		return fmt.Errorf("unsupported platform")
-	}
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-	return nil
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -708,7 +708,6 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	pl := bundler.NewPipeline(&bundler.PipelineOptions{})
 	memfs := fsextras.NewMemFS()
 
-
 	registryStep.NewSubstep("Snapshotting OpenAPI Revision")
 
 	rootDocumentPath, err := pl.Localize(ctx, memfs, bundler.LocalizeOptions{
@@ -910,7 +909,7 @@ func (w *Workflow) printGenerationOverview(logger log.Logger, endDuration time.D
 	}
 
 	msg := styles.RenderInstructionalMessage(
-		fmt.Sprintf("%s", styles.HeavilyEmphasized.Render("Generation Overview")),
+		fmt.Sprintf("%s", "Generation Summary"),
 		additionalLines...,
 	)
 	logger.Println(msg)
@@ -975,7 +974,7 @@ func (w *Workflow) printTargetSuccessMessage(logger log.Logger) {
 	heading := fmt.Sprintf("SDK Targets %s", styles.Success.Render("Generated Successfully"))
 	var additionalLines []string
 	for target, url := range w.SDKOverviewURLs {
-		additionalLines = append(additionalLines, styles.Success.Render(fmt.Sprintf("└─%s overview: ", target)+styles.Dimmed.Render(url)))
+		additionalLines = append(additionalLines, styles.Success.Render(fmt.Sprintf("└─%s overview: ", styles.HeavilyEmphasized.Render(target))+styles.Dimmed.Render(url)))
 	}
 
 	msg := fmt.Sprintf("%s\n%s\n", styles.Success.Render(heading), strings.Join(additionalLines, "\n"))

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -39,7 +39,7 @@ func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, he
 	logger := log.From(ctx).WithAssociatedFile(schemaPath)
 
 	generationAccess, level, message, _ := access.HasGenerationAccess(ctx, &access.GenerationAccessArgs{
-		GenLockID:  getGenLockID(outDir),
+		GenLockID:  GetGenLockID(outDir),
 		TargetType: &lang,
 	})
 
@@ -185,7 +185,7 @@ func ValidateConfig(ctx context.Context, outDir string) error {
 	return nil
 }
 
-func getGenLockID(outDir string) *string {
+func GetGenLockID(outDir string) *string {
 	if utils.FileExists(filepath.Join(utils.SanitizeFilePath(outDir), ".speakeasy/gen.lock")) || utils.FileExists(filepath.Join(utils.SanitizeFilePath(outDir), ".gen/gen.lock")) {
 		if cfg, err := gen_config.Load(outDir); err == nil && cfg.LockFile != nil {
 			return &cfg.LockFile.ID


### PR DESCRIPTION
We want to create more of a direct link between the CLI and our SDK UX overview.
- Always print overview links for each SDK target in speakeasy run
- In speakeasy quickstart best effort auto open the overview URL
<img width="758" alt="Screenshot 2024-05-15 at 12 05 22 PM" src="https://github.com/speakeasy-api/speakeasy/assets/42415738/18bb0794-eb13-49b4-ad1d-606f9fbac4a7">
