### PR TITLE
fix: validation of YAML files fail if they look like JSON

### DIFF
--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -67,6 +67,7 @@ func Apply(schema string, overlayFile string, w io.Writer) error {
 	}
 
 	enc := yaml.NewEncoder(w)
+	enc.SetIndent(2)
 	if err := enc.Encode(ys); err != nil {
 		return fmt.Errorf("failed to encode spec file %q: %w", specFile, err)
 	}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -2,12 +2,14 @@ package validation
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/reports"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"gopkg.in/yaml.v2"
 
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -105,6 +107,22 @@ func ValidateOpenAPI(ctx context.Context, source, schemaPath, header, token stri
 	}
 
 	prefixedLogger := logger.WithAssociatedFile(schemaPath).WithFormatter(log.PrefixedFormatter)
+
+	// If it's YAML but starts with { and ends with }, we need to reformat it as otherwise libopenapi will sniff this as JSON and then fail validation
+	var runes = strings.Split(strings.TrimSpace(string(schema)), "")
+	if runes[0] == "{" && runes[len(runes)-1] == "}" {
+		var parsedJSON map[string]interface{}
+		if err := json.Unmarshal(schema, &parsedJSON); err != nil {
+			var parsedYAML map[string]interface{}
+			// If we manage to parse as YAML then prettify it
+			if err := yaml.Unmarshal(schema, &parsedYAML); err == nil {
+				schema, err = yaml.Marshal(parsedYAML)
+				if err != nil {
+					return nil, fmt.Errorf("failed to marshal YAML: %w", err)
+				}
+			}
+		}
+	}
 
 	res, err := Validate(ctx, logger, schema, schemaPath, limits, isRemote, defaultRuleset, workingDir, isQuickstart)
 	if err != nil {


### PR DESCRIPTION
[Libopenapi sniffs whether a document is JSON or YAML based on whether the document starts with { and ends with }](https://github.com/pb33f/libopenapi/blob/f27d57aab08d3c63b47a22a67665c909b773391c/datamodel/spec_info.go#L71). It turns out that you can have a valid YAML document which starts with { and ends with } which has lead to a valid document failing validation. This workaround detects this edge case and reformats the document before validating if needed.
