### PR TITLE
feat: standardize publishing secret names

### DIFF
--- a/prompts/github.go
+++ b/prompts/github.go
@@ -75,90 +75,35 @@ func ConfigurePublishing(target *workflow.Target, name string) (*workflow.Target
 	promptMap := make(map[publishingPrompt]*string)
 	switch target.Target {
 	case "typescript":
-		currentNpmToken := npmTokenDefault
-		if target.Publishing != nil && target.Publishing.NPM != nil {
-			currentNpmToken = target.Publishing.NPM.Token
-		}
-		npmTokenVal := &currentNpmToken
-		promptMap[publishingPrompt{
-			key:       "NPM Token",
-			entryType: publishingTypeSecret,
-		}] = npmTokenVal
-		if err := executePromptsForPublishing(promptMap, target, name); err != nil {
-			return nil, err
-		}
 		target.Publishing = &workflow.Publishing{
 			NPM: &workflow.NPM{
-				Token: formatWorkflowSecret(*npmTokenVal),
+				Token: formatWorkflowSecret(npmTokenDefault),
 			},
 		}
 	case "python":
-		currentPyPIToken := pypiTokenDefault
-		if target.Publishing != nil && target.Publishing.PyPi != nil {
-			currentPyPIToken = target.Publishing.PyPi.Token
-		}
-		pypiTokenVal := &currentPyPIToken
-		promptMap[publishingPrompt{
-			key:       "PyPI Token",
-			entryType: publishingTypeSecret,
-		}] = pypiTokenVal
-		if err := executePromptsForPublishing(promptMap, target, name); err != nil {
-			return nil, err
-		}
 		target.Publishing = &workflow.Publishing{
 			PyPi: &workflow.PyPi{
-				Token: formatWorkflowSecret(*pypiTokenVal),
+				Token: formatWorkflowSecret(pypiTokenDefault),
 			},
 		}
 	case "csharp":
-		currentNugetKey := nugetTokenDefault
-		if target.Publishing != nil && target.Publishing.Nuget != nil {
-			currentNugetKey = target.Publishing.Nuget.APIKey
-		}
-		nugetKeyVal := &currentNugetKey
-		promptMap[publishingPrompt{
-			key:       "Nuget API Key",
-			entryType: publishingTypeSecret,
-		}] = nugetKeyVal
-		if err := executePromptsForPublishing(promptMap, target, name); err != nil {
-			return nil, err
-		}
 		target.Publishing = &workflow.Publishing{
 			Nuget: &workflow.Nuget{
-				APIKey: formatWorkflowSecret(*nugetKeyVal),
+				APIKey: formatWorkflowSecret(nugetTokenDefault),
 			},
 		}
 	case "ruby":
-		currentRubyGemsToken := rubyGemsTokenDefault
-		if target.Publishing != nil && target.Publishing.RubyGems != nil {
-			currentRubyGemsToken = target.Publishing.RubyGems.Token
-		}
-		rubyGemsTokenVal := &currentRubyGemsToken
-		promptMap[publishingPrompt{
-			key:       "Ruby Gems Auth Token",
-			entryType: publishingTypeSecret,
-		}] = rubyGemsTokenVal
-		if err := executePromptsForPublishing(promptMap, target, name); err != nil {
-			return nil, err
-		}
 		target.Publishing = &workflow.Publishing{
 			RubyGems: &workflow.RubyGems{
-				Token: formatWorkflowSecret(*rubyGemsTokenVal),
+				Token: formatWorkflowSecret(rubyGemsTokenDefault),
 			},
 		}
 	case "php":
-		currentPackagistToken := packagistTokenDefault
 		currentPackagistUserName := ""
 		if target.Publishing != nil && target.Publishing.Packagist != nil {
-			currentPackagistToken = target.Publishing.Packagist.Token
 			currentPackagistUserName = target.Publishing.Packagist.Username
 		}
-		packagistToken := &currentPackagistToken
 		packagistUsername := &currentPackagistUserName
-		promptMap[publishingPrompt{
-			key:       "Packagist Token",
-			entryType: publishingTypeSecret,
-		}] = packagistToken
 		promptMap[publishingPrompt{
 			key:       "Packagist Username",
 			entryType: publishingTypeValue,
@@ -168,38 +113,17 @@ func ConfigurePublishing(target *workflow.Target, name string) (*workflow.Target
 		}
 		target.Publishing = &workflow.Publishing{
 			Packagist: &workflow.Packagist{
-				Token:    formatWorkflowSecret(*packagistToken),
+				Token:    formatWorkflowSecret(packagistTokenDefault),
 				Username: *packagistUsername,
 			},
 		}
 	case "java":
 		sonatypeLegacy := target.Publishing != nil && target.Publishing.Java != nil && target.Publishing.Java.UseSonatypeLegacy
-		currentGPGSecretKey := gpgSecretKeyDefault
-		currentGPGPassPhrase := gpgPassPhraseDefault
-		currentossrhPassword := ossrhPasswordDefault
 		currentossrhUsername := ""
 		if target.Publishing != nil && target.Publishing.Java != nil {
-			currentGPGSecretKey = target.Publishing.Java.GPGSecretKey
-			currentGPGPassPhrase = target.Publishing.Java.GPGPassPhrase
-			currentossrhPassword = target.Publishing.Java.OSSHRPassword
 			currentossrhUsername = target.Publishing.Java.OSSRHUsername
 		}
-		gpgSecretKey := &currentGPGSecretKey
-		gpgPassPhrase := &currentGPGPassPhrase
-		ossrhPassword := &currentossrhPassword
 		ossrhUsername := &currentossrhUsername
-		promptMap[publishingPrompt{
-			key:       "GPG Secret Key",
-			entryType: publishingTypeSecret,
-		}] = gpgSecretKey
-		promptMap[publishingPrompt{
-			key:       "GPG Pass Phrase",
-			entryType: publishingTypeSecret,
-		}] = gpgPassPhrase
-		promptMap[publishingPrompt{
-			key:       "OSSRH Password",
-			entryType: publishingTypeSecret,
-		}] = ossrhPassword
 		promptMap[publishingPrompt{
 			key:       "OSSRH Username",
 			entryType: publishingTypeValue,
@@ -209,9 +133,9 @@ func ConfigurePublishing(target *workflow.Target, name string) (*workflow.Target
 		}
 		target.Publishing = &workflow.Publishing{
 			Java: &workflow.Java{
-				GPGSecretKey:      formatWorkflowSecret(*gpgSecretKey),
-				GPGPassPhrase:     formatWorkflowSecret(*gpgPassPhrase),
-				OSSHRPassword:     formatWorkflowSecret(*ossrhPassword),
+				GPGSecretKey:      formatWorkflowSecret(gpgSecretKeyDefault),
+				GPGPassPhrase:     formatWorkflowSecret(gpgPassPhraseDefault),
+				OSSHRPassword:     formatWorkflowSecret(ossrhPasswordDefault),
 				OSSRHUsername:     *ossrhUsername,
 				UseSonatypeLegacy: sonatypeLegacy,
 			},


### PR DESCRIPTION
Out github action requires publishing secrets to be placed in specific environment variables. We will start setting up workflows files and instructing users to put secrets in those variables rather than leaving variable name open to input.