### PR TITLE
feat: support json output for overlays + maintain key ordering

### DIFF
--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -2,14 +2,13 @@ package cmd
 
 import (
 	"context"
-	"os"
-	"path/filepath"
-
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"github.com/speakeasy-api/speakeasy/internal/overlay"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"os"
 )
 
 var overlayFlag = flag.StringFlag{
@@ -104,9 +103,7 @@ func runApply(ctx context.Context, flags overlayApplyFlags) error {
 		defer file.Close()
 		out = file
 
-		if filepath.Ext(flags.Out) == ".json" {
-			yamlOut = false
-		}
+		yamlOut = utils.FileIsYAML(flags.Out)
 	}
 
 	return overlay.Apply(flags.Schema, flags.Overlay, yamlOut, out)

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -103,7 +103,7 @@ func runApply(ctx context.Context, flags overlayApplyFlags) error {
 		defer file.Close()
 		out = file
 
-		yamlOut = utils.FileIsYAML(flags.Out)
+		yamlOut = utils.HasYAMLExt(flags.Out)
 	}
 
 	return overlay.Apply(flags.Schema, flags.Overlay, yamlOut, out)

--- a/cmd/overlay.go
+++ b/cmd/overlay.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"os"
+	"path/filepath"
 
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/log"
@@ -93,6 +94,8 @@ func runCompare(ctx context.Context, flags overlayCompareFlags) error {
 
 func runApply(ctx context.Context, flags overlayApplyFlags) error {
 	out := os.Stdout
+	yamlOut := true
+
 	if flags.Out != "" {
 		file, err := os.Create(flags.Out)
 		if err != nil {
@@ -100,7 +103,11 @@ func runApply(ctx context.Context, flags overlayApplyFlags) error {
 		}
 		defer file.Close()
 		out = file
+
+		if filepath.Ext(flags.Out) == ".json" {
+			yamlOut = false
+		}
 	}
 
-	return overlay.Apply(flags.Schema, flags.Overlay, out)
+	return overlay.Apply(flags.Schema, flags.Overlay, yamlOut, out)
 }

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -7,10 +7,9 @@ import (
 	"github.com/pb33f/libopenapi/json"
 	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
 	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"gopkg.in/yaml.v3"
 	"io"
-	"path/filepath"
-	"slices"
 )
 
 func Validate(overlayFile string) error {
@@ -70,7 +69,7 @@ func Apply(schema string, overlayFile string, yamlOut bool, w io.Writer) error {
 		return fmt.Errorf("failed to apply overlay to spec file %q: %w", specFile, err)
 	}
 
-	bytes, err := render(ys, isYAML(schema), yamlOut)
+	bytes, err := render(ys, utils.FileIsYAML(schema), yamlOut)
 	if err != nil {
 		return fmt.Errorf("failed to render document: %w", err)
 	}
@@ -80,12 +79,6 @@ func Apply(schema string, overlayFile string, yamlOut bool, w io.Writer) error {
 	}
 
 	return nil
-}
-
-var yamlExtensions = []string{".yaml", ".yml"}
-
-func isYAML(path string) bool {
-	return slices.Contains(yamlExtensions, filepath.Ext(path))
 }
 
 func render(y *yaml.Node, yamlIn bool, yamlOut bool) ([]byte, error) {

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -1,12 +1,16 @@
 package overlay
 
 import (
+	"bytes"
 	"fmt"
-	"io"
-
+	"github.com/pb33f/libopenapi"
+	"github.com/pb33f/libopenapi/json"
 	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
 	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 	"gopkg.in/yaml.v3"
+	"io"
+	"path/filepath"
+	"slices"
 )
 
 func Validate(overlayFile string) error {
@@ -47,7 +51,7 @@ func Compare(schemas []string, w io.Writer) error {
 	return nil
 }
 
-func Apply(schema string, overlayFile string, w io.Writer) error {
+func Apply(schema string, overlayFile string, yamlOut bool, w io.Writer) error {
 	o, err := loader.LoadOverlay(overlayFile)
 	if err != nil {
 		return err
@@ -66,16 +70,58 @@ func Apply(schema string, overlayFile string, w io.Writer) error {
 		return fmt.Errorf("failed to apply overlay to spec file %q: %w", specFile, err)
 	}
 
-	// Decode into an interface{} to avoid preserving the original formatting of the input file
-	// otherwise this can result in 1 line YAML files
-	var unformattedYaml interface{}
-	ys.Decode(&unformattedYaml)
+	bytes, err := render(ys, isYAML(schema), yamlOut)
+	if err != nil {
+		return fmt.Errorf("failed to render document: %w", err)
+	}
 
-	enc := yaml.NewEncoder(w)
-	enc.SetIndent(2)
-	if err := enc.Encode(unformattedYaml); err != nil {
-		return fmt.Errorf("failed to encode spec file %q: %w", specFile, err)
+	if _, err := w.Write(bytes); err != nil {
+		return fmt.Errorf("failed to write to output: %w", err)
 	}
 
 	return nil
+}
+
+var yamlExtensions = []string{".yaml", ".yml"}
+
+func isYAML(path string) bool {
+	return slices.Contains(yamlExtensions, filepath.Ext(path))
+}
+
+func render(y *yaml.Node, yamlIn bool, yamlOut bool) ([]byte, error) {
+	if yamlIn && yamlOut {
+		var res bytes.Buffer
+		if err := yaml.NewEncoder(&res).Encode(y); err != nil {
+			return nil, fmt.Errorf("failed to encode YAML: %w", err)
+		}
+		return res.Bytes(), nil
+	}
+
+	// Preserves key ordering
+	specBytes, err := json.YAMLNodeToJSON(y, "  ")
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert YAML to JSON: %w", err)
+	}
+
+	if yamlOut {
+		// Use libopenapi to convert JSON to YAML to preserve key ordering
+		doc, err := libopenapi.NewDocument(specBytes)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert JSON to YAML: %w", err)
+		}
+
+		model, errs := doc.BuildV3Model()
+		if len(errs) > 0 {
+			return nil, fmt.Errorf("failed to build V3 model: %v", errs)
+		}
+
+		yamlBytes, err := model.Model.Render()
+		if err != nil {
+			return nil, fmt.Errorf("failed to render YAML: %w", err)
+		}
+
+		return yamlBytes, nil
+	} else {
+		return specBytes, nil
+	}
 }

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -69,7 +69,7 @@ func Apply(schema string, overlayFile string, yamlOut bool, w io.Writer) error {
 		return fmt.Errorf("failed to apply overlay to spec file %q: %w", specFile, err)
 	}
 
-	bytes, err := render(ys, utils.FileIsYAML(schema), yamlOut)
+	bytes, err := render(ys, utils.HasYAMLExt(schema), yamlOut)
 	if err != nil {
 		return fmt.Errorf("failed to render document: %w", err)
 	}

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -51,5 +51,7 @@ func test(t *testing.T, schemaFile string, expectedFile string, yamlOut bool) {
 	actualContent, err := os.ReadFile(tmpFile.Name())
 	assert.NoError(t, err)
 
+	println(string(actualContent))
+
 	assert.Equal(t, string(expectedContent), string(actualContent))
 }

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -1,4 +1,3 @@
-
 package overlay
 
 import (
@@ -10,18 +9,40 @@ import (
 )
 
 const (
-	schemaFile    = "testdata/base.yaml"
-	overlayFile   = "testdata/overlay.yaml"
-	expectedFile  = "testdata/expected.yaml"
+	schemaFile               = "testdata/base.yaml"
+	schemaJSON               = "testdata/base.json"
+	overlayFile              = "testdata/overlay.yaml"
+	expectedFile             = "testdata/expected.yaml"
+	expectedFileJSON         = "testdata/expected.json"
+	expectedFileYAMLFromJSON = "testdata/expectedWrapped.yaml"
 )
 
+func TestApply_inYAML_outYAML(t *testing.T) {
+	test(t, schemaFile, expectedFile, true)
+}
 
-func TestApply(t *testing.T) {
-	tmpFile, err := os.CreateTemp("", "output.yaml")
+func TestApply_inJSON_outJSON(t *testing.T) {
+	test(t, schemaJSON, expectedFileJSON, false)
+}
+
+func TestApply_inYAML_outJSON(t *testing.T) {
+	test(t, schemaFile, expectedFileJSON, false)
+}
+
+func TestApply_inJSON_outYAML(t *testing.T) {
+	test(t, schemaJSON, expectedFileYAMLFromJSON, true)
+}
+
+func test(t *testing.T, schemaFile string, expectedFile string, yamlOut bool) {
+	ext := "json"
+	if yamlOut {
+		ext = "yaml"
+	}
+	tmpFile, err := os.CreateTemp("", "output."+ext)
 	require.NoError(t, err)
 	defer tmpFile.Close()
 
-	err = Apply(schemaFile, overlayFile, tmpFile)
+	err = Apply(schemaFile, overlayFile, yamlOut, tmpFile)
 	assert.NoError(t, err)
 
 	expectedContent, err := os.ReadFile(expectedFile)

--- a/internal/overlay/testdata/base.json
+++ b/internal/overlay/testdata/base.json
@@ -21,6 +21,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./components.yaml#/components/schemas/Products"
+                }
+              }
+            }
           }
         }
       }

--- a/internal/overlay/testdata/base.json
+++ b/internal/overlay/testdata/base.json
@@ -1,0 +1,29 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test",
+    "version": "0.1.0",
+    "summary": "Test Summary",
+    "description": "Some test description.\nAbout our test document."
+  },
+  "paths": {
+    "/anything/selectGlobalServer": {
+      "x-my-ignore": true,
+      "get": {
+        "operationId": "selectGlobalServer",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Optional-Header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/internal/overlay/testdata/base.yaml
+++ b/internal/overlay/testdata/base.yaml
@@ -18,3 +18,9 @@ paths:
             X-Optional-Header:
               schema:
                 type: string
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "./components.yaml#/components/schemas/Products"

--- a/internal/overlay/testdata/components.yaml
+++ b/internal/overlay/testdata/components.yaml
@@ -1,0 +1,30 @@
+openapi: 3.1.0
+components:
+  schemas:
+    Products:
+      type: array
+      items:
+        $ref: '#/components/schemas/Product'
+    Product:
+      type: object
+      required:
+        - id
+        - name
+        - price
+        - stock
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        price:
+          type: number
+          format: double
+        tags:
+          type: array
+          items:
+            type: string
+        stock:
+          type: integer
+          # TODO: Figure out why this breaks merge step

--- a/internal/overlay/testdata/expected.json
+++ b/internal/overlay/testdata/expected.json
@@ -28,6 +28,16 @@
                 }
               }
             }
+          },
+          "404": {
+            "description": "Not found",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "./components.yaml#/components/schemas/Products"
+                }
+              }
+            }
           }
         },
         "servers": [

--- a/internal/overlay/testdata/expected.json
+++ b/internal/overlay/testdata/expected.json
@@ -1,0 +1,42 @@
+{
+  "openapi": "3.1.0",
+  "info": {
+    "title": "Test",
+    "version": "0.1.0",
+    "summary": "Test Summary",
+    "description": "Some test description.\nAbout our test document."
+  },
+  "paths": {
+    "/anything/selectGlobalServer": {
+      "x-my-ignore": {
+        "servers": [
+          {
+            "url": "http://localhost:35123",
+            "description": "The default server."
+          }
+        ]
+      },
+      "get": {
+        "operationId": "selectGlobalServer",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "headers": {
+              "X-Optional-Header": {
+                "schema": {
+                  "type": "string"
+                }
+              }
+            }
+          }
+        },
+        "servers": [
+          {
+            "url": "http://localhost:35123",
+            "description": "The default server."
+          }
+        ]
+      }
+    }
+  }
+}

