### PR TITLE
fix: remove generate.WithAllowRemoteReferences

### DIFF
--- a/internal/docsgen/sdkgen.go
+++ b/internal/docsgen/sdkgen.go
@@ -71,7 +71,6 @@ func GenerateContent(ctx context.Context, inputLangs []string, customerID, schem
 		generate.WithRunLocation("cli"),
 		generate.WithGenVersion(strings.TrimPrefix(changelog.GetLatestVersion(), "v")),
 		generate.WithRepoDetails(repo, repoSubDir),
-		generate.WithAllowRemoteReferences(),
 		generate.WithSDKDocLanguages(langs...),
 	}
 

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -94,7 +94,6 @@ func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, he
 		generate.WithInstallationURL(installationURL),
 		generate.WithPublished(published),
 		generate.WithRepoDetails(repo, repoSubDir),
-		generate.WithAllowRemoteReferences(),
 		generate.WithCLIVersion(cliVersion),
 	}
 

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -60,7 +60,6 @@ func Generate(ctx context.Context, customerID, lang, schemaPath, header, token, 
 		generate.WithFileSystem(&fileSystem{buf: tmpOutput}),
 		generate.WithRunLocation("cli"),
 		generate.WithGenVersion(strings.TrimPrefix(changelog.GetLatestVersion(), "v")),
-		generate.WithAllowRemoteReferences(),
 		generate.WithForceGeneration(),
 	}
 


### PR DESCRIPTION
This option updates the CLI code since openapi-generation removed the `generate.WithAllowRemoteReferences` option recently. Remote references are always allowed now.

https://github.com/speakeasy-api/openapi-generation/pull/1243