### PR TITLE
chore: run all tests all the time

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,14 +30,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-        include:
-          - test-group: "Test Generations"
-            test-pattern: "TestGenerationWorkflows"
-          - test-group: "Test Spec Operations"
-            test-pattern: "TestSpecWorkflows"
-          - test-group: "Test Fallback Code Samples Workflow"
-            test-pattern: "TestFallbackCodeSamplesWorkflow"
-
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -89,6 +81,6 @@ jobs:
         run: go build ./...
 
       - name: ${{ matrix.test-group }}
-        run: go test -json -v -p 1 -run ${{ matrix.test-pattern }} ./... | gotestfmt
+        run: go test -json -v -p 1 -run ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -37,7 +37,7 @@ func setupTestDir(t *testing.T) string {
 	t.Helper()
 	_, filename, _, _ := runtime.Caller(0)
 	workingDir := filepath.Dir(filename)
-	temp, err := createTempDir()
+	temp, err := createTempDir(workingDir)
 	assert.NoError(t, err)
 	registerCleanup(t, workingDir, temp)
 

--- a/integration/overlay_test.go
+++ b/integration/overlay_test.go
@@ -24,7 +24,7 @@ func TestOverlayMatchesSnapshot(t *testing.T) {
 	require.NoError(t, err)
 
 	args := []string{"overlay", "apply", "--schema", schemaFilePath, "--overlay", overlayFilePath, "--out", outputPath}
-	cmdErr := execute(t, temp, args...)
+	cmdErr := execute(t, temp, args...).Run()
 	require.NoError(t, cmdErr)
 	readBytes, err := os.ReadFile(outputPath)
 	require.NoError(t, err)

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -1,7 +1,6 @@
 package integration_tests
 
 import (
-	"fmt"
 	"io"
 	"math/rand"
 	"net/url"
@@ -19,12 +18,12 @@ const (
 )
 
 func createTempDir(wd string) (string, error) {
-	temp := fmt.Sprintf("%s/%s", tempDir, randStringBytes(7))
-	if err := os.Mkdir(filepath.Join(wd, temp), 0o755); err != nil {
+	target := filepath.Join(wd, tempDir, randStringBytes(7))
+	if err := os.Mkdir(target, 0o755); err != nil {
 		return "", err
 	}
 
-	return temp, nil
+	return target, nil
 }
 
 func isLocalFileReference(filePath string) bool {

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -18,9 +18,9 @@ const (
 	artifactArch = "linux_amd64"
 )
 
-func createTempDir() (string, error) {
+func createTempDir(wd string) (string, error) {
 	temp := fmt.Sprintf("%s/%s", tempDir, randStringBytes(7))
-	if err := os.Mkdir(temp, 0o755); err != nil {
+	if err := os.Mkdir(filepath.Join(wd, temp), 0o755); err != nil {
 		return "", err
 	}
 


### PR DESCRIPTION
The `matrix` doesn't appear to work right (as it's not running each test group), but we don't need it. This adjusts the target to run `./...` (i.e. all tests) on both ubuntu and windows.

Also fixes up some tests