### PR TITLE
chore: add new change summary form

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,6 +41,7 @@ require (
 	github.com/inkeep/ai-api-go v0.3.1
 	github.com/pb33f/openapi-changes v0.0.61
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/speakeasy-api/versioning-reports v0.2.1
 	github.com/stoewer/go-strcase v1.3.0
 )
 
@@ -186,7 +187,6 @@ require (
 	github.com/speakeasy-api/jsonpath v0.1.0 // indirect
 	github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 // indirect
 	github.com/speakeasy-api/speakeasy-schemas v1.3.0 // indirect
-	github.com/speakeasy-api/versioning-reports v0.2.0 // indirect
 	github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd // indirect
 	github.com/spf13/afero v1.11.0 // indirect
 	github.com/spf13/cast v1.6.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.0.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.365.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.366.1
 	github.com/speakeasy-api/openapi-overlay v0.6.0
 	github.com/speakeasy-api/sdk-gen-config v1.16.1
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.8.9
@@ -41,7 +41,7 @@ require (
 	github.com/inkeep/ai-api-go v0.3.1
 	github.com/pb33f/openapi-changes v0.0.61
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
-	github.com/speakeasy-api/versioning-reports v0.2.1
+	github.com/speakeasy-api/versioning-reports v0.3.1
 	github.com/stoewer/go-strcase v1.3.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNID
 github.com/speakeasy-api/speakeasy-proxy v0.0.2/go.mod h1:cvMxdIEPYAvXS5mpYMU6CuJRPQnhq4gRXKE7xeCP/V0=
 github.com/speakeasy-api/speakeasy-schemas v1.3.0 h1:7Arm2d0/K9owEBQPmNon1KPERmf58g0Eg/NmPgXaEY0=
 github.com/speakeasy-api/speakeasy-schemas v1.3.0/go.mod h1:g6NfrOjYLCJZp81ZLY2ksF7afC9BW9bL4Bg1V1oAFlw=
-github.com/speakeasy-api/versioning-reports v0.2.0 h1:ha0B8q8rY+KD6ETTOKXkfs/p3Tb3xIN3l9/LUoG34rY=
-github.com/speakeasy-api/versioning-reports v0.2.0/go.mod h1:e3cvYTwPB3RJdgAPbf7Gc6BDfBM63bF3V+In2yKbHWs=
+github.com/speakeasy-api/versioning-reports v0.2.1 h1:bf6PayXjF2vpvy8St7XTUcQA2Jd0rPvxsrimOrn/ASg=
+github.com/speakeasy-api/versioning-reports v0.2.1/go.mod h1:e3cvYTwPB3RJdgAPbf7Gc6BDfBM63bF3V+In2yKbHWs=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd h1:csraKifkLpqDClUIbFTetjtraueL1KUhKBm6okL+ug4=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd/go.mod h1:cyGycBxnlCATLUv5jtPwaHnkiYomNWzXQougLmaCTzU=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/go.sum
+++ b/go.sum
@@ -492,6 +492,8 @@ github.com/speakeasy-api/jsonpath v0.1.0 h1:bzdbTty5bfMWSd1ZTlmWoldVyBsGC6mqvwer
 github.com/speakeasy-api/jsonpath v0.1.0/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/openapi-generation/v2 v2.365.0 h1:ROY1cCV6dge4fuXLDbopNDztYuTZfQiJDmjkTPTiFrg=
 github.com/speakeasy-api/openapi-generation/v2 v2.365.0/go.mod h1:UbZunE41YIEY/pnaP9aDt0Tyrhc2s+YP+VFrLnYIY94=
+github.com/speakeasy-api/openapi-generation/v2 v2.366.1 h1:1zISPjbN7rBBA4Ao6x+OuygFUgvvig+g6YEYjtwiBA8=
+github.com/speakeasy-api/openapi-generation/v2 v2.366.1/go.mod h1:V0fWmQY6/6moi5WF9sFbGBcVmVUa/aF+gxKSfKZVEsc=
 github.com/speakeasy-api/openapi-overlay v0.6.0 h1:LqJWrE2nBE16lgGVkIhN4OceXpMZI4qHymuIgXmDIno=
 github.com/speakeasy-api/openapi-overlay v0.6.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.16.1 h1:/+Rr7LjrfviA92/NBDMSnvp0ltPTAlOtKsrpL7rBlYc=
@@ -508,6 +510,7 @@ github.com/speakeasy-api/speakeasy-schemas v1.3.0 h1:7Arm2d0/K9owEBQPmNon1KPERmf
 github.com/speakeasy-api/speakeasy-schemas v1.3.0/go.mod h1:g6NfrOjYLCJZp81ZLY2ksF7afC9BW9bL4Bg1V1oAFlw=
 github.com/speakeasy-api/versioning-reports v0.2.1 h1:bf6PayXjF2vpvy8St7XTUcQA2Jd0rPvxsrimOrn/ASg=
 github.com/speakeasy-api/versioning-reports v0.2.1/go.mod h1:e3cvYTwPB3RJdgAPbf7Gc6BDfBM63bF3V+In2yKbHWs=
+github.com/speakeasy-api/versioning-reports v0.3.1/go.mod h1:LW5FABrvi5SBbeiD3HJYw0JZYe6Rw2Xna59pFJ2BmLI=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd h1:csraKifkLpqDClUIbFTetjtraueL1KUhKBm6okL+ug4=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd/go.mod h1:cyGycBxnlCATLUv5jtPwaHnkiYomNWzXQougLmaCTzU=
 github.com/spf13/afero v1.11.0 h1:WJQKhtpdm3v2IzqG8VMqrr6Rf3UYpEF239Jy9wNepM8=

--- a/go.sum
+++ b/go.sum
@@ -490,8 +490,6 @@ github.com/speakeasy-api/huh v1.0.0 h1:QXnwLB038QE/+t4NsrDFfaGqxL5B/+zwI6aY1MoRj
 github.com/speakeasy-api/huh v1.0.0/go.mod h1:mK3NAgt1YiqhPhEgxWdQeRCv9KmeLqfz2+KNCpuJ+yU=
 github.com/speakeasy-api/jsonpath v0.1.0 h1:bzdbTty5bfMWSd1ZTlmWoldVyBsGC6mqvwerwWM4dqQ=
 github.com/speakeasy-api/jsonpath v0.1.0/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
-github.com/speakeasy-api/openapi-generation/v2 v2.365.0 h1:ROY1cCV6dge4fuXLDbopNDztYuTZfQiJDmjkTPTiFrg=
-github.com/speakeasy-api/openapi-generation/v2 v2.365.0/go.mod h1:UbZunE41YIEY/pnaP9aDt0Tyrhc2s+YP+VFrLnYIY94=
 github.com/speakeasy-api/openapi-generation/v2 v2.366.1 h1:1zISPjbN7rBBA4Ao6x+OuygFUgvvig+g6YEYjtwiBA8=
 github.com/speakeasy-api/openapi-generation/v2 v2.366.1/go.mod h1:V0fWmQY6/6moi5WF9sFbGBcVmVUa/aF+gxKSfKZVEsc=
 github.com/speakeasy-api/openapi-overlay v0.6.0 h1:LqJWrE2nBE16lgGVkIhN4OceXpMZI4qHymuIgXmDIno=
@@ -508,8 +506,7 @@ github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNID
 github.com/speakeasy-api/speakeasy-proxy v0.0.2/go.mod h1:cvMxdIEPYAvXS5mpYMU6CuJRPQnhq4gRXKE7xeCP/V0=
 github.com/speakeasy-api/speakeasy-schemas v1.3.0 h1:7Arm2d0/K9owEBQPmNon1KPERmf58g0Eg/NmPgXaEY0=
 github.com/speakeasy-api/speakeasy-schemas v1.3.0/go.mod h1:g6NfrOjYLCJZp81ZLY2ksF7afC9BW9bL4Bg1V1oAFlw=
-github.com/speakeasy-api/versioning-reports v0.2.1 h1:bf6PayXjF2vpvy8St7XTUcQA2Jd0rPvxsrimOrn/ASg=
-github.com/speakeasy-api/versioning-reports v0.2.1/go.mod h1:e3cvYTwPB3RJdgAPbf7Gc6BDfBM63bF3V+In2yKbHWs=
+github.com/speakeasy-api/versioning-reports v0.3.1 h1:AtynRZBTAc1BcHWU984yHNBLoyBrf0M6F0xUWEIWFHI=
 github.com/speakeasy-api/versioning-reports v0.3.1/go.mod h1:LW5FABrvi5SBbeiD3HJYw0JZYe6Rw2Xna59pFJ2BmLI=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd h1:csraKifkLpqDClUIbFTetjtraueL1KUhKBm6okL+ug4=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd/go.mod h1:cyGycBxnlCATLUv5jtPwaHnkiYomNWzXQougLmaCTzU=

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -1,7 +1,9 @@
 package integration_tests
 
 import (
+	"context"
 	"fmt"
+	"github.com/speakeasy-api/versioning-reports/versioning"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -120,7 +122,11 @@ func TestGenerationWorkflows(t *testing.T) {
 				args = append(args, "--force", "true")
 			}
 
-			cmdErr := execute(t, temp, args...)
+			report, _, cmdErr := versioning.WithVersionReportCapture[bool](context.Background(), func(ctx context.Context) (bool, error) {
+				cmdErr := execute(t, temp, args...)
+				return cmdErr == nil, cmdErr
+			})
+			require.Len(t, report.Reports, 1)
 			require.NoError(t, cmdErr)
 
 			if tt.withCodeSamples {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -126,7 +126,8 @@ func TestGenerationWorkflows(t *testing.T) {
 				cmdErr := execute(t, temp, args...)
 				return cmdErr == nil, cmdErr
 			})
-			require.Len(t, report.Reports, 1)
+			require.Len(t, report.Reports, 2)
+			require.Truef(t, report.MustGenerate(), "no prior gen.lock -- should always generate")
 			require.NoError(t, cmdErr)
 
 			if tt.withCodeSamples {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"github.com/speakeasy-api/speakeasy/internal/changes"
+	"github.com/speakeasy-api/versioning-reports/versioning"
 	"os"
 	"regexp"
 	"strconv"
@@ -127,6 +128,14 @@ func GenerateChangesSummary(ctx context.Context, url string, summary changes.Sum
 		}
 		log.From(ctx).Infof("wrote changes summary to \"%s\"", filepath)
 	}
+
+	// New form -- the above form is deprecated.
+	_ = versioning.AddVersionReport(ctx, versioning.VersionReport{
+		MustGenerate: summary.Bump != changes.None,
+		Key:          "openapi_change_summary",
+		PRReport:     summary.Text,
+		Priority:     5, // High priority -- place at top
+	})
 }
 
 func GenerateWorkflowSummary(ctx context.Context, summary WorkflowSummary) {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -133,7 +133,7 @@ func GenerateChangesSummary(ctx context.Context, url string, summary changes.Sum
 	_ = versioning.AddVersionReport(ctx, versioning.VersionReport{
 		MustGenerate: summary.Bump != changes.None,
 		Key:          "openapi_change_summary",
-		PRReport:     summary.Text,
+		PRReport:     "## OpenAPI Change Summary\n" + summary.Text + "\n",
 		Priority:     5, // High priority -- place at top
 	})
 }

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -179,6 +179,14 @@ func (w *Workflow) runSource(ctx context.Context, parentStep *workflowTracking.W
 			}
 		}
 	}
+	if sourceRes.ChangeReport == nil {
+		// If we failed to compute changes, always generate the SDK
+		_ = versioning.AddVersionReport(ctx, versioning.VersionReport{
+			MustGenerate: true,
+			Key:          "openapi_change_summary",
+			Priority:     5,
+		})
+	}
 
 	sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.projectDir)
 	if err != nil {
@@ -218,11 +226,6 @@ func (w *Workflow) computeChanges(ctx context.Context, rootStep *workflowTrackin
 	} else {
 		changesStep.Skip("no previous revision found")
 
-		_ = versioning.AddVersionReport(ctx, versioning.VersionReport{
-			MustGenerate: true,
-			Key:          "openapi_change_summary",
-			Priority:     5,
-		})
 		return
 	}
 

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/versioning-reports/versioning"
 	"io"
 	"io/fs"
 	"math/rand"
@@ -216,6 +217,12 @@ func (w *Workflow) computeChanges(ctx context.Context, rootStep *workflowTrackin
 			targetLock.SourceNamespace, targetLock.SourceRevisionDigest)
 	} else {
 		changesStep.Skip("no previous revision found")
+
+		_ = versioning.AddVersionReport(ctx, versioning.VersionReport{
+			MustGenerate: true,
+			Key:          "openapi_change_summary",
+			Priority:     5,
+		})
 		return
 	}
 


### PR DESCRIPTION
Part of a body of work that will stop SDK flux. Safe to deploy alone -- behind a feature toggle with an environment variable.

Also upgrades to latest openapi-generation version