### PR TITLE
chore: make yaml default indentation 2

### DIFF
--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -3,6 +3,7 @@ package integration_tests
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -34,8 +35,8 @@ func TestMain(m *testing.M) {
 
 func setupTestDir(t *testing.T) string {
 	t.Helper()
-	workingDir, err := os.Getwd()
-	assert.NoError(t, err)
+	_, filename, _, _ := runtime.Caller(0)
+	workingDir := filepath.Dir(filename)
 	temp, err := createTempDir()
 	assert.NoError(t, err)
 	registerCleanup(t, workingDir, temp)

--- a/integration/overlay_test.go
+++ b/integration/overlay_test.go
@@ -1,0 +1,32 @@
+package integration_tests
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestOverlayMatchesSnapshot(t *testing.T) {
+	t.Parallel()
+	_, filename, _, _ := runtime.Caller(0)
+	overlayFolder := filepath.Join(filepath.Dir(filename), "resources", "overlay")
+	overlayFilePath, err := filepath.Abs(filepath.Join(overlayFolder, "overlay.yaml"))
+	require.NoError(t, err)
+	schemaFilePath, err := filepath.Abs(filepath.Join(overlayFolder, "openapi.yaml"))
+	require.NoError(t, err)
+	expectedBytes, err := os.ReadFile(filepath.Join(overlayFolder, "openapi-overlayed-expected.yaml"))
+	require.NoError(t, err)
+
+	temp := setupTestDir(t)
+	outputPath, err := filepath.Abs(filepath.Join(temp, "output.yaml"))
+	require.NoError(t, err)
+
+	args := []string{"overlay", "apply", "--schema", schemaFilePath, "--overlay", overlayFilePath, "--out", outputPath}
+	cmdErr := execute(t, temp, args...)
+	require.NoError(t, cmdErr)
+	readBytes, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	require.Equal(t, string(expectedBytes), string(readBytes))
+}

--- a/integration/resources/overlay/openapi-overlayed-expected.yaml
+++ b/integration/resources/overlay/openapi-overlayed-expected.yaml
@@ -1,0 +1,440 @@
+openapi: 3.1.0
+info:
+  title: The Speakeasy Bar
+  version: 1.0.0
+  summary: A bar that serves drinks.
+  description: A secret underground bar that serves drinks to those in the know.
+  contact:
+    name: Speakeasy Support
+    url: https://support.speakeasy.bar
+    email: support@speakeasy.bar
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  termsOfService: https://speakeasy.bar/terms
+externalDocs:
+  url: https://docs.speakeasy.bar
+  description: The Speakeasy Bar Documentation.
+servers:
+  - url: https://speakeasy.bar
+    description: The production server.
+    x-speakeasy-server-id: prod
+  - url: https://staging.speakeasy.bar
+    description: The staging server.
+    x-speakeasy-server-id: staging
+  - url: https://{organization}.{environment}.speakeasy.bar
+    description: A per-organization and per-environment API.
+    x-speakeasy-server-id: customer
+    variables:
+      organization:
+        description: The organization name. Defaults to a generic organization.
+        default: api
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+security:
+  - apiKey: []
+tags:
+  - name: drinks
+    description: The drinks endpoints.
+  - name: ingredients
+    description: The ingredients endpoints.
+  - name: orders
+    description: The orders endpoints.
+  - name: authentication
+    description: The authentication endpoints.
+  - name: config
+  - name: Testing
+    description: just a description
+paths:
+  x-speakeasy-errors:
+    statusCodes: # Defines status codes to handle as errors for all operations
+      - 4XX # Wildcard to handle all status codes in the 400-499 range
+      - 5XX
+  /anything/selectGlobalServer:
+    x-my-ignore:
+      servers:
+        - url: http://localhost:35123
+          description: The default server.
+    get:
+      operationId: selectGlobalServer
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Optional-Header:
+              schema:
+                type: string
+  /authenticate:
+    post:
+      operationId: authenticate
+      summary: Authenticate with the API by providing a username and password.
+      security: []
+      tags:
+        - authentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: The api key to use for authenticated endpoints.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        "401":
+          description: Invalid credentials provided.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+  /drinks:
+    x-speakeasy-note:
+      "$ref": "./removeNote.yaml"
+  /drink/{name}: # Example comment -- should be maintained
+    get:
+      operationId: getDrink
+      summary: Get a drink.
+      description: |
+        A long description
+        to validate that we handle indentation properly
+
+        With a second paragraph
+      tags:
+        - drinks
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - x-parameter-extension: foo
+          name: test
+          description: Test parameter
+          in: query
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Test response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Drink"
+                type: string
+          x-response-extension: foo
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+  /ingredients:
+    get:
+      operationId: listIngredients
+      summary: Get a list of ingredients.
+      description: Get a list of ingredients, if authenticated this will include stock levels and product codes otherwise it will only include public information.
+      tags:
+        - ingredients
+      parameters:
+        - name: ingredients
+          in: query
+          description: A list of ingredients to filter by. If not provided all ingredients will be returned.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: A list of ingredients.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Ingredient"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+  /order:
+    post:
+      operationId: createOrder
+      summary: Create an order.
+      description: Create an order for a drink.
+      tags:
+        - orders
+      parameters:
+        - name: callback_url
+          in: query
+          description: The url to call when the order is updated.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/Order"
+      responses:
+        "200":
+          description: The order was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+      callbacks:
+        orderUpdate:
+          "{$request.query.callback_url}":
+            post:
+              summary: Receive order updates.
+              description: Receive order updates from the supplier, this will be called whenever the status of an order changes.
+              tags:
+                - orders
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        order:
+                          $ref: "#/components/schemas/Order"
+              responses:
+                "200":
+                  description: The order update was received successfully.
+                "5XX":
+                  $ref: "#/components/responses/APIError"
+                default:
+                  $ref: "#/components/responses/UnknownError"
+  /webhooks/subscribe:
+    post:
+      operationId: subscribeToWebhooks
+      summary: Subscribe to webhooks.
+      description: Subscribe to webhooks.
+      tags:
+        - config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  url:
+                    type: string
+                  webhook:
+                    type: string
+                    enum:
+                      - stockUpdate
+      responses:
+        "200":
+          description: The webhook was subscribed to successfully.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+webhooks:
+  stockUpdate:
+    post:
+      summary: Receive stock updates.
+      description: Receive stock updates from the bar, this will be called whenever the stock levels of a drink or ingredient changes.
+      tags:
+        - drinks
+        - ingredients
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                drink:
+                  $ref: "#/components/schemas/Drink"
+                ingredient:
+                  $ref: "#/components/schemas/Ingredient"
+      responses:
+        "200":
+          description: The stock update was received successfully.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+components:
+  schemas:
+    APIError:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+    Drink:
+      type: object
+      properties:
+        name:
+          description: The name of the drink.
+          type: string
+          examples:
+            - Old Fashioned
+            - Manhattan
+            - Negroni
+        type:
+          $ref: "#/components/schemas/DrinkType"
+        price:
+          description: The price of one unit of the drink in US cents.
+          type: number
+          examples:
+            - 1000 # $10.00
+            - 1200 # $12.00
+            - 1500 # $15.00
+        stock:
+          description: The number of units of the drink in stock, only available when authenticated.
+          type: integer
+          readOnly: true
+        productCode:
+          description: The product code of the drink, only available when authenticated.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+      required:
+        - name
+        - price
+    DrinkType:
+      description: The type of drink.
+      type: string
+      enum:
+        - cocktail
+        - non-alcoholic
+        - beer
+        - wine
+        - spirit
+        - other
+    Ingredient:
+      type: object
+      properties:
+        name:
+          description: The name of the ingredient.
+          type: string
+          examples:
+            - Sugar Syrup
+            - Angostura Bitters
+            - Orange Peel
+        type:
+          $ref: "#/components/schemas/IngredientType"
+        stock:
+          description: The number of units of the ingredient in stock, only available when authenticated.
+          type: integer
+          examples:
+            - 10
+            - 5
+            - 0
+          readOnly: true
+        productCode:
+          description: The product code of the ingredient, only available when authenticated.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+      required:
+        - name
+        - type
+    IngredientType:
+      description: The type of ingredient.
+      type: string
+      enum:
+        - fresh
+        - long-life
+        - packaged
+    Order:
+      description: An order for a drink or ingredient.
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/OrderType"
+        productCode:
+          description: The product code of the drink or ingredient.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+        quantity:
+          description: The number of units of the drink or ingredient to order.
+          type: integer
+          minimum: 1
+        status:
+          description: The status of the order.
+          type: string
+          enum:
+            - pending
+            - processing
+            - complete
+          readOnly: true
+      required:
+        - type
+        - productCode
+        - quantity
+        - status
+    OrderType:
+      description: The type of order.
+      type: string
+      enum:
+        - drink
+        - ingredient
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: Authorization
+      in: header
+  responses:
+    APIError:
+      description: An error occurred interacting with the API.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIError"
+    UnknownError:
+      description: An unknown error occurred interacting with the API.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"

--- a/integration/resources/overlay/openapi.yaml
+++ b/integration/resources/overlay/openapi.yaml
@@ -1,0 +1,455 @@
+openapi: 3.1.0
+info:
+  title: The Speakeasy Bar
+  version: 1.0.0
+  summary: A bar that serves drinks.
+  description: A secret underground bar that serves drinks to those in the know.
+  contact:
+    name: Speakeasy Support
+    url: https://support.speakeasy.bar
+    email: support@speakeasy.bar
+  license:
+    name: Apache 2.0
+    url: https://www.apache.org/licenses/LICENSE-2.0.html
+  termsOfService: https://speakeasy.bar/terms
+externalDocs:
+  url: https://docs.speakeasy.bar
+  description: The Speakeasy Bar Documentation.
+servers:
+  - url: https://speakeasy.bar
+    description: The production server.
+    x-speakeasy-server-id: prod
+  - url: https://staging.speakeasy.bar
+    description: The staging server.
+    x-speakeasy-server-id: staging
+  - url: https://{organization}.{environment}.speakeasy.bar
+    description: A per-organization and per-environment API.
+    x-speakeasy-server-id: customer
+    variables:
+      organization:
+        description: The organization name. Defaults to a generic organization.
+        default: api
+      environment:
+        description: The environment name. Defaults to the production environment.
+        default: prod
+        enum:
+          - prod
+          - staging
+          - dev
+security:
+  - apiKey: []
+tags:
+  - name: drinks
+    description: The drinks endpoints.
+  - name: ingredients
+    description: The ingredients endpoints.
+  - name: orders
+    description: The orders endpoints.
+  - name: authentication
+    description: The authentication endpoints.
+  - name: config
+
+paths:
+  x-speakeasy-errors:
+    statusCodes: # Defines status codes to handle as errors for all operations
+      - 4XX # Wildcard to handle all status codes in the 400-499 range
+      - 5XX
+  /anything/selectGlobalServer:
+    x-my-ignore: true
+    get:
+      operationId: selectGlobalServer
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Optional-Header:
+              schema:
+                type: string
+  /authenticate:
+    post:
+      operationId: authenticate
+      summary: Authenticate with the API by providing a username and password.
+      security: []
+      tags:
+        - authentication
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                username:
+                  type: string
+                password:
+                  type: string
+      responses:
+        "200":
+          description: The api key to use for authenticated endpoints.
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  token:
+                    type: string
+        "401":
+          description: Invalid credentials provided.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+
+  /drinks:
+    get:
+      x-speakeasy-usage-example: true
+      operationId: listDrinks
+      summary: Get a list of drinks.
+      description: Get a list of drinks, if authenticated this will include stock levels and product codes otherwise it will only include public information.
+      security:
+        - {}
+      tags:
+        - drinks
+      parameters:
+        - name: drinkType
+          in: query
+          description: The type of drink to filter by. If not provided all drinks will be returned.
+          required: false
+          schema:
+            $ref: "#/components/schemas/DrinkType"
+      responses:
+        "200":
+          description: A list of drinks.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Drink"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+
+  /drink/{name}: # Example comment -- should be maintained
+    get:
+      operationId: getDrink
+      summary: Get a drink.
+      description: Get a drink by name, if authenticated this will include stock levels and product codes otherwise it will only include public information.
+      tags:
+        - drinks
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: A drink.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Drink"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+
+  /ingredients:
+    get:
+      operationId: listIngredients
+      summary: Get a list of ingredients.
+      description: Get a list of ingredients, if authenticated this will include stock levels and product codes otherwise it will only include public information.
+      tags:
+        - ingredients
+      parameters:
+        - name: ingredients
+          in: query
+          description: A list of ingredients to filter by. If not provided all ingredients will be returned.
+          required: false
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        "200":
+          description: A list of ingredients.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Ingredient"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+
+  /order:
+    post:
+      operationId: createOrder
+      summary: Create an order.
+      description: Create an order for a drink.
+      tags:
+        - orders
+      parameters:
+        - name: callback_url
+          in: query
+          description: The url to call when the order is updated.
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/Order"
+      responses:
+        "200":
+          description: The order was created successfully.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+      callbacks:
+        orderUpdate:
+          "{$request.query.callback_url}":
+            post:
+              summary: Receive order updates.
+              description: Receive order updates from the supplier, this will be called whenever the status of an order changes.
+              tags:
+                - orders
+              requestBody:
+                required: true
+                content:
+                  application/json:
+                    schema:
+                      type: object
+                      properties:
+                        order:
+                          $ref: "#/components/schemas/Order"
+              responses:
+                "200":
+                  description: The order update was received successfully.
+                "5XX":
+                  $ref: "#/components/responses/APIError"
+                default:
+                  $ref: "#/components/responses/UnknownError"
+  /webhooks/subscribe:
+    post:
+      operationId: subscribeToWebhooks
+      summary: Subscribe to webhooks.
+      description: Subscribe to webhooks.
+      tags:
+        - config
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                type: object
+                properties:
+                  url:
+                    type: string
+                  webhook:
+                    type: string
+                    enum:
+                      - stockUpdate
+      responses:
+        "200":
+          description: The webhook was subscribed to successfully.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+webhooks:
+  stockUpdate:
+    post:
+      summary: Receive stock updates.
+      description: Receive stock updates from the bar, this will be called whenever the stock levels of a drink or ingredient changes.
+      tags:
+        - drinks
+        - ingredients
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                drink:
+                  $ref: "#/components/schemas/Drink"
+                ingredient:
+                  $ref: "#/components/schemas/Ingredient"
+      responses:
+        "200":
+          description: The stock update was received successfully.
+        "5XX":
+          $ref: "#/components/responses/APIError"
+        default:
+          $ref: "#/components/responses/UnknownError"
+components:
+  schemas:
+    APIError:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+        details:
+          type: object
+          additionalProperties: true
+    Error:
+      type: object
+      properties:
+        code:
+          type: string
+        message:
+          type: string
+    Drink:
+      type: object
+      properties:
+        name:
+          description: The name of the drink.
+          type: string
+          examples:
+            - Old Fashioned
+            - Manhattan
+            - Negroni
+        type:
+          $ref: "#/components/schemas/DrinkType"
+        price:
+          description: The price of one unit of the drink in US cents.
+          type: number
+          examples:
+            - 1000 # $10.00
+            - 1200 # $12.00
+            - 1500 # $15.00
+        stock:
+          description: The number of units of the drink in stock, only available when authenticated.
+          type: integer
+          readOnly: true
+        productCode:
+          description: The product code of the drink, only available when authenticated.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+      required:
+        - name
+        - price
+    DrinkType:
+      description: The type of drink.
+      type: string
+      enum:
+        - cocktail
+        - non-alcoholic
+        - beer
+        - wine
+        - spirit
+        - other
+    Ingredient:
+      type: object
+      properties:
+        name:
+          description: The name of the ingredient.
+          type: string
+          examples:
+            - Sugar Syrup
+            - Angostura Bitters
+            - Orange Peel
+        type:
+          $ref: "#/components/schemas/IngredientType"
+        stock:
+          description: The number of units of the ingredient in stock, only available when authenticated.
+          type: integer
+          examples:
+            - 10
+            - 5
+            - 0
+          readOnly: true
+        productCode:
+          description: The product code of the ingredient, only available when authenticated.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+      required:
+        - name
+        - type
+    IngredientType:
+      description: The type of ingredient.
+      type: string
+      enum:
+        - fresh
+        - long-life
+        - packaged
+    Order:
+      description: An order for a drink or ingredient.
+      type: object
+      properties:
+        type:
+          $ref: "#/components/schemas/OrderType"
+        productCode:
+          description: The product code of the drink or ingredient.
+          type: string
+          examples:
+            - "AC-A2DF3"
+            - "NAC-3F2D1"
+            - "APM-1F2D3"
+        quantity:
+          description: The number of units of the drink or ingredient to order.
+          type: integer
+          minimum: 1
+        status:
+          description: The status of the order.
+          type: string
+          enum:
+            - pending
+            - processing
+            - complete
+          readOnly: true
+      required:
+        - type
+        - productCode
+        - quantity
+        - status
+    OrderType:
+      description: The type of order.
+      type: string
+      enum:
+        - drink
+        - ingredient
+  securitySchemes:
+    apiKey:
+      type: apiKey
+      name: Authorization
+      in: header
+  responses:
+    APIError:
+      description: An error occurred interacting with the API.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/APIError"
+    UnknownError:
+      description: An unknown error occurred interacting with the API.
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"

--- a/integration/resources/overlay/overlay.yaml
+++ b/integration/resources/overlay/overlay.yaml
@@ -1,0 +1,50 @@
+overlay: 1.0.0
+info:
+  title: Drinks Overlay
+  version: 1.2.3
+  x-info-extension: 42
+actions:
+  - target: $.paths["/drink/{name}"].get
+    description: Test update
+    update:
+      parameters:
+        - x-parameter-extension: foo
+          name: test
+          description: Test parameter
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          x-response-extension: foo
+          description: Test response
+          content:
+            application/json:
+              schema:
+                type: string
+    x-action-extension: foo
+  - target: $.paths["/drinks"].get
+    description: Test remove
+    remove: true
+    x-action-extension: bar
+  - target: $.paths["/drinks"]
+    update:
+      x-speakeasy-note:
+        "$ref": "./removeNote.yaml"
+  - target: $.tags
+    update:
+      - name: Testing
+        description: just a description
+  - target: $.paths["/anything/selectGlobalServer"].x-my-ignore
+    update:
+      servers:
+        - url: http://localhost:35123
+          description: The default server.
+  - target: $.paths["/drink/{name}"].get
+    update:
+      description: |
+        A long description
+        to validate that we handle indentation properly
+
+        With a second paragraph
+x-top-level-extension: true

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -7,6 +7,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -36,7 +37,10 @@ func isLocalFileReference(filePath string) bool {
 }
 
 func copyFile(src, dst string) error {
-	sourceFile, err := os.Open(src)
+	_, filename, _, _ := runtime.Caller(0)
+	targetSrc := filepath.Join(filepath.Dir(filename), src)
+
+	sourceFile, err := os.Open(targetSrc)
 	if err != nil {
 		return err
 	}

--- a/internal/overlay/overlay.go
+++ b/internal/overlay/overlay.go
@@ -98,7 +98,11 @@ func render(y *yaml.Node, schemaPath string, yamlOut bool) ([]byte, error) {
 
 	if yamlIn && yamlOut {
 		var res bytes.Buffer
-		if err := yaml.NewEncoder(&res).Encode(y); err != nil {
+		encoder := yaml.NewEncoder(&res)
+		// Note: would love to make this generic but the indentation information isn't in go-yaml nodes
+		// https://github.com/go-yaml/yaml/issues/899
+		encoder.SetIndent(2)
+		if err := encoder.Encode(y); err != nil {
 			return nil, fmt.Errorf("failed to encode YAML: %w", err)
 		}
 		return res.Bytes(), nil

--- a/internal/overlay/testdata/expected.yaml
+++ b/internal/overlay/testdata/expected.yaml
@@ -1,32 +1,32 @@
 openapi: 3.1.0
 info:
-    title: Test
-    version: 0.1.0
-    summary: Test Summary
-    description: |-
-        Some test description.
-        About our test document.
+  title: Test
+  version: 0.1.0
+  summary: Test Summary
+  description: |-
+    Some test description.
+    About our test document.
 paths:
-    /anything/selectGlobalServer:
-        x-my-ignore:
-            servers:
-                - url: http://localhost:35123
-                  description: The default server.
-        get:
-            operationId: selectGlobalServer
-            responses:
-                "200":
-                    description: OK
-                    headers:
-                        X-Optional-Header:
-                            schema:
-                                type: string
-                "404":
-                    description: Not found
-                    content:
-                        application/json:
-                            schema:
-                                $ref: "./components.yaml#/components/schemas/Products"
-            servers:
-                - url: http://localhost:35123
-                  description: The default server.
+  /anything/selectGlobalServer:
+    x-my-ignore:
+      servers:
+        - url: http://localhost:35123
+          description: The default server.
+    get:
+      operationId: selectGlobalServer
+      responses:
+        "200":
+          description: OK
+          headers:
+            X-Optional-Header:
+              schema:
+                type: string
+        "404":
+          description: Not found
+          content:
+            application/json:
+              schema:
+                $ref: "./components.yaml#/components/schemas/Products"
+      servers:
+        - url: http://localhost:35123
+          description: The default server.


### PR DESCRIPTION
When we apply an overlay, we lose indentation of the original file.

This sucks, and can in-particular have negative effects because the overlay file uses `|` for multi-line strings.

Underlying issue is https://github.com/go-yaml/yaml/issues/899

Ideally we'd keep indentation through either [migrating to https://github.com/goccy/go-yaml, or discovering the indentation as the document is parsed]. However as a stop-gap we can make the indentation `2` which aligns it with almost all YAML documents we work with and the overlay files we generate. 

This PR implements that stop-gap and adds an integration test for multi-line strings in overlay files.