### PR TITLE
feat: supply sdk version in generation run

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -258,6 +258,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		!flags.SkipCompile,
 		false,
 		[]string{},
+		"",
 	)
 	if err != nil {
 		return err
@@ -343,6 +344,7 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 		!skipCompile,
 		false,
 		[]string{},
+		"",
 	)
 
 	err = wf.RunWithVisualization(ctx)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -32,6 +32,7 @@ type RunFlags struct {
 	Output           string            `json:"output"`
 	Pinned           bool              `json:"pinned"`
 	RegistryTags     []string          `json:"registry-tags"`
+	Version          string            `json:"version"`
 }
 
 var runCmd = &model.ExecutableCommand[RunFlags]{
@@ -114,6 +115,11 @@ A full workflow is capable of running the following steps:
 		flag.StringSliceFlag{
 			Name:        "registry-tags",
 			Description: "tags to apply to the speakeasy registry bundle",
+		},
+		flag.StringFlag{
+			Name:        "version",
+			Shorthand:   "v",
+			Description: "the manual version to apply to the generated SDK",
 		},
 	},
 }
@@ -234,6 +240,7 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 		!flags.SkipCompile,
 		flags.Force,
 		flags.RegistryTags,
+		flags.Version,
 	)
 	if err != nil {
 		return err
@@ -261,6 +268,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		!flags.SkipCompile,
 		flags.Force,
 		flags.RegistryTags,
+		flags.Version,
 	)
 	if err != nil {
 		return err


### PR DESCRIPTION
 Allow a forced version to be passed in to speakeasy run. Typically this will be applied via workflow dispatch in github actions

Note: we do not explicitly check things like git releases in the CLI. This is the same behavior as `speakeasy bump` locally the user can supply whatever they want as long as it's a valid SEMVER version.

Things like the UX and GH Actions are what check against previous version see [here](https://github.com/speakeasy-api/sdk-generation-action/blob/main/internal/actions/runWorkflow.go#L74).