### PR TITLE
feat: Introduce status command

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,13 @@ You can run the Speakeasy CLI locally or in your CI/CD pipeline to validate your
 
 Here are a few key functions of the CLI:
 
-* `generate` - Generate idiomatic client SDKs from your API specs.
+* `quickstart` - Create an idiomatic client SDK or target, such as a Terraform Provider, from your API specs.
+* `run` - Regenerate existing SDK/target from your API specs.
 * `validate` - Validate the correctness of your API specs. The CLI has a built-in command to validate your spec for SDK readiness and post helpful error messages.
 * `suggest` - Use an LLM to autocorrect your spec validation failures. 
 * `merge` - Work with your existing documentation workflows by merging your API specs into a single spec. 
 * `auth` - Authenticate with the platform and manage API keys. 
+* `status` - Review all SDK/targets in current workspace.
 
 For a complete list of commands check out our [reference](https://www.speakeasyapi.dev/docs/speakeasy-cli/getting-started) or type `speakeasy` and our interactive mode will take you through the available functions. 
 
@@ -369,6 +371,7 @@ speakeasy [flags]
 * [speakeasy overlay](docs/overlay/README.md)	 - Work with OpenAPI Overlays
 * [speakeasy quickstart](docs/quickstart.md)	 - Guided setup to help you create a new SDK in minutes.
 * [speakeasy run](docs/run.md)	 - generate an SDK, compile OpenAPI sources, and much more from a workflow.yaml file
+* [speakeasy status](docs/status.md)	 - Review status of current workspace
 * [speakeasy suggest](docs/suggest/README.md)	 - Automatically improve your OpenAPI document with an LLM
 * [speakeasy tag](docs/tag/README.md)	 - Add tags to a given revision of your API. Specific to a registry namespace
 * [speakeasy update](docs/update.md)	 - Update the Speakeasy CLI to the latest version

--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -49,6 +49,11 @@ func loginExec(cmd *cobra.Command, args []string) error {
 	log.From(cmd.Context()).
 		WithInteractiveOnly().
 		Successf("Authenticated with workspace successfully - %s/workspaces/%s\n", core.GetServerURL(), workspaceID)
+
+	log.From(cmd.Context()).
+		WithInteractiveOnly().
+		Infof("Review the workspace with `speakeasy status` or create a new target with `speakeasy quickstart`.")
+
 	return nil
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -61,6 +61,7 @@ func Init(version, artifactArch string) {
 	addCommand(rootCmd, lintCmd)
 	addCommand(rootCmd, openapiCmd)
 	addCommand(rootCmd, migrateCmd)
+	addCommand(rootCmd, statusCmd)
 
 	authInit()
 	mergeInit()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,7 @@ func Init(version, artifactArch string) {
 	rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
 
 	// TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
+	addCommand(rootCmd, statusCmd)
 	addCommand(rootCmd, quickstartCmd)
 	addCommand(rootCmd, runCmd)
 	addCommand(rootCmd, configureCmd)
@@ -61,7 +62,6 @@ func Init(version, artifactArch string) {
 	addCommand(rootCmd, lintCmd)
 	addCommand(rootCmd, openapiCmd)
 	addCommand(rootCmd, migrateCmd)
-	addCommand(rootCmd, statusCmd)
 
 	authInit()
 	mergeInit()

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -1,0 +1,702 @@
+package cmd
+
+import (
+	"cmp"
+	"context"
+	"fmt"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/charmbracelet/lipgloss"
+	speakeasyclientsdkgo "github.com/speakeasy-api/speakeasy-client-sdk-go/v3"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/operations"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+	core "github.com/speakeasy-api/speakeasy-core/auth"
+
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/links"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/model"
+	"github.com/speakeasy-api/speakeasy/internal/model/flag"
+	"github.com/speakeasy-api/speakeasy/internal/sdk"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+)
+
+type statusFlagsArgs struct{}
+
+var statusCmd = &model.ExecutableCommand[statusFlagsArgs]{
+	Usage:        "status",
+	Short:        "Review status of current workspace",
+	Run:          runStatus,
+	RequiresAuth: true,
+	Flags:        []flag.Flag{},
+}
+
+func runStatus(ctx context.Context, flags statusFlagsArgs) error {
+	client, err := sdk.InitSDK()
+
+	if err != nil {
+		return fmt.Errorf("error initializing Speakeasy client: %w", err)
+	}
+
+	model, err := newStatusModel(ctx, client)
+
+	if err != nil {
+		return err
+	}
+
+	model.Print(ctx)
+
+	return nil
+}
+
+var (
+	skipMeaninglessTargetNames = []string{
+		"",
+		"first-target",
+		"my-first-target",
+	}
+)
+
+type statusModel struct {
+	accountType  *string
+	organization statusOrganizationModel
+	workspace    statusWorkspaceModel
+}
+
+func newStatusModel(ctx context.Context, client *speakeasyclientsdkgo.Speakeasy) (statusModel, error) {
+	var model statusModel
+
+	if accountType := core.GetAccountTypeFromContext(ctx); accountType != nil {
+		v := string(*accountType)
+		model.accountType = &v
+	}
+
+	workspaceID, err := core.GetWorkspaceIDFromContext(ctx)
+
+	if err != nil {
+		return model, err
+	}
+
+	model.workspace.id = workspaceID
+
+	model.organization.slug = core.GetOrgSlugFromContext(ctx)
+	model.workspace.slug = core.GetWorkspaceSlugFromContext(ctx)
+
+	req := operations.GetWorkspaceTargetsRequest{
+		WorkspaceID: &model.workspace.id,
+	}
+
+	res, err := client.Events.GetWorkspaceTargets(ctx, req)
+
+	if err != nil {
+		return model, fmt.Errorf("error getting Speakeasy workspace targets: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		return model, fmt.Errorf("unexpected status code getting Speakeasy workspace targets: %d", res.StatusCode)
+	}
+
+	model.workspace.targets, err = newStatusWorkspaceTargetsModel(ctx, client, model.organization, model.workspace, res.TargetSDKList)
+
+	return model, err
+}
+
+func (m statusModel) Print(ctx context.Context) {
+	m.workspace.targets.Print(ctx)
+}
+
+type statusOrganizationModel struct {
+	slug string
+}
+
+type statusWorkspaceModel struct {
+	id      string
+	slug    string
+	targets statusWorkspaceTargetsModel
+}
+
+type statusWorkspaceTargetsModel struct {
+	published    []statusWorkspaceTargetModel
+	configured   []statusWorkspaceTargetModel
+	unconfigured []statusWorkspaceTargetModel
+}
+
+func newStatusWorkspaceTargetsModel(ctx context.Context, client *speakeasyclientsdkgo.Speakeasy, org statusOrganizationModel, workspace statusWorkspaceModel, targets []shared.TargetSDK) (statusWorkspaceTargetsModel, error) {
+	var result statusWorkspaceTargetsModel
+
+	for _, target := range targets {
+		targetModel, err := newStatusWorkspaceTargetModel(ctx, client, org, workspace, target)
+
+		if err != nil {
+			return result, err
+		}
+
+		if target.GeneratePublished != nil && *target.GeneratePublished {
+			result.published = append(result.published, targetModel)
+
+			continue
+		}
+
+		if target.GhActionOrganization != nil && target.GhActionRepository != nil {
+			result.configured = append(result.configured, targetModel)
+
+			continue
+		}
+
+		if target.GenerateConfigPostVersion == nil {
+			// Archived
+			continue
+		}
+
+		result.unconfigured = append(result.unconfigured, targetModel)
+	}
+
+	sortFunc := func(a, b statusWorkspaceTargetModel) int {
+		return cmp.Or(
+			cmp.Compare(strconv.FormatBool(a.Success()), strconv.FormatBool(b.Success())),
+			cmp.Compare(a.TargetName(), b.TargetName()),
+		)
+	}
+
+	slices.SortFunc(result.configured, sortFunc)
+	slices.SortFunc(result.published, sortFunc)
+	slices.SortFunc(result.unconfigured, sortFunc)
+
+	return result, nil
+}
+
+func (m statusWorkspaceTargetsModel) Print(ctx context.Context) {
+	logger := log.From(ctx)
+
+	// Leave room for padding (if the terminal is too small to fit, we need to wrap)
+	width := min(m.RenderFullWidth(ctx), styles.TerminalWidth()-2)
+
+	for _, target := range m.published {
+		if !target.Success() {
+			logger.Println(renderPublishedErrorTargetBox(
+				width,
+				target.TargetHeading(),
+				target.TargetInfo(ctx)...,
+			))
+		} else {
+			logger.Println(renderPublishedSuccessTargetBox(
+				width,
+				target.TargetHeading(),
+				target.TargetInfo(ctx)...,
+			))
+		}
+	}
+
+	for _, target := range m.configured {
+		logger.Println(renderConfiguredTargetBox(
+			width,
+			target.TargetHeading(),
+			target.TargetInfo(ctx)...,
+		))
+	}
+
+	for _, target := range m.unconfigured {
+		logger.Println(renderUnconfiguredTargetBox(
+			width,
+			target.TargetHeading(),
+			target.TargetInfo(ctx)...,
+		))
+	}
+}
+
+func (m statusWorkspaceTargetsModel) RenderFullWidth(ctx context.Context) int {
+	var width int
+
+	for _, target := range m.published {
+		width = max(width, target.RenderFullWidth(ctx))
+	}
+
+	for _, target := range m.configured {
+		width = max(width, target.RenderFullWidth(ctx))
+	}
+
+	for _, target := range m.unconfigured {
+		width = max(width, target.RenderFullWidth(ctx))
+	}
+
+	return width
+}
+
+type statusWorkspaceEventModel struct {
+	// Passthrough from search events API
+
+	continuousIntegrationEnvironment *string
+	createdAt                        time.Time
+	ghActionRunLink                  *string
+	gitUserEmail                     *string
+	gitUserName                      *string
+	hostname                         *string
+	publishPackageName               *string
+	publishPackageRegistryName       *string
+	publishPackageURL                *string
+	publishPackageVersion            *string
+	success                          bool
+}
+
+func newStatusWorkspaceEventModel(event shared.CliEvent) statusWorkspaceEventModel {
+	result := statusWorkspaceEventModel{
+		continuousIntegrationEnvironment: event.ContinuousIntegrationEnvironment,
+		createdAt:                        event.CreatedAt,
+		ghActionRunLink:                  event.GhActionRunLink,
+		gitUserEmail:                     event.GitUserEmail,
+		gitUserName:                      event.GitUserName,
+		hostname:                         event.Hostname,
+		publishPackageName:               event.PublishPackageName,
+		publishPackageRegistryName:       event.PublishPackageRegistryName,
+		publishPackageURL:                event.PublishPackageURL,
+		publishPackageVersion:            event.PublishPackageVersion,
+		success:                          event.Success,
+	}
+
+	return result
+}
+
+func (m statusWorkspaceEventModel) GenerateInfo() string {
+	var result strings.Builder
+
+	if m.ghActionRunLink == nil {
+		result.WriteString("locally at ")
+	}
+
+	result.WriteString(m.createdAt.Format(time.RFC3339))
+	result.WriteString(" by ")
+
+	if m.ghActionRunLink != nil {
+		result.WriteString("GitHub Actions")
+	} else if m.continuousIntegrationEnvironment != nil {
+		result.WriteString("CI")
+	} else if m.gitUserName != nil {
+		result.WriteString(*m.gitUserName)
+	} else if m.gitUserEmail != nil {
+		result.WriteString(*m.gitUserEmail)
+	} else if m.hostname != nil {
+		result.WriteString(*m.hostname)
+	} else {
+		result.WriteString("Unknown")
+	}
+
+	return result.String()
+}
+
+func (m statusWorkspaceEventModel) PublishInfo() string {
+	var result strings.Builder
+
+	if m.publishPackageVersion != nil {
+		result.WriteString(*m.publishPackageVersion)
+		result.WriteString(" at ")
+	}
+
+	if m.ghActionRunLink == nil {
+		result.WriteString("locally at ")
+	}
+
+	result.WriteString(m.createdAt.Format(time.RFC3339))
+	result.WriteString(" by ")
+
+	if m.ghActionRunLink != nil {
+		result.WriteString("GitHub Actions")
+	} else if m.continuousIntegrationEnvironment != nil {
+		result.WriteString("CI")
+	} else if m.gitUserName != nil {
+		result.WriteString(*m.gitUserName)
+	} else if m.gitUserEmail != nil {
+		result.WriteString(*m.gitUserEmail)
+	} else if m.hostname != nil {
+		result.WriteString(*m.hostname)
+	} else {
+		result.WriteString("Unknown")
+	}
+
+	return result.String()
+}
+
+type statusWorkspaceTargetModel struct {
+	// Passthrough from targets API
+
+	continuousIntegrationEnvironment  *string
+	generateConfigPostVersion         *string
+	generateGenLockPreVersion         *string
+	generateNumberOfOperationsIgnored *int64
+	generateNumberOfOperationsUsed    *int64
+	generatePublished                 *bool
+	generateTarget                    string
+	generateTargetName                *string
+	generateTargetVersion             *string
+	ghActionOrganization              *string
+	ghActionRepository                *string
+	ghActionRunLink                   *string
+	gitUserEmail                      *string
+	gitUserName                       *string
+	hostname                          *string
+	id                                string
+	lastEventCreatedAt                time.Time
+	success                           *bool
+
+	// Generate events
+	generateEvents []statusWorkspaceEventModel
+
+	// Publish events
+	publishEvents []statusWorkspaceEventModel
+
+	// Speakeasy URL
+	speakeasyURL string
+
+	// If a target upgrade is recommended, the URL for upgrade documentation.
+	upgradeDocumentationURL *string
+}
+
+func newStatusWorkspaceTargetModel(ctx context.Context, client *speakeasyclientsdkgo.Speakeasy, org statusOrganizationModel, workspace statusWorkspaceModel, target shared.TargetSDK) (statusWorkspaceTargetModel, error) {
+	result := statusWorkspaceTargetModel{
+		continuousIntegrationEnvironment:  target.ContinuousIntegrationEnvironment,
+		generateConfigPostVersion:         target.GenerateConfigPostVersion,
+		generateGenLockPreVersion:         target.GenerateGenLockPreVersion,
+		generateNumberOfOperationsIgnored: target.GenerateNumberOfOperationsIgnored,
+		generateNumberOfOperationsUsed:    target.GenerateNumberOfOperationsUsed,
+		generatePublished:                 target.GeneratePublished,
+		generateTarget:                    target.GenerateTarget,
+		generateTargetName:                target.GenerateTargetName,
+		generateTargetVersion:             target.GenerateTargetVersion,
+		ghActionOrganization:              target.GhActionOrganization,
+		ghActionRepository:                target.GhActionRepository,
+		ghActionRunLink:                   target.GhActionRunLink,
+		gitUserEmail:                      target.GitUserEmail,
+		gitUserName:                       target.GitUserName,
+		hostname:                          target.Hostname,
+		id:                                target.ID,
+		lastEventCreatedAt:                target.LastEventCreatedAt,
+		speakeasyURL:                      links.Shorten(ctx, fmt.Sprintf("https://app.speakeasyapi.dev/org/%s/%s/targets/%s", org.slug, workspace.slug, target.ID)),
+		success:                           target.Success,
+	}
+
+	if result.generateTarget == "python" && (result.generateTargetVersion == nil || *result.generateTargetVersion == "v1") {
+		upgradeURL := "https://www.speakeasy.com/docs/python-migration"
+		result.upgradeDocumentationURL = &upgradeURL
+	}
+
+	interactionTypeTargetGenerate := shared.InteractionTypeTargetGenerate
+	req := operations.SearchWorkspaceEventsRequest{
+		GenerateGenLockID: &target.ID,
+		InteractionType:   &interactionTypeTargetGenerate,
+		WorkspaceID:       &workspace.id,
+	}
+
+	res, err := client.Events.SearchWorkspaceEvents(ctx, req)
+
+	if err != nil {
+		return result, fmt.Errorf("error searching Speakeasy target events: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		return result, fmt.Errorf("unexpected status code searching Speakeasy target events: %d", res.StatusCode)
+	}
+
+	if len(res.CliEventBatch) == 0 {
+		return result, nil
+	}
+
+	for _, event := range res.CliEventBatch {
+		eventModel := newStatusWorkspaceEventModel(event)
+		result.generateEvents = append(result.generateEvents, eventModel)
+	}
+
+	interactionTypePublish := shared.InteractionTypePublish
+	req = operations.SearchWorkspaceEventsRequest{
+		GenerateGenLockID: &target.ID,
+		InteractionType:   &interactionTypePublish,
+		WorkspaceID:       &workspace.id,
+	}
+
+	res, err = client.Events.SearchWorkspaceEvents(ctx, req)
+
+	if err != nil {
+		return result, fmt.Errorf("error searching Speakeasy target events: %w", err)
+	}
+
+	if res.StatusCode != 200 {
+		return result, fmt.Errorf("unexpected status code searching Speakeasy target events: %d", res.StatusCode)
+	}
+
+	if len(res.CliEventBatch) == 0 {
+		return result, nil
+	}
+
+	for _, event := range res.CliEventBatch {
+		eventModel := newStatusWorkspaceEventModel(event)
+		result.publishEvents = append(result.publishEvents, eventModel)
+	}
+
+	return result, nil
+}
+
+func (m statusWorkspaceTargetModel) GenerateInfo() string {
+	var result strings.Builder
+
+	if m.ghActionRunLink == nil {
+		result.WriteString("locally at ")
+	}
+
+	result.WriteString(m.lastEventCreatedAt.Format(time.RFC3339))
+	result.WriteString(" by ")
+
+	if m.ghActionRunLink != nil {
+		result.WriteString("GitHub Actions")
+	} else if m.continuousIntegrationEnvironment != nil {
+		result.WriteString("CI")
+	} else if m.gitUserName != nil {
+		result.WriteString(*m.gitUserName)
+	} else if m.gitUserEmail != nil {
+		result.WriteString(*m.gitUserEmail)
+	} else if m.hostname != nil {
+		result.WriteString(*m.hostname)
+	} else {
+		result.WriteString("Unknown")
+	}
+
+	return result.String()
+}
+
+func (m statusWorkspaceTargetModel) LastGenerateEvent() *statusWorkspaceEventModel {
+	if len(m.generateEvents) == 0 {
+		return nil
+	}
+
+	return &m.generateEvents[0]
+}
+
+func (m statusWorkspaceTargetModel) LastGenerateSuccessEvent() *statusWorkspaceEventModel {
+	if len(m.generateEvents) == 0 {
+		return nil
+	}
+
+	for _, event := range m.generateEvents {
+		if event.success {
+			return &event
+		}
+	}
+
+	return nil
+}
+
+func (m statusWorkspaceTargetModel) LastPublishEvent() *statusWorkspaceEventModel {
+	if len(m.publishEvents) == 0 {
+		return nil
+	}
+
+	return &m.publishEvents[0]
+}
+
+func (m statusWorkspaceTargetModel) LastPublishSuccessEvent() *statusWorkspaceEventModel {
+	if len(m.publishEvents) == 0 {
+		return nil
+	}
+
+	for _, event := range m.publishEvents {
+		if event.success {
+			return &event
+		}
+	}
+
+	return nil
+}
+
+func (m statusWorkspaceTargetModel) RenderFullWidth(ctx context.Context) int {
+	// Add 2 to account for box padding
+	return lipgloss.Width(strings.Join(m.TargetInfo(ctx), "\n")) + 2
+}
+
+func (m statusWorkspaceTargetModel) RepositoryURL() string {
+	if m.ghActionOrganization != nil || m.ghActionRepository != nil {
+		return "https://github.com/" + *m.ghActionOrganization + "/" + *m.ghActionRepository
+	}
+
+	return ""
+}
+
+func (m statusWorkspaceTargetModel) Success() bool {
+	if event := m.LastPublishEvent(); event != nil && !event.success {
+		return false
+	}
+
+	if event := m.LastGenerateEvent(); event != nil && !event.success {
+		return false
+	}
+
+	return true
+}
+
+func (m statusWorkspaceTargetModel) TargetHeading() string {
+	var result strings.Builder
+
+	result.WriteString(m.TargetName())
+	result.WriteString(" [")
+
+	if m.generatePublished != nil && *m.generatePublished {
+		result.WriteString("Published")
+	} else if m.ghActionOrganization != nil && m.ghActionRepository != nil {
+		result.WriteString("Unpublished")
+	} else {
+		result.WriteString("Unconfigured")
+	}
+
+	if event := m.LastPublishSuccessEvent(); event != nil && event.publishPackageName != nil && event.publishPackageVersion != nil {
+		result.WriteString(": ")
+		result.WriteString(*event.publishPackageVersion)
+	} else if m.generateConfigPostVersion != nil {
+		result.WriteString(": ")
+		result.WriteString(*m.generateConfigPostVersion)
+	} else if m.generateGenLockPreVersion != nil {
+		result.WriteString(": ")
+		result.WriteString(*m.generateGenLockPreVersion)
+	}
+
+	result.WriteString("]")
+
+	return result.String()
+}
+
+func (m statusWorkspaceTargetModel) TargetInfo(ctx context.Context) []string {
+	lastGenerateEvent := m.LastGenerateEvent()
+	lastGenerateSuccessEvent := m.LastGenerateSuccessEvent()
+	lastPublishEvent := m.LastPublishEvent()
+	lastPublishSuccessEvent := m.LastPublishSuccessEvent()
+
+	var result []string
+
+	if lastPublishEvent != nil && !lastPublishEvent.success {
+		var message strings.Builder
+
+		message.WriteString("✖ Last Publish Failed")
+
+		if lastPublishEvent.ghActionRunLink != nil {
+			message.WriteString(": ")
+			message.WriteString(links.Shorten(ctx, *lastPublishEvent.ghActionRunLink))
+		}
+
+		result = append(result, styles.None.Foreground(styles.Colors.Red).Italic(true).Render(message.String()))
+	}
+
+	if lastGenerateEvent != nil && !lastGenerateEvent.success {
+		var message strings.Builder
+
+		message.WriteString("✖ Last Generate Failed")
+
+		if lastGenerateEvent.ghActionRunLink != nil {
+			message.WriteString(": ")
+			message.WriteString(links.Shorten(ctx, *lastGenerateEvent.ghActionRunLink))
+		}
+
+		result = append(result, styles.None.Foreground(styles.Colors.Red).Italic(true).Render(message.String()))
+	}
+
+	if m.upgradeDocumentationURL != nil {
+		result = append(result, styles.None.Foreground(styles.Colors.Yellow).Italic(true).Render("⚠ Target Upgrade Available: "+*m.upgradeDocumentationURL))
+	}
+
+	if lastPublishSuccessEvent != nil && lastPublishSuccessEvent.publishPackageURL != nil {
+		result = append(result, styles.Dimmed.Render("Publish URL: "+*lastPublishSuccessEvent.publishPackageURL))
+	}
+
+	if m.RepositoryURL() != "" {
+		result = append(result, styles.Dimmed.Render("Repository URL: "+m.RepositoryURL()))
+	}
+
+	result = append(result, styles.Dimmed.Render("Speakeasy URL: "+m.speakeasyURL))
+
+	if lastPublishEvent != nil {
+		if !lastPublishEvent.success {
+			result = append(result, styles.Dimmed.Render("Last Publish Attempt: "+lastPublishEvent.PublishInfo()))
+
+			if lastPublishSuccessEvent != nil {
+				result = append(result, styles.Dimmed.Render("Last Publish Success: "+lastPublishSuccessEvent.GenerateInfo()))
+			} else {
+				result = append(result, styles.Dimmed.Render("Last Publish Success: Unknown"))
+			}
+		} else {
+			result = append(result, styles.Dimmed.Render("Last Publish: "+lastPublishEvent.PublishInfo()))
+		}
+	}
+
+	if lastGenerateEvent != nil {
+		if !lastGenerateEvent.success {
+			result = append(result, styles.Dimmed.Render("Last Generate Attempt: "+lastGenerateEvent.GenerateInfo()))
+
+			if lastGenerateSuccessEvent != nil {
+				result = append(result, styles.Dimmed.Render("Last Generate Success: "+lastGenerateSuccessEvent.GenerateInfo()))
+			} else {
+				result = append(result, styles.Dimmed.Render("Last Generate Success: Unknown"))
+			}
+		} else {
+			result = append(result, styles.Dimmed.Render("Last Generate: "+lastGenerateEvent.GenerateInfo()))
+		}
+	} else {
+		result = append(result, styles.Dimmed.Render("Last Generate: "+m.GenerateInfo()))
+	}
+
+	return result
+}
+
+func (m statusWorkspaceTargetModel) TargetName() string {
+	var result strings.Builder
+
+	result.WriteString(m.generateTarget)
+	result.WriteString(" (")
+
+	if m.upgradeDocumentationURL != nil {
+		result.WriteString("⚠")
+	}
+
+	if m.generateTargetVersion != nil && *m.generateTargetVersion != "" {
+		result.WriteString(*m.generateTargetVersion)
+	} else {
+		result.WriteString("v1")
+	}
+
+	result.WriteString(")")
+
+	if m.generateTargetName != nil && !slices.Contains(skipMeaninglessTargetNames, *m.generateTargetName) {
+		result.WriteString(": ")
+		result.WriteString(*m.generateTargetName)
+	}
+
+	return result.String()
+}
+
+func renderPublishedSuccessTargetBox(width int, heading string, additionalLines ...string) string {
+	return renderTargetBox(width, styles.Colors.Green, heading, additionalLines...)
+}
+
+func renderPublishedErrorTargetBox(width int, heading string, additionalLines ...string) string {
+	return renderTargetBox(width, styles.Colors.Red, heading, additionalLines...)
+}
+
+func renderConfiguredTargetBox(width int, heading string, additionalLines ...string) string {
+	return renderTargetBox(width, styles.Colors.Yellow, heading, additionalLines...)
+}
+
+func renderUnconfiguredTargetBox(width int, heading string, additionalLines ...string) string {
+	return renderTargetBox(width, styles.Colors.Blue, heading, additionalLines...)
+}
+
+func renderTargetBox(width int, color lipgloss.AdaptiveColor, heading string, additionalLines ...string) string {
+	s := lipgloss.NewStyle().Foreground(color).Bold(true).Render(utils.CapitalizeFirst(heading))
+
+	for _, line := range additionalLines {
+		s += "\n" + lipgloss.NewStyle().Foreground(color).Render(line)
+	}
+
+	return lipgloss.NewStyle().
+		Border(lipgloss.RoundedBorder()).
+		BorderForeground(color).
+		Padding(0, 1).
+		AlignHorizontal(lipgloss.Left).
+		Width(width).
+		Render(s)
+}

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -573,71 +573,71 @@ func (m statusWorkspaceTargetModel) TargetInfo(ctx context.Context) []string {
 	if lastPublishEvent != nil && !lastPublishEvent.success {
 		var message strings.Builder
 
-		message.WriteString("✖ Last Publish Failed")
+		message.WriteString(renderAlertErrorText("✖ Last Publish Failed"))
 
 		if lastPublishEvent.ghActionRunLink != nil {
-			message.WriteString(": ")
-			message.WriteString(links.Shorten(ctx, *lastPublishEvent.ghActionRunLink))
+			message.WriteString(renderAlertErrorText(": "))
+			message.WriteString(renderAlertErrorURL(links.Shorten(ctx, *lastPublishEvent.ghActionRunLink)))
 		}
 
-		result = append(result, styles.None.Foreground(styles.Colors.Red).Italic(true).Render(message.String()))
+		result = append(result, message.String())
 	}
 
 	if lastGenerateEvent != nil && !lastGenerateEvent.success {
 		var message strings.Builder
 
-		message.WriteString("✖ Last Generate Failed")
+		message.WriteString(renderAlertErrorText("✖ Last Generate Failed"))
 
 		if lastGenerateEvent.ghActionRunLink != nil {
-			message.WriteString(": ")
-			message.WriteString(links.Shorten(ctx, *lastGenerateEvent.ghActionRunLink))
+			message.WriteString(renderAlertErrorText(": "))
+			message.WriteString(renderAlertErrorURL(links.Shorten(ctx, *lastGenerateEvent.ghActionRunLink)))
 		}
 
-		result = append(result, styles.None.Foreground(styles.Colors.Red).Italic(true).Render(message.String()))
+		result = append(result, message.String())
 	}
 
 	if m.upgradeDocumentationURL != nil {
-		result = append(result, styles.None.Foreground(styles.Colors.Yellow).Italic(true).Render("⚠ Target Upgrade Available: "+*m.upgradeDocumentationURL))
+		result = append(result, renderAlertWarningText("⚠ Target Upgrade Available: ")+renderAlertWarningURL(*m.upgradeDocumentationURL))
 	}
 
 	if lastPublishSuccessEvent != nil && lastPublishSuccessEvent.publishPackageURL != nil {
-		result = append(result, styles.Dimmed.Render("Publish URL: "+*lastPublishSuccessEvent.publishPackageURL))
+		result = append(result, renderInfoText("Publish URL: ")+renderInfoURL(*lastPublishSuccessEvent.publishPackageURL))
 	}
 
 	if m.RepositoryURL() != "" {
-		result = append(result, styles.Dimmed.Render("Repository URL: "+m.RepositoryURL()))
+		result = append(result, renderInfoText("Repository URL: "+renderInfoURL(m.RepositoryURL())))
 	}
 
-	result = append(result, styles.Dimmed.Render("Speakeasy URL: "+m.speakeasyURL))
+	result = append(result, renderInfoText("Speakeasy URL: "+renderInfoURL(m.speakeasyURL)))
 
 	if lastPublishEvent != nil {
 		if !lastPublishEvent.success {
-			result = append(result, styles.Dimmed.Render("Last Publish Attempt: "+lastPublishEvent.PublishInfo()))
+			result = append(result, renderInfoText("Last Publish Attempt: "+lastPublishEvent.PublishInfo()))
 
 			if lastPublishSuccessEvent != nil {
-				result = append(result, styles.Dimmed.Render("Last Publish Success: "+lastPublishSuccessEvent.GenerateInfo()))
+				result = append(result, renderInfoText("Last Publish Success: "+lastPublishSuccessEvent.GenerateInfo()))
 			} else {
-				result = append(result, styles.Dimmed.Render("Last Publish Success: Unknown"))
+				result = append(result, renderInfoText("Last Publish Success: Unknown"))
 			}
 		} else {
-			result = append(result, styles.Dimmed.Render("Last Publish: "+lastPublishEvent.PublishInfo()))
+			result = append(result, renderInfoText("Last Publish: "+lastPublishEvent.PublishInfo()))
 		}
 	}
 
 	if lastGenerateEvent != nil {
 		if !lastGenerateEvent.success {
-			result = append(result, styles.Dimmed.Render("Last Generate Attempt: "+lastGenerateEvent.GenerateInfo()))
+			result = append(result, renderInfoText("Last Generate Attempt: "+lastGenerateEvent.GenerateInfo()))
 
 			if lastGenerateSuccessEvent != nil {
-				result = append(result, styles.Dimmed.Render("Last Generate Success: "+lastGenerateSuccessEvent.GenerateInfo()))
+				result = append(result, renderInfoText("Last Generate Success: "+lastGenerateSuccessEvent.GenerateInfo()))
 			} else {
-				result = append(result, styles.Dimmed.Render("Last Generate Success: Unknown"))
+				result = append(result, renderInfoText("Last Generate Success: Unknown"))
 			}
 		} else {
-			result = append(result, styles.Dimmed.Render("Last Generate: "+lastGenerateEvent.GenerateInfo()))
+			result = append(result, renderInfoText("Last Generate: "+lastGenerateEvent.GenerateInfo()))
 		}
 	} else {
-		result = append(result, styles.Dimmed.Render("Last Generate: "+m.GenerateInfo()))
+		result = append(result, renderInfoText("Last Generate: "+m.GenerateInfo()))
 	}
 
 	return result
@@ -667,6 +667,30 @@ func (m statusWorkspaceTargetModel) TargetName() string {
 	}
 
 	return result.String()
+}
+
+func renderAlertErrorText(s string) string {
+	return styles.None.Foreground(styles.Colors.Red).Italic(true).Render(s)
+}
+
+func renderAlertErrorURL(s string) string {
+	return styles.None.Foreground(styles.Colors.Red).Italic(true).Underline(true).Render(s)
+}
+
+func renderAlertWarningText(s string) string {
+	return styles.None.Foreground(styles.Colors.Yellow).Italic(true).Render(s)
+}
+
+func renderAlertWarningURL(s string) string {
+	return styles.None.Foreground(styles.Colors.Yellow).Italic(true).Underline(true).Render(s)
+}
+
+func renderInfoText(s string) string {
+	return styles.Dimmed.Render(s)
+}
+
+func renderInfoURL(s string) string {
+	return styles.None.Foreground(styles.Colors.BrightGrey).Underline(true).Render(s)
 }
 
 func renderPublishedSuccessTargetBox(width int, heading string, additionalLines ...string) string {

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ speakeasy [flags]
 * [speakeasy overlay](overlay/README.md)	 - Work with OpenAPI Overlays
 * [speakeasy quickstart](quickstart.md)	 - Guided setup to help you create a new SDK in minutes.
 * [speakeasy run](run.md)	 - generate an SDK, compile OpenAPI sources, and much more from a workflow.yaml file
+* [speakeasy status](status.md)	 - Review status of current workspace
 * [speakeasy suggest](suggest/README.md)	 - Automatically improve your OpenAPI document with an LLM
 * [speakeasy tag](tag/README.md)	 - Add tags to a given revision of your API. Specific to a registry namespace
 * [speakeasy update](update.md)	 - Update the Speakeasy CLI to the latest version

--- a/docs/status.md
+++ b/docs/status.md
@@ -1,0 +1,27 @@
+# status  
+`speakeasy status`  
+
+
+Review status of current workspace  
+
+## Usage
+
+```
+speakeasy status [flags]
+```
+
+### Options
+
+```
+  -h, --help   help for status
+```
+
+### Options inherited from parent commands
+
+```
+      --logLevel string   the log level (available options: [info, warn, error]) (default "info")
+```
+
+### Parent Command
+
+* [speakeasy](README.md)	 - The speakeasy cli tool provides access to the speakeasyapi.dev toolchain

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/speakeasy-api/openapi-generation/v2 v2.379.3
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.16.2
-	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.0
+	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.2
 	github.com/speakeasy-api/speakeasy-core v0.12.1
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -498,8 +498,8 @@ github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.16.2 h1:8Ebi1Kxdu+O2+7WnVP4mG4UrYf+/TyVzYGaBCaiEkWQ=
 github.com/speakeasy-api/sdk-gen-config v1.16.2/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.0 h1:3AE10I2Si0D0xwnK6nN2nXDc9N8hLLU+16xR3aAHAQ0=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.2 h1:xy85A0Ij3Tdmu3kiMygkzGidt7SSiQYI8i79zgSjX8Y=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.10.2/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.12.1 h1:d/vEqYNeLq7+8Y2mzblbjzs/weA0CHxu9T8F1FF0mrU=
 github.com/speakeasy-api/speakeasy-core v0.12.1/go.mod h1:yjdMxqHFLT2+XipHFHF6rDN8qGuiEvQeO7fA9w22cLk=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -301,7 +301,8 @@ func (w *Workflow) printGenerationOverview(logger log.Logger, endDuration time.D
 	}
 
 	if w.FromQuickstart {
-		additionalLines = append(additionalLines, "Execute `speakeasy run` to regenerate your SDK!")
+		additionalLines = append(additionalLines, "Regenerate your target with `speakeasy run`!")
+		additionalLines = append(additionalLines, "Review all targets with `speakeasy status`.")
 	}
 
 	if t.CodeSamples != nil {


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/SPE-3840/feature-implement-speakeasy-status-cli-command

Initially provides a user with a visual overview of their current (non-archived) workspace targets using colors and textual formatting. Each target is displayed as a card. Each card has:

- Headline: Target type, target name (if available and meaningful), onboarding status, and latest version
- Alerts: Such as publish failures (with direct link), generate failures (with direct link), and target upgrades (with docs link)
- Information: Publish URL, repository URL, Speakeasy URL, last publish time, last generate time

The cards are sorted with the top-down precedence:

- Errors, then success
- Onboarding status (published, configured, then unconfigured)
- Target type and version (alphabetical: Go (v1), Python (v2), etc.)
- Target name (if provided, alphabetical)