### PR TITLE
chore: cleaner failure state on workflowTracking

### DIFF
--- a/internal/workflowTracking/workflowTracking.go
+++ b/internal/workflowTracking/workflowTracking.go
@@ -91,9 +91,21 @@ func (w *WorkflowStep) FailWorkflow() {
 }
 
 func (w *WorkflowStep) Fail() {
+	w.failLastSubstep() // Otherwise the parent step might fail even though all the child steps say "success"
+
 	if w.status == StatusRunning {
 		w.status = StatusFailed
 		w.logger.Errorf("\nStep Failed: %s\n", w.name)
+	}
+}
+
+func (w *WorkflowStep) failLastSubstep() {
+	for i, substep := range w.substeps {
+		if len(substep.substeps) > 0 {
+			substep.failLastSubstep()
+		} else if i == len(w.substeps)-1 { // Fail the last substep only
+			substep.Fail()
+		}
 	}
 }
 


### PR DESCRIPTION
New:
<img width="621" alt="Screenshot 2024-06-27 at 3 49 48 PM" src="https://github.com/speakeasy-api/speakeasy/assets/90289500/185d1d76-dec6-428e-96b4-ccebcc0ca485">

Old:
<img width="590" alt="Screenshot 2024-06-27 at 3 49 56 PM" src="https://github.com/speakeasy-api/speakeasy/assets/90289500/cffa8bfb-f0b4-4247-9266-40aba73c0316">
