### PR TITLE
fix: prevent pushing registry entries to the wrong workspace

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -53,6 +53,8 @@ import (
 
 const minimumViableOverlayPath = "valid-overlay.yaml"
 
+const speakeasySelf = "speakeasy-self"
+
 type LintingError struct {
 	Err      error
 	Document string
@@ -695,7 +697,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			if "speakeasy-self" == auth.GetOrgSlugFromContext(ctx) && !env.IsGithubAction() {
+			if speakeasySelf == auth.GetOrgSlugFromContext(ctx) && !env.IsGithubAction() {
 				log.From(ctx).Warn(message)
 			} else {
 				return fmt.Errorf(message)
@@ -707,7 +709,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			if "speakeasy-self" == auth.GetWorkspaceSlugFromContext(ctx) && !env.IsGithubAction() {
+			if speakeasySelf == auth.GetWorkspaceSlugFromContext(ctx) && !env.IsGithubAction() {
 				log.From(ctx).Warn(message)
 			} else {
 				return fmt.Errorf(message)

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -689,12 +689,17 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			log.From(ctx).Warnf("error parsing registry location %s: %v", string(source.Registry.Location), err)
 		}
 
+		// If not match and
 		if orgSlug != auth.GetOrgSlugFromContext(ctx) {
 			message := fmt.Sprintf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			return fmt.Errorf(message)
+			if "speakeasy-self" == auth.GetOrgSlugFromContext(ctx) && !env.IsGithubAction() {
+				log.From(ctx).Warn(message)
+			} else {
+				return fmt.Errorf(message)
+			}
 		}
 
 		if workspaceSlug != auth.GetWorkspaceSlugFromContext(ctx) {
@@ -702,7 +707,11 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			return fmt.Errorf(message)
+			if "speakeasy-self" == auth.GetWorkspaceSlugFromContext(ctx) && !env.IsGithubAction() {
+				log.From(ctx).Warn(message)
+			} else {
+				return fmt.Errorf(message)
+			}
 		}
 
 		namespaceName = name

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -691,7 +691,6 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			log.From(ctx).Warnf("error parsing registry location %s: %v", string(source.Registry.Location), err)
 		}
 
-		// If not match and
 		if orgSlug != auth.GetOrgSlugFromContext(ctx) {
 			message := fmt.Sprintf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
 			if !env.IsGithubAction() {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -690,19 +690,19 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 		}
 
 		if orgSlug != auth.GetOrgSlugFromContext(ctx) {
-			if env.IsGithubAction() {
-				return fmt.Errorf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
+			message := fmt.Sprintf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
+			if !env.IsGithubAction() {
+				message += " run `speakeasy auth logout`"
 			}
-
-			log.From(ctx).Warnf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
+			return fmt.Errorf(message)
 		}
 
 		if workspaceSlug != auth.GetWorkspaceSlugFromContext(ctx) {
-			if env.IsGithubAction() {
-				return fmt.Errorf("current authenticated workspace %s does not match provided location %s", auth.GetWorkspaceSlugFromContext(ctx), string(source.Registry.Location))
+			message := fmt.Sprintf("current authenticated workspace %s does not match provided location %s", auth.GetWorkspaceSlugFromContext(ctx), string(source.Registry.Location))
+			if !env.IsGithubAction() {
+				message += " run `speakeasy auth logout`"
 			}
-
-			log.From(ctx).Warnf("current authenticated workspace %s does not match provided location %s", auth.GetWorkspaceSlugFromContext(ctx), string(source.Registry.Location))
+			return fmt.Errorf(message)
 		}
 
 		namespaceName = name


### PR DESCRIPTION
A common case which I have hit
* Run `speakeasy run` in workspace 1
* Switch directory and run `speakeasy run` ends up pushing bogus registry entries to workspace 1