--- a/internal/overlay/testdata/expected.yaml
+++ b/internal/overlay/testdata/expected.yaml
@@ -21,6 +21,12 @@ paths:
                         X-Optional-Header:
                             schema:
                                 type: string
+                "404":
+                    description: Not found
+                    content:
+                        application/json:
+                            schema:
+                                $ref: "./components.yaml#/components/schemas/Products"
             servers:
                 - url: http://localhost:35123
                   description: The default server.

--- a/internal/overlay/testdata/expectedWrapped.yaml
+++ b/internal/overlay/testdata/expectedWrapped.yaml
@@ -1,0 +1,21 @@
+openapi: "3.1.0"
+info:
+    title: "Test"
+    version: "0.1.0"
+    summary: "Test Summary"
+    description: "Some test description.\nAbout our test document."
+paths:
+    "/anything/selectGlobalServer":
+        x-my-ignore: {"servers": [{"url": "http://localhost:35123", "description": "The default server."}]}
+        get:
+            operationId: "selectGlobalServer"
+            responses:
+                "200":
+                    description: "OK"
+                    headers:
+                        "X-Optional-Header":
+                            schema:
+                                type: "string"
+            servers:
+                - url: "http://localhost:35123"
+                  description: "The default server."

--- a/internal/overlay/testdata/expectedWrapped.yaml
+++ b/internal/overlay/testdata/expectedWrapped.yaml
@@ -16,6 +16,11 @@ paths:
                         "X-Optional-Header":
                             schema:
                                 type: "string"
