### PR TITLE
feat: improve admin CLI dx for registry publishing/downloading

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -1,11 +1,15 @@
 package cmd
 
 import (
+	"fmt"
+	"github.com/charmbracelet/bubbles/list"
 	core "github.com/speakeasy-api/speakeasy-core/auth"
 	"github.com/speakeasy-api/speakeasy/internal/auth"
+	"github.com/speakeasy-api/speakeasy/internal/config"
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/spf13/cobra"
+	"strings"
 )
 
 var authCmd = &cobra.Command{
@@ -29,14 +33,66 @@ var logoutCmd = &cobra.Command{
 	RunE:  logoutExec,
 }
 
+var switchCmd = &cobra.Command{
+	Use:   "switch",
+	Short: "Switch between authenticated workspaces",
+	Long:  `Change the default workspace to a different authenticated workspace`,
+	RunE:  switchExec,
+}
+
 func authInit() {
 	authCmd.AddCommand(loginCmd)
 	authCmd.AddCommand(logoutCmd)
+	authCmd.AddCommand(switchCmd)
 	rootCmd.AddCommand(authCmd)
 }
 
 func loginExec(cmd *cobra.Command, args []string) error {
-	authCtx, err := auth.Authenticate(cmd.Context(), true)
+	return login(cmd, true)
+}
+
+func logoutExec(cmd *cobra.Command, args []string) error {
+	return auth.Logout(cmd.Context())
+}
+
+func switchExec(cmd *cobra.Command, args []string) error {
+	var items []list.Item
+
+	for _, workspace := range config.GetAuthenticatedWorkspaces() {
+		// Always show speakeasy-self at the beginning
+		if workspace == "speakeasy-self@speakeasy-self" {
+			items = append([]list.Item{interactivity.Item[string]{
+				Label: workspace,
+				Value: workspace,
+			}}, items...)
+		} else {
+			items = append(items, interactivity.Item[string]{
+				Label: workspace,
+				Value: workspace,
+			})
+		}
+	}
+
+	selected := interactivity.SelectFrom[string]("Select a workspace to switch to", items)
+
+	parts := strings.Split(selected, "@")
+	if len(parts) != 2 {
+		return fmt.Errorf("failed to switch workspaces. Unrecognized key format")
+	}
+
+	key := config.GetWorkspaceAPIKey(parts[0], parts[1])
+	if err := config.ClearSpeakeasyAuthInfo(); err != nil {
+		return err
+	}
+	if err := config.SetSpeakeasyAPIKey(key); err != nil {
+		return err
+	}
+
+	return login(cmd, false)
+}
+
+func login(cmd *cobra.Command, force bool) error {
+	authCtx, err := auth.Authenticate(cmd.Context(), force)
 	if err != nil {
 		return err
 	}
@@ -55,8 +111,4 @@ func loginExec(cmd *cobra.Command, args []string) error {
 		Infof("Review the workspace with `speakeasy status` or create a new target with `speakeasy quickstart`.")
 
 	return nil
-}
-
-func logoutExec(cmd *cobra.Command, args []string) error {
-	return auth.Logout(cmd.Context())
 }

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -15,7 +15,7 @@ func Authenticate(ctx context.Context, force bool) (context.Context, error) {
 	if err != nil {
 		return authCtx, err
 	}
-	if err := config.SetSpeakeasyAuthInfo(res); err != nil {
+	if err := config.SetSpeakeasyAuthInfo(authCtx, res); err != nil {
 		return authCtx, fmt.Errorf("failed to save API key: %w", err)
 	}
 
@@ -35,10 +35,11 @@ func UseExistingAPIKeyIfAvailable(ctx context.Context) (context.Context, error) 
 	if err != nil {
 		return ctx, err
 	}
-	config.SetSpeakeasyAuthInfo(core.SpeakeasyAuthInfo{
+	config.SetSpeakeasyAuthInfo(ctx, core.SpeakeasyAuthInfo{
 		APIKey:      existingApiKey,
 		WorkspaceID: workspaceID,
 	})
+
 	return ctx, nil
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"context"
+	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"os"
 	"path/filepath"
 
@@ -12,6 +15,10 @@ import (
 var (
 	vCfg   = viper.New()
 	cfgDir string
+)
+
+const (
+	workspaceKeysKey = "workspace_api_keys"
 )
 
 func Load() error {
@@ -56,16 +63,55 @@ func GetStudioSecret() string {
 	return vCfg.GetString("speakeasy_studio_secret")
 }
 
+func GetWorkspaceAPIKey(orgSlug, workspaceSlug string) string {
+	keys := vCfg.Sub(workspaceKeysKey)
+
+	if keys != nil {
+		return keys.GetString(getWorkspaceKey(orgSlug, workspaceSlug))
+	}
+
+	return ""
+}
+
+func SetWorkspaceAPIKey(orgSlug, workspaceSlug, key string) error {
+	keys := map[string]interface{}{}
+
+	keysVal := vCfg.Get(workspaceKeysKey)
+	if keysVal != nil {
+		keys = keysVal.(map[string]interface{})
+	}
+
+	keys[getWorkspaceKey(orgSlug, workspaceSlug)] = key
+
+	vCfg.Set(workspaceKeysKey, keys)
+
+	return save()
+}
+
+func getWorkspaceKey(orgSlug, workspaceSlug string) string {
+	return fmt.Sprintf("%s@%s", orgSlug, workspaceSlug)
+}
+
 func SetStudioSecret(secret string) error {
 	vCfg.Set("speakeasy_studio_secret", secret)
 	return save()
 }
 
-func SetSpeakeasyAuthInfo(info core.SpeakeasyAuthInfo) error {
-	vCfg.Set("speakeasy_api_key", info.APIKey)
-	vCfg.Set("speakeasy_workspace_id", info.WorkspaceID)
-	vCfg.Set("speakeasy_customer_id", info.CustomerID)
-	return save()
+func SetSpeakeasyAuthInfo(ctx context.Context, info core.SpeakeasyAuthInfo) error {
+	// Keep speakeasy-self as default workspace
+	if vCfg.GetString("speakeasy_workspace_id") != "self" {
+		vCfg.Set("speakeasy_api_key", info.APIKey)
+		vCfg.Set("speakeasy_workspace_id", info.WorkspaceID)
+		vCfg.Set("speakeasy_customer_id", info.CustomerID)
+	} else {
+		println(styles.DimmedItalic.Render("Keeping speakeasy-self as default workspace. New workspace will still be usable as a registry source. Logout first if you want to change default workspaces\n"))
+	}
+
+	orgSlug := core.GetOrgSlugFromContext(ctx)
+	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
+
+	// SetWorkspaceAPIKey executes save()
+	return SetWorkspaceAPIKey(orgSlug, workspaceSlug, info.APIKey)
 }
 
 func ClearSpeakeasyAuthInfo() error {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -127,7 +127,7 @@ func DownloadRegistryOpenAPIBundle(ctx context.Context, document workflow.Speake
 
 	apiKey := config.GetWorkspaceAPIKey(document.OrganizationSlug, document.WorkspaceSlug)
 	if apiKey == "" {
-		return nil, fmt.Errorf("no API key found for workspace %s/%s. Run `speakeasy auth login` to authenticate with the correct workspace", document.OrganizationSlug, document.WorkspaceSlug)
+		apiKey = config.GetSpeakeasyAPIKey()
 	}
 
 	bundleLoader := loader.NewLoader(loader.OCILoaderOptions{

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -116,7 +116,7 @@ func DownloadFile(url, outPath, header, token string) error {
 }
 
 // DownloadRegistryOpenAPIBundle Returns a file path within the downloaded bundle or error
-func DownloadRegistryOpenAPIBundle(ctx context.Context, namespaceName, reference, outPath string) (*DownloadedRegistryOpenAPIBundle, error) {
+func DownloadRegistryOpenAPIBundle(ctx context.Context, document workflow.SpeakeasyRegistryDocument, outPath string) (*DownloadedRegistryOpenAPIBundle, error) {
 	serverURL := auth.GetServerURL()
 	insecurePublish := false
 	if strings.HasPrefix(serverURL, "http://") {
@@ -125,14 +125,19 @@ func DownloadRegistryOpenAPIBundle(ctx context.Context, namespaceName, reference
 	reg := strings.TrimPrefix(serverURL, "http://")
 	reg = strings.TrimPrefix(reg, "https://")
 
+	apiKey := config.GetWorkspaceAPIKey(document.OrganizationSlug, document.WorkspaceSlug)
+	if apiKey == "" {
+		return nil, fmt.Errorf("no API key found for workspace %s/%s. Run `speakeasy auth login` to authenticate with the correct workspace", document.OrganizationSlug, document.WorkspaceSlug)
+	}
+
 	bundleLoader := loader.NewLoader(loader.OCILoaderOptions{
 		Registry: reg,
-		Access: ocicommon.NewRepositoryAccess(config.GetSpeakeasyAPIKey(), namespaceName, ocicommon.RepositoryAccessOptions{
+		Access: ocicommon.NewRepositoryAccess(apiKey, document.NamespaceName, ocicommon.RepositoryAccessOptions{
 			Insecure: insecurePublish,
 		}),
 	})
 
-	bundleResult, err := bundleLoader.LoadOpenAPIBundle(ctx, reference)
+	bundleResult, err := bundleLoader.LoadOpenAPIBundle(ctx, document.Reference)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +169,8 @@ func DownloadRegistryOpenAPIBundle(ctx context.Context, namespaceName, reference
 
 	return &DownloadedRegistryOpenAPIBundle{
 		LocalFilePath:     outputFileName,
-		NamespaceName:     namespaceName,
-		ManifestReference: reference,
+		NamespaceName:     document.NamespaceName,
+		ManifestReference: document.Reference,
 		ManifestDigest:    bundleResult.ManifestDigest,
 		BlobDigest:        bundleResult.BlobDigest,
 	}, nil

--- a/internal/interactivity/hiddenCommands.go
+++ b/internal/interactivity/hiddenCommands.go
@@ -13,4 +13,5 @@ var HiddenCommands = []string{
 	"bump",
 	"tag",
 	"clean",
+	"generate",
 }

--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -62,7 +62,7 @@ func SelectCommand(label string, cmd *cobra.Command) *cobra.Command {
 		return cmd
 	}
 
-	selected := getSelectionFromList(label, subcommands)
+	selected := selectCommand(label, subcommands)
 
 	if selected != nil && selected != cmd && selected.HasSubCommands() {
 		return SelectCommand(label, selected)
@@ -110,7 +110,7 @@ func RequestFlagValues(commandName string, flags *pflag.FlagSet) ([]*pflag.Flag,
 	var missingOptionalFlags []*pflag.Flag
 
 	requestValue := func(flag *pflag.Flag) {
-		// If the flag already has a value, skip it
+		// If the flag already has a Value, skip it
 		if flag.Changed || flag.Hidden || slices.Contains(utils.FlagsToIgnore, flag.Name) {
 			return
 		}
@@ -154,7 +154,7 @@ func RequestFlagValues(commandName string, flags *pflag.FlagSet) ([]*pflag.Flag,
 		}
 
 		if v != "" {
-			// Check if the flag takes an array value
+			// Check if the flag takes an array Value
 			if sliceVal, ok := flag.Value.(pflag.SliceValue); ok {
 				vals := strings.Split(v, ",")
 				if err := sliceVal.Replace(vals); err != nil {

--- a/internal/interactivity/multiInput.go
+++ b/internal/interactivity/multiInput.go
@@ -251,7 +251,7 @@ func (m *MultiInput) getFilledValues() map[string]string {
 
 func (m *MultiInput) OnUserExit() {}
 
-// Run returns a map from input name to the input value
+// Run returns a map from input name to the input Value
 func (m *MultiInput) Run() map[string]string {
 	newM, err := charm_internal.RunModel(m)
 	if err != nil {

--- a/internal/interactivity/simpleInput.go
+++ b/internal/interactivity/simpleInput.go
@@ -90,7 +90,7 @@ func (m *SimpleInput) SetWidth(width int) {}
 
 func (m *SimpleInput) Validate() error {
 	if m.inputModel.Value() == "" {
-		return fmt.Errorf("please supply a value")
+		return fmt.Errorf("please supply a Value")
 	}
 	return m.validate(m.inputModel.Value())
 }
@@ -115,7 +115,7 @@ func (m *SimpleInput) View() string {
 
 func (m *SimpleInput) OnUserExit() {}
 
-// Run returns a map from input name to the input value
+// Run returns a map from input name to the input Value
 func (m *SimpleInput) Run() string {
 	newM, err := charm_internal.RunModel(m)
 	if err != nil {

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -325,6 +325,8 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	}()
 
 	namespaceName := strcase.ToKebab(sourceID)
+	apiKey := config.GetSpeakeasyAPIKey()
+
 	if source.Registry != nil {
 		orgSlug, workspaceSlug, name, err := source.Registry.ParseRegistryLocation()
 		if err != nil {
@@ -335,30 +337,19 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			log.From(ctx).Warnf("error parsing registry location %s: %v", string(source.Registry.Location), err)
 		}
 
-		authenticatedOrg := auth.GetOrgSlugFromContext(ctx)
-		if orgSlug != authenticatedOrg {
-			// If the user is authenticated with speakeasy-self, just skip snapshotting rather than failing
-			if authenticatedOrg == speakeasySelf && !env.IsGithubAction() {
-				registryStep.Skip("you are authenticated with speakeasy-self")
-				return nil
-			}
+		skip, key, err := getAndValidateAPIKey(ctx, orgSlug, workspaceSlug, string(source.Registry.Location))
 
-			message := fmt.Sprintf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), string(source.Registry.Location))
-			if !env.IsGithubAction() {
-				message += " run `speakeasy auth logout`"
-			}
-			return fmt.Errorf(message)
+		if skip {
+			registryStep.Skip("you are authenticated with speakeasy-self")
+			return nil
 		}
 
-		if workspaceSlug != auth.GetWorkspaceSlugFromContext(ctx) {
-			message := fmt.Sprintf("current authenticated workspace %s does not match provided location %s", auth.GetWorkspaceSlugFromContext(ctx), string(source.Registry.Location))
-			if !env.IsGithubAction() {
-				message += " run `speakeasy auth logout`"
-			}
-			return fmt.Errorf(message)
+		if err != nil {
+			return err
 		}
 
 		namespaceName = name
+		apiKey = key
 	}
 
 	tags, err := w.getRegistryTags(ctx, sourceID)
@@ -429,7 +420,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	pushResult, err := pl.PushOCIImage(ctx, memfs, &bundler.OCIPushOptions{
 		Tags:     tags,
 		Registry: reg,
-		Access: ocicommon.NewRepositoryAccess(config.GetSpeakeasyAPIKey(), namespaceName, ocicommon.RepositoryAccessOptions{
+		Access: ocicommon.NewRepositoryAccess(apiKey, namespaceName, ocicommon.RepositoryAccessOptions{
 			Insecure: insecurePublish,
 		}),
 	})
@@ -492,6 +483,41 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	}
 
 	return nil
+}
+
+func getAndValidateAPIKey(ctx context.Context, orgSlug, workspaceSlug, registryLocation string) (skip bool, key string, err error) {
+	if key = config.GetWorkspaceAPIKey(orgSlug, workspaceSlug); key != "" {
+		return
+	}
+
+	authenticatedOrg := auth.GetOrgSlugFromContext(ctx)
+	if orgSlug != authenticatedOrg {
+		// If the user is authenticated with speakeasy-self, just skip snapshotting rather than failing
+		if authenticatedOrg == speakeasySelf && !env.IsGithubAction() {
+			skip = true
+			return
+		}
+
+		message := fmt.Sprintf("current authenticated org %s does not match provided location %s", auth.GetOrgSlugFromContext(ctx), registryLocation)
+		if !env.IsGithubAction() {
+			message += " run `speakeasy auth logout`"
+		}
+		err = fmt.Errorf(message)
+		return
+	}
+
+	if workspaceSlug != auth.GetWorkspaceSlugFromContext(ctx) {
+		message := fmt.Sprintf("current authenticated workspace %s does not match provided location %s", auth.GetWorkspaceSlugFromContext(ctx), registryLocation)
+		if !env.IsGithubAction() {
+			message += " run `speakeasy auth logout`"
+		}
+		err = fmt.Errorf(message)
+		return
+	}
+
+	key = config.GetSpeakeasyAPIKey()
+
+	return
 }
 
 func (w *Workflow) getRegistryTags(ctx context.Context, sourceID string) ([]string, error) {

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -338,7 +338,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 		authenticatedOrg := auth.GetOrgSlugFromContext(ctx)
 		if orgSlug != authenticatedOrg {
 			// If the user is authenticated with speakeasy-self, just skip snapshotting rather than failing
-			if authenticatedOrg == "speakeasy-self" {
+			if authenticatedOrg == speakeasySelf && !env.IsGithubAction() {
 				registryStep.Skip("you are authenticated with speakeasy-self")
 				return nil
 			}
@@ -347,11 +347,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			if speakeasySelf == auth.GetOrgSlugFromContext(ctx) && !env.IsGithubAction() {
-				log.From(ctx).Warn(message)
-			} else {
-				return fmt.Errorf(message)
-			}
+			return fmt.Errorf(message)
 		}
 
 		if workspaceSlug != auth.GetWorkspaceSlugFromContext(ctx) {
@@ -359,11 +355,7 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 			if !env.IsGithubAction() {
 				message += " run `speakeasy auth logout`"
 			}
-			if speakeasySelf == auth.GetWorkspaceSlugFromContext(ctx) && !env.IsGithubAction() {
-				log.From(ctx).Warn(message)
-			} else {
-				return fmt.Errorf(message)
-			}
+			return fmt.Errorf(message)
 		}
 
 		namespaceName = name

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -3,6 +3,7 @@ package registry
 import (
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/config"
 	"os"
 	"path/filepath"
 
@@ -30,8 +31,8 @@ func ResolveSpeakeasyRegistryBundle(ctx context.Context, d workflow.Document, ou
 		return nil, fmt.Errorf("failed to parse speakeasy registry reference %s", d.Location)
 	}
 
-	// Allow speakeasy-self to bypass this check for downloading only
-	if organizationSlug != "speakeasy-self" {
+	keyForWorkspace := config.GetWorkspaceAPIKey(organizationSlug, workspaceSlug)
+	if keyForWorkspace == "" {
 		if registryBreakdown.OrganizationSlug != organizationSlug {
 			return nil, fmt.Errorf("organization mismatch: %s != %s", registryBreakdown.OrganizationSlug, organizationSlug)
 		}
@@ -41,7 +42,7 @@ func ResolveSpeakeasyRegistryBundle(ctx context.Context, d workflow.Document, ou
 		}
 	}
 
-	return download.DownloadRegistryOpenAPIBundle(ctx, registryBreakdown.NamespaceName, registryBreakdown.Reference, outPath)
+	return download.DownloadRegistryOpenAPIBundle(ctx, *registryBreakdown, outPath)
 }
 
 func IsRegistryEnabled(ctx context.Context) bool {

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -30,12 +30,15 @@ func ResolveSpeakeasyRegistryBundle(ctx context.Context, d workflow.Document, ou
 		return nil, fmt.Errorf("failed to parse speakeasy registry reference %s", d.Location)
 	}
 
-	if registryBreakdown.OrganizationSlug != organizationSlug {
-		return nil, fmt.Errorf("organization mismatch: %s != %s", registryBreakdown.OrganizationSlug, organizationSlug)
-	}
+	// Allow speakeasy-self to bypass this check for downloading only
+	if organizationSlug != "speakeasy-self" {
+		if registryBreakdown.OrganizationSlug != organizationSlug {
+			return nil, fmt.Errorf("organization mismatch: %s != %s", registryBreakdown.OrganizationSlug, organizationSlug)
+		}
 
-	if registryBreakdown.WorkspaceSlug != workspaceSlug {
-		return nil, fmt.Errorf("workspace mismatch: %s != %s", registryBreakdown.WorkspaceSlug, workspaceSlug)
+		if registryBreakdown.WorkspaceSlug != workspaceSlug {
+			return nil, fmt.Errorf("workspace mismatch: %s != %s", registryBreakdown.WorkspaceSlug, workspaceSlug)
+		}
 	}
 
 	return download.DownloadRegistryOpenAPIBundle(ctx, registryBreakdown.NamespaceName, registryBreakdown.Reference, outPath)


### PR DESCRIPTION
This PR makes it easier and safer for admins to work in customer repos.
It adds support for "multi-auth", making `speakeasy auth login` an additive operation:
- You will now be able to download any registry images without switching workspaces. This should reduce the need to authenticate with customer workspaces and thus reduce the risk of accidentally pushing an image to the wrong workspace
- Snapshotting will be skipped (rather than failing) if the target org doesn't match, again reducing the need to authenticate with customer workspaces