### PR TITLE
fix: implicit pushing to registry

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -546,9 +546,11 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 	}
 
 	if !isSingleRegistrySource(source) {
-		err = w.snapshotSource(ctx, rootStep, sourceID, source, currentDocument)
-		if err != nil && !errors.Is(err, ocicommon.ErrAccessGated) {
-			return "", nil, err
+		if source.Registry != nil {
+			err = w.snapshotSource(ctx, rootStep, sourceID, source, currentDocument)
+			if err != nil && !errors.Is(err, ocicommon.ErrAccessGated) {
+				return "", nil, err
+			}
 		}
 	}
 


### PR DESCRIPTION
[Workflows like this one](https://github.com/speakeasy-api/sdk-generation-action-overlay-test/blob/main/.speakeasy/workflow.yaml) push to the registry despite no reference to the registry. This change fixes that.
