### PR TITLE
fix: don't panic on bad validation lineNums

### DIFF
--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -199,7 +199,7 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 	sb.WriteString(err.Message)
 	sb.WriteString("\n\n")
 
-	if err.LineNumber == -1 || err.LineNumber > len(lines)-1 || err.LineNumber < 0 {
+	if err.LineNumber < 0 || err.LineNumber > len(lines)-1 {
 		sb.WriteString(styles.Dimmed.Render("This error does not apply to any specific line."))
 		return sb.String()
 	}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -199,7 +199,7 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 	sb.WriteString(err.Message)
 	sb.WriteString("\n\n")
 
-	if err.LineNumber == -1 {
+	if err.LineNumber == -1 || err.LineNumber > len(lines)-1 || err.LineNumber < 0 {
 		sb.WriteString(styles.Dimmed.Render("This error does not apply to any specific line."))
 		return sb.String()
 	}
@@ -213,8 +213,8 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 	}
 
 	endLine := err.LineNumber + 3
-	if endLine > len(lines) {
-		endLine = len(lines)
+	if endLine > len(lines)-1 {
+		endLine = len(lines) - 1
 	}
 
 	shortestWhitespacePrefix := ""


### PR DESCRIPTION
Ideally we would just not return bogus line numbers, but this is a fine band-aid