+                "404":
+                    description: "Not found"
+                    content:
+                        "application/json":
+                            schema: {"$ref": "./components.yaml#/components/schemas/Products"}
             servers:
                 - url: "http://localhost:35123"
                   description: "The default server."

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -561,7 +561,7 @@ func overlayDocument(ctx context.Context, schema string, overlayFiles []string, 
 			return err
 		}
 
-		if err := overlay.Apply(currentBase, overlayFile, true, tempOutFile); err != nil {
+		if err := overlay.Apply(currentBase, overlayFile, utils.HasYAMLExt(applyPath), tempOutFile); err != nil {
 			return err
 		}
 

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -561,7 +561,7 @@ func overlayDocument(ctx context.Context, schema string, overlayFiles []string, 
 			return err
 		}
 
-		if err := overlay.Apply(currentBase, overlayFile, tempOutFile); err != nil {
+		if err := overlay.Apply(currentBase, overlayFile, true, tempOutFile); err != nil {
 			return err
 		}
 

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -23,7 +23,7 @@ import (
 )
 
 func Suggest(ctx context.Context, schemaLocation, outPath string, asOverlay bool, style shared.Style, depthStyle shared.DepthStyle) error {
-	if asOverlay && !utils.FileIsYAML(outPath) {
+	if asOverlay && !utils.HasYAMLExt(outPath) {
 		return fmt.Errorf("output path must be a YAML or YML file when generating an overlay. Set --overlay=false to write an updated spec")
 	}
 
@@ -90,7 +90,7 @@ func Suggest(ctx context.Context, schemaLocation, outPath string, asOverlay bool
 		}
 	} else {
 		// Output yaml if output path is yaml, json if output path is json
-		if utils.FileIsYAML(outPath) {
+		if utils.HasYAMLExt(outPath) {
 			if _, err = outFile.Write(finalBytesYAML); err != nil {
 				return err
 			}

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -3,9 +3,9 @@ package suggest
 import (
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
@@ -23,7 +23,7 @@ import (
 )
 
 func Suggest(ctx context.Context, schemaLocation, outPath string, asOverlay bool, style shared.Style, depthStyle shared.DepthStyle) error {
-	if asOverlay && !isYAML(outPath) {
+	if asOverlay && !utils.FileIsYAML(outPath) {
 		return fmt.Errorf("output path must be a YAML or YML file when generating an overlay. Set --overlay=false to write an updated spec")
 	}
 
@@ -90,7 +90,7 @@ func Suggest(ctx context.Context, schemaLocation, outPath string, asOverlay bool
 		}
 	} else {
 		// Output yaml if output path is yaml, json if output path is json
-		if isYAML(outPath) {
+		if utils.FileIsYAML(outPath) {
 			if _, err = outFile.Write(finalBytesYAML); err != nil {
 				return err
 			}
@@ -154,9 +154,4 @@ func printSuggestions(ctx context.Context, updates []suggestions.OperationUpdate
 		l := lipgloss.NewStyle().Width(maxWidth).Render(lhs[i])
 		logger.Printf("%s %s %s", l, arrow, rhs[i])
 	}
-}
-
-func isYAML(path string) bool {
-	ext := filepath.Ext(path)
-	return ext == ".yaml" || ext == ".yml"
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"unicode"
 
@@ -179,4 +180,10 @@ func getSetFlags(flags *pflag.FlagSet) []*pflag.Flag {
 // For these customers we limit callbacks to the speakeasy server outside of auth
 func IsZeroTelemetryOrganization(ctx context.Context) bool {
 	return core.IsTelemetryDisabled(ctx)
+}
+
+var yamlExtensions = []string{".yaml", ".yml"}
+
+func FileIsYAML(path string) bool {
+	return slices.Contains(yamlExtensions, filepath.Ext(path))
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -184,6 +184,6 @@ func IsZeroTelemetryOrganization(ctx context.Context) bool {
 
 var yamlExtensions = []string{".yaml", ".yml"}
 
-func FileIsYAML(path string) bool {
+func HasYAMLExt(path string) bool {
 	return slices.Contains(yamlExtensions, filepath.Ext(path))
 }


### PR DESCRIPTION
Fixes several issues:
- Properly outputs JSON if the requested filetype is JSON
- Maintains key ordering when applying overlays

Risk areas:
- Some customers might be expecting the current (wrong) behavior, in which we output json into `.yaml` files 