### PR TITLE
fix: show keymap for configure publishing target selection

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -374,24 +374,14 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		return fmt.Errorf("you cannot run configure when a speakeasy workflow does not exist, try speakeasy quickstart")
 	}
 
-	var publishingOptions []huh.Option[string]
+	var targets []string
 	for name, target := range workflowFile.Targets {
 		if slices.Contains(prompts.SupportedPublishingTargets, target.Target) {
-			publishingOptions = append(publishingOptions, huh.NewOption(fmt.Sprintf("%s [%s]", name, strings.ToUpper(target.Target)), name))
+			targets = append(targets, name)
 		}
 	}
 
-	if len(publishingOptions) == 0 {
-		logger.Println(styles.Info.Render("No existing SDK targets require package manager publishing configuration."))
-		return nil
-	}
-
-	chosenTargets, err := prompts.SelectPublishingTargets(publishingOptions, true)
-	if err != nil {
-		return err
-	}
-
-	for _, name := range chosenTargets {
+	for _, name := range targets {
 		target := workflowFile.Targets[name]
 		modifiedTarget, err := prompts.ConfigurePublishing(&target, name)
 		if err != nil {
@@ -417,7 +407,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		}
 		generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
 	} else if len(workflowFile.Targets) > 1 {
-		for _, name := range chosenTargets {
+		for _, name := range targets {
 			generationWorkflow, generationWorkflowFilePath, newPaths, err := writePublishingFile(workflowFile, workingDir, &name)
 			if err != nil {
 				return err

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -561,25 +561,3 @@ func defaultPublishingFile() *config.PublishWorkflow {
 		},
 	}
 }
-
-func SelectPublishingTargets(publishingOptions []huh.Option[string], autoSelect bool) ([]string, error) {
-	chosenTargets := make([]string, 0)
-	if autoSelect {
-		for _, option := range publishingOptions {
-			chosenTargets = append(chosenTargets, option.Value)
-		}
-	}
-	if _, err := charm.NewForm(huh.NewForm(huh.NewGroup(
-		huh.NewMultiSelect[string]().
-			Title("Select targets to configure publishing configs for.").
-			Description("Setup variables to configure publishing directly from Speakeasy.\n").
-			Options(publishingOptions...).
-			Value(&chosenTargets),
-	)),
-		"Would you like to configure publishing for any existing targets?").
-		ExecuteForm(); err != nil {
-		return nil, err
-	}
-
-	return chosenTargets, nil
-}


### PR DESCRIPTION
For `speakeasy configure publishing`:
- Automatically skip the target selection if there's only one target
- Actually show the keys which control the target multiselect in the keymap

![CleanShot 2024-08-06 at 12 52 44@2x](https://github.com/user-attachments/assets/376c7468-00be-45cb-bd0e-8f5b84d57f7a)

https://linear.app/speakeasy/issue/SPE-3890/bug-speakeasy-configure-publishing-sets-up-all-targets-regardless-of