### PR TITLE
chore: move to use option func pattern

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -255,17 +255,8 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 
 	wf, err := run.NewWorkflow(
 		ctx,
-		"Workflow",
-		initialTarget,
-		"",
-		"",
-		nil,
-		nil,
-		false,
-		!flags.SkipCompile,
-		false,
-		[]string{},
-		"",
+		run.WithTarget(initialTarget),
+		run.WithShouldCompile(!flags.SkipCompile),
 	)
 	if err != nil {
 		return err
@@ -335,17 +326,8 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 
 	wf, err := run.NewWorkflow(
 		ctx,
-		"Workflow",
-		initialTarget,
-		"",
-		"",
-		nil,
-		nil,
-		false,
-		!skipCompile,
-		false,
-		[]string{},
-		"",
+		run.WithTarget(initialTarget),
+		run.WithShouldCompile(!skipCompile),
 	)
 
 	err = wf.RunWithVisualization(ctx)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -259,17 +259,16 @@ func askForSource(sources []string) (string, error) {
 func runFunc(ctx context.Context, flags RunFlags) error {
 	workflow, err := run.NewWorkflow(
 		ctx,
-		"Workflow",
-		flags.Target,
-		flags.Source,
-		flags.Repo,
-		flags.RepoSubdirs,
-		flags.InstallationURLs,
-		flags.Debug,
-		!flags.SkipCompile,
-		flags.Force,
-		flags.RegistryTags,
-		flags.SetVersion,
+		run.WithTarget(flags.Target),
+		run.WithSource(flags.Source),
+		run.WithRepo(flags.Repo),
+		run.WithRepoSubDirs(flags.RepoSubdirs),
+		run.WithInstallationURLs(flags.InstallationURLs),
+		run.WithDebug(flags.Debug),
+		run.WithShouldCompile(!flags.SkipCompile),
+		run.WithForceGeneration(flags.Force),
+		run.WithRegistryTags(flags.RegistryTags),
+		run.WithSetVersion(flags.SetVersion),
 	)
 	if err != nil {
 		return err
@@ -287,17 +286,16 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 func runInteractive(ctx context.Context, flags RunFlags) error {
 	workflow, err := run.NewWorkflow(
 		ctx,
-		"ignored",
-		flags.Target,
-		flags.Source,
-		flags.Repo,
-		flags.RepoSubdirs,
-		flags.InstallationURLs,
-		flags.Debug,
-		!flags.SkipCompile,
-		flags.Force,
-		flags.RegistryTags,
-		flags.SetVersion,
+		run.WithTarget(flags.Target),
+		run.WithSource(flags.Source),
+		run.WithRepo(flags.Repo),
+		run.WithRepoSubDirs(flags.RepoSubdirs),
+		run.WithInstallationURLs(flags.InstallationURLs),
+		run.WithDebug(flags.Debug),
+		run.WithShouldCompile(!flags.SkipCompile),
+		run.WithForceGeneration(flags.Force),
+		run.WithRegistryTags(flags.RegistryTags),
+		run.WithSetVersion(flags.SetVersion),
 	)
 	if err != nil {
 		return err

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -1,0 +1,184 @@
+package run
+
+import (
+	"context"
+	"fmt"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/speakeasy-core/events"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/sdkgen"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
+)
+
+type Workflow struct {
+	// Opts
+	Target           string
+	Source           string
+	Repo             string
+	SetVersion       string
+	Debug            bool
+	ShouldCompile    bool
+	ForceGeneration  bool
+	SkipLinting      bool
+	SkipChangeReport bool
+	SkipSnapshot     bool
+	FromQuickstart   bool
+	RepoSubDirs      map[string]string
+	InstallationURLs map[string]string
+	RegistryTags     []string
+
+	// Internal
+	workflowName       string
+	SDKOverviewURLs    map[string]string
+	RootStep           *workflowTracking.WorkflowStep
+	workflow           workflow.Workflow
+	projectDir         string
+	validatedDocuments []string
+	generationAccess   *sdkgen.GenerationAccess
+	OperationsRemoved  []string
+	computedChanges    map[string]bool
+	sourceResults      map[string]*SourceResult
+	lockfile           *workflow.LockFile
+	lockfileOld        *workflow.LockFile // the lockfile as it was before the current run
+}
+
+type Opt func(w *Workflow)
+
+func NewWorkflow(
+	ctx context.Context,
+	opts ...Opt,
+) (*Workflow, error) {
+	wf, projectDir, err := utils.GetWorkflowAndDir()
+	if err != nil || wf == nil {
+		return nil, fmt.Errorf("failed to load workflow.yaml: %w", err)
+	}
+
+	// Load the current lockfile so that we don't overwrite all targets
+	lockfile, err := workflow.LoadLockfile(projectDir)
+	lockfileOld := lockfile
+
+	if err != nil || lockfile == nil {
+		lockfile = &workflow.LockFile{
+			Sources: make(map[string]workflow.SourceLock),
+			Targets: make(map[string]workflow.TargetLock),
+		}
+	}
+	lockfile.SpeakeasyVersion = events.GetSpeakeasyVersionFromContext(ctx)
+	lockfile.Workflow = *wf
+
+	// Default values
+	w := &Workflow{
+		workflowName:     "Workflow",
+		RepoSubDirs:      make(map[string]string),
+		InstallationURLs: make(map[string]string),
+		SDKOverviewURLs:  make(map[string]string),
+		Debug:            false,
+		ShouldCompile:    true,
+		workflow:         *wf,
+		projectDir:       projectDir,
+		ForceGeneration:  false,
+		sourceResults:    make(map[string]*SourceResult),
+		computedChanges:  make(map[string]bool),
+		lockfile:         lockfile,
+		lockfileOld:      lockfileOld,
+	}
+
+	for _, opt := range opts {
+		opt(w)
+	}
+
+	w.RootStep = workflowTracking.NewWorkflowStep(w.workflowName, log.From(ctx), nil)
+
+	return w, nil
+}
+
+func WithWorkflowName(name string) Opt {
+	return func(w *Workflow) {
+		w.workflowName = name
+	}
+}
+
+func WithSource(source string) Opt {
+	return func(w *Workflow) {
+		w.Source = source
+	}
+}
+
+func WithTarget(target string) Opt {
+	return func(w *Workflow) {
+		w.Target = target
+	}
+}
+
+func WithSetVersion(version string) Opt {
+	return func(w *Workflow) {
+		w.SetVersion = version
+	}
+}
+
+func WithDebug(debug bool) Opt {
+	return func(w *Workflow) {
+		w.Debug = debug
+	}
+}
+
+func WithSkipChangeReport(skip bool) Opt {
+	return func(w *Workflow) {
+		w.SkipChangeReport = skip
+	}
+}
+
+func WithSkipSnapshot(skip bool) Opt {
+	return func(w *Workflow) {
+		w.SkipSnapshot = skip
+	}
+}
+
+func WithRepo(repo string) Opt {
+	return func(w *Workflow) {
+		w.Repo = repo
+	}
+}
+
+func WithShouldCompile(shouldCompile bool) Opt {
+	return func(w *Workflow) {
+		w.ShouldCompile = shouldCompile
+	}
+}
+
+func WithForceGeneration(forceGeneration bool) Opt {
+	return func(w *Workflow) {
+		w.ForceGeneration = forceGeneration
+	}
+}
+
+func WithSkipLinting() Opt {
+	return func(w *Workflow) {
+		w.SkipLinting = true
+	}
+}
+
+func WithFromQuickstart(fromQuickstart bool) Opt {
+	return func(w *Workflow) {
+		w.FromQuickstart = fromQuickstart
+	}
+}
+
+func WithRepoSubDirs(repoSubDirs map[string]string) Opt {
+	return func(w *Workflow) {
+		w.RepoSubDirs = repoSubDirs
+	}
+}
+
+func WithInstallationURLs(installationURLs map[string]string) Opt {
+	return func(w *Workflow) {
+		w.InstallationURLs = installationURLs
+	}
+}
+
+func WithRegistryTags(registryTags []string) Opt {
+	return func(w *Workflow) {
+		w.RegistryTags = registryTags
+	}
+}


### PR DESCRIPTION
Refactors `run` to use the "functional options pattern". This should only be a code hygiene change. Additionally adds a few options to skip certain steps, though these are unused at the moment