### PR TITLE
fix(configure): GitHub Secret instructions for workspace API Key URL

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -505,10 +505,8 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 
 	logger := log.From(ctx)
 
-	workspaceID, err := core.GetWorkspaceIDFromContext(ctx)
-	if err != nil {
-		return err
-	}
+	orgSlug := core.GetOrgSlugFromContext(ctx)
+	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
 
 	workflowFile, _, _ := workflow.Load(workingDir)
 	if workflowFile == nil {
@@ -693,7 +691,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	}
 
 	if !autoConfigureRepoSuccess {
-		agenda = append(agenda, fmt.Sprintf("• Setup a Speakeasy API Key as a GitHub Secret - %s/workspaces/%s/apikeys", core.GetServerURL(), workspaceID))
+		agenda = append(agenda, fmt.Sprintf("• Setup a Speakeasy API Key as a GitHub Secret - %s/org/%s/%s/settings/api-keys", core.GetServerURL(), orgSlug, workspaceSlug))
 	}
 
 	if len(secrets) > 2 || !autoConfigureRepoSuccess {


### PR DESCRIPTION
Previously, the URL returned in the developer instructions would 404, e.g.

```
│ • Setup a Speakeasy API Key as a GitHub Secret - https://app.speakeasyapi.dev/workspaces/clxvz22lp00003b6jplb1ix37/apikeys
```

Now the URL returned is correct:

```
│ • Setup a Speakeasy API Key as a GitHub Secret - https://app.speakeasyapi.dev/org/playground-wnq/playground-testing/settings/api-keys
```