### PR TITLE
fix: show keymap for configure publishing target selection

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -144,8 +144,10 @@ func configureSources(ctx context.Context, flags ConfigureSourcesFlags) error {
 
 	if !flags.New && existingSource == nil {
 		prompt := charm.NewSelectPrompt("What source would you like to configure?", "You may choose an existing source or create a new source.", sourceOptions, &existingSourceName)
-		if _, err := charm.NewForm(huh.NewForm(prompt),
-			"Let's configure a source for your workflow.").ExecuteForm(); err != nil {
+		if _, err := charm.NewForm(
+			huh.NewForm(prompt),
+			charm.WithTitle("Let's configure a source for your workflow."),
+		).ExecuteForm(); err != nil {
 			return err
 		}
 		if existingSourceName == "new source" {
@@ -248,7 +250,7 @@ func configureTarget(ctx context.Context, flags ConfigureTargetFlags) error {
 	if !newTarget && existingTarget == "" {
 		prompt := charm.NewSelectPrompt("What target would you like to configure?", "You may choose an existing target or create a new target.", targetOptions, &existingTarget)
 		if _, err := charm.NewForm(huh.NewForm(prompt),
-			"Let's configure a target for your workflow.").
+			charm.WithTitle("Let's configure a target for your workflow.")).
 			ExecuteForm(); err != nil {
 			return err
 		}
@@ -381,14 +383,17 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		}
 	}
 
+	var chosenTargets []string
 	if len(publishingOptions) == 0 {
 		logger.Println(styles.Info.Render("No existing SDK targets require package manager publishing configuration."))
 		return nil
-	}
-
-	chosenTargets, err := prompts.SelectPublishingTargets(publishingOptions, true)
-	if err != nil {
-		return err
+	} else if len(publishingOptions) == 1 {
+		chosenTargets = []string{publishingOptions[0].Value}
+	} else {
+		chosenTargets, err = prompts.SelectPublishingTargets(publishingOptions, true)
+		if err != nil {
+			return err
+		}
 	}
 
 	for _, name := range chosenTargets {

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -170,7 +170,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 				return nil
 			}).
 			Value(&promptedDir))),
-			"Pick an output directory for your newly created files.").
+			charm.WithTitle("Pick an output directory for your newly created files.")).
 			ExecuteForm()
 	} else {
 		promptedDir = "."

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -230,7 +230,7 @@ func askForTarget(title, description, confirmation string, targets []string, all
 	target := ""
 
 	prompt := charm.NewSelectPrompt(title, description, targetOptions, &target)
-	if _, err := charm.NewForm(huh.NewForm(prompt), confirmation).ExecuteForm(); err != nil {
+	if _, err := charm.NewForm(huh.NewForm(prompt), charm.WithTitle(confirmation)).ExecuteForm(); err != nil {
 		return "", err
 	}
 
@@ -249,7 +249,7 @@ func askForSource(sources []string) (string, error) {
 	source := ""
 
 	prompt := charm.NewSelectPrompt("What source would you like to run?", "You may choose an individual target or 'all'.", sourceOptions, &source)
-	if _, err := charm.NewForm(huh.NewForm(prompt), "Let's choose a target to run the generation workflow.").ExecuteForm(); err != nil {
+	if _, err := charm.NewForm(huh.NewForm(prompt), charm.WithTitle("Let's choose a target to run the generation workflow.")).ExecuteForm(); err != nil {
 		return "", err
 	}
 

--- a/internal/ask/ask.go
+++ b/internal/ask/ask.go
@@ -152,7 +152,7 @@ func RunInteractiveChatSession(ctx context.Context, message string, sessionID st
 	logger := log.From(ctx)
 	scanner := bufio.NewScanner(os.Stdin)
 	logger.Info("Entering interactive chat session, type exit or use ctrl + c to close.")
-    logger.PrintfStyled(styles.Dimmed, "Example: How do I override a method name in my OpenAPI document?")
+	logger.PrintfStyled(styles.Dimmed, "Example: How do I override a method name in my OpenAPI document?")
 
 	if message != "" {
 		logger.Info("\nProcessing your question, this may take a minute...")
@@ -178,7 +178,7 @@ func RunInteractiveChatSession(ctx context.Context, message string, sessionID st
 		}
 
 		var err error
-        logger.Info("Processing your question, this may take a minute...")
+		logger.Info("Processing your question, this may take a minute...")
 		sessionID, err = Ask(ctx, input, sessionID)
 		if err != nil {
 			logger.Errorf("An error occurred: %v\n", err)
@@ -193,8 +193,10 @@ func OfferChatSessionOnError(ctx context.Context, message string) {
 	logger := log.From(ctx)
 	var confirm bool
 
-	if _, err := charm_internal.NewForm(huh.NewForm(
-		charm_internal.NewBranchPrompt("Would you like to enter an interactive chat session with Speakeasy AI for help?", &confirm)), fmt.Sprintf("Ask Speakeasy AI:")).
+	if _, err := charm_internal.NewForm(
+		huh.NewForm(charm_internal.NewBranchPrompt("Would you like to enter an interactive chat session with Speakeasy AI for help?", &confirm)),
+		charm_internal.WithTitle(fmt.Sprintf("Ask Speakeasy AI:")),
+	).
 		ExecuteForm(); err != nil {
 		logger.Printf("Failed to display confirmation prompt: %v", err)
 		return

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -125,7 +125,7 @@ func PromptForTargetConfig(targetName string, wf *workflow.Workflow, target *wor
 
 	if len(initialFields) > 0 {
 		form := huh.NewForm(huh.NewGroup(initialFields...))
-		if _, err := charm.NewForm(form, formTitle, formSubtitle).ExecuteForm(); err != nil {
+		if _, err := charm.NewForm(form, charm.WithTitle(formTitle), charm.WithDescription(formSubtitle)).ExecuteForm(); err != nil {
 			return nil, err
 		}
 	}
@@ -147,7 +147,7 @@ func PromptForTargetConfig(targetName string, wf *workflow.Workflow, target *wor
 
 	if len(languageGroups) > 0 {
 		form := huh.NewForm(languageGroups...)
-		if _, err := charm.NewForm(form, formTitle, formSubtitle).
+		if _, err := charm.NewForm(form, charm.WithTitle(formTitle), charm.WithDescription(formSubtitle)).
 			ExecuteForm(); err != nil {
 			return nil, err
 		}

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -218,8 +218,8 @@ func executePromptsForPublishing(prompts map[publishingPrompt]*string, target *w
 	}
 
 	if _, err := charm.NewForm(huh.NewForm(groups...),
-		fmt.Sprintf("Setup publishing variables for your %s target %s.", target.Target, name),
-		"These environment variables will be used to publish to package managers from your speakeasy workflow.").
+		charm.WithTitle(fmt.Sprintf("Setup publishing variables for your %s target %s.", target.Target, name)),
+		charm.WithDescription("These environment variables will be used to publish to package managers from your speakeasy workflow.")).
 		ExecuteForm(); err != nil {
 		return err
 	}
@@ -569,15 +569,16 @@ func SelectPublishingTargets(publishingOptions []huh.Option[string], autoSelect 
 			chosenTargets = append(chosenTargets, option.Value)
 		}
 	}
-	if _, err := charm.NewForm(huh.NewForm(huh.NewGroup(
+
+	form := charm.NewForm(huh.NewForm(huh.NewGroup(
 		huh.NewMultiSelect[string]().
 			Title("Select targets to configure publishing configs for.").
 			Description("Setup variables to configure publishing directly from Speakeasy.\n").
 			Options(publishingOptions...).
 			Value(&chosenTargets),
-	)),
-		"Would you like to configure publishing for any existing targets?").
-		ExecuteForm(); err != nil {
+	)), charm.WithKey("x/space", "toggle"))
+
+	if _, err := form.ExecuteForm(); err != nil {
 		return nil, err
 	}
 

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -30,7 +30,7 @@ func getOASLocation(location, authHeader *string, allowSample bool) error {
 
 	_, err := charm_internal.NewForm(huh.NewForm(
 		getRemoteAuthenticationPrompts(location, authHeader)...),
-		"Looks like your document requires authentication").
+		charm_internal.WithTitle("Looks like your document requires authentication")).
 		ExecuteForm()
 
 	return err
@@ -229,7 +229,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 	prompt := charm_internal.NewSelectPrompt("Would you like to modify the location of an existing OpenAPI document or add a new one?", "", inputOptions, &selectedDoc)
 	if _, err := charm_internal.NewForm(huh.NewForm(
 		prompt),
-		fmt.Sprintf("Let's modify the source %s", name)).
+		charm_internal.WithTitle(fmt.Sprintf("Let's modify the source %s", name))).
 		ExecuteForm(); err != nil {
 		return nil, err
 	}
@@ -254,7 +254,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		groups = append(groups, getRemoteAuthenticationPrompts(&fileLocation, &authHeader)...)
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's modify the source %s", name)).
+			charm_internal.WithTitle(fmt.Sprintf("Let's modify the source %s", name))).
 			ExecuteForm(); err != nil {
 			return nil, err
 		}
@@ -285,7 +285,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another openapi file to this source?", &addOpenAPIFile))
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's add to the source %s", name)).
+			charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
 			ExecuteForm(); err != nil {
 			return nil, err
 		}
@@ -300,7 +300,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 	addOverlayFile := false
 	if _, err := charm_internal.NewForm(huh.NewForm(
 		charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", &addOverlayFile)),
-		fmt.Sprintf("Let's add to the source %s", name)).
+		charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
 		ExecuteForm(); err != nil {
 		return nil, err
 	}
@@ -313,7 +313,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another overlay file to this source?", &addOverlayFile))
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
-			fmt.Sprintf("Let's add to the source %s", name)).
+			charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
 			ExecuteForm(); err != nil {
 			return nil, err
 		}
@@ -344,7 +344,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 					})).
 					Value(&outputLocation),
 			)),
-			fmt.Sprintf("Let's modify the source %s", name)).
+			charm_internal.WithTitle(fmt.Sprintf("Let's modify the source %s", name))).
 			ExecuteForm(); err != nil {
 			return nil, err
 		}
@@ -394,8 +394,8 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	if _, err := charm_internal.NewForm(huh.NewForm(
 		groups...),
-		"Let's set up a new source for your workflow.",
-		"A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.").
+		charm_internal.WithTitle("Let's set up a new source for your workflow."),
+		charm_internal.WithDescription("A source is a compiled set of OpenAPI specs and overlays that are used as the input for a SDK generation.")).
 		ExecuteForm(); err != nil {
 		return "", nil, err
 	}

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -115,8 +115,8 @@ func PromptForNewTarget(currentWorkflow *workflow.Workflow, targetName, targetTy
 	sourceName := getSourcesFromWorkflow(currentWorkflow)[0]
 	prompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, true)
 	if _, err := charm.NewForm(huh.NewForm(prompts...),
-		"Let's set up a new target for your workflow.",
-		"A target defines what language to generate and how.").
+		charm.WithTitle("Let's set up a new target for your workflow."),
+		charm.WithDescription("A target defines what language to generate and how.")).
 		ExecuteForm(); err != nil {
 		return "", nil, err
 	}
@@ -148,8 +148,8 @@ func PromptForExistingTarget(currentWorkflow *workflow.Workflow, targetName stri
 
 	prompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, false)
 	if _, err := charm.NewForm(huh.NewForm(prompts...),
-		"Let's set up a new target for your workflow.",
-		"A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.").ExecuteForm(); err != nil {
+		charm.WithTitle("Let's set up a new target for your workflow."),
+		charm.WithDescription("A target is a set of workflow instructions and a gen.yaml config that defines what you would like to generate.")).ExecuteForm(); err != nil {
 		return "", nil, err
 	}
 
@@ -190,7 +190,7 @@ func PromptForOutDirMigration(currentWorkflow *workflow.Workflow, existingTarget
 					Suggestions(charm.DirsInCurrentDir(outDir)).
 					SetSuggestionCallback(charm.SuggestionCallback(charm.SuggestionCallbackConfig{IsDirectories: true})).
 					Value(&outDir))),
-				"When setting up multiple targets we recommend you select an output directory not in the root folder.").ExecuteForm(); err != nil {
+				charm.WithTitle("When setting up multiple targets we recommend you select an output directory not in the root folder.")).ExecuteForm(); err != nil {
 				return err
 			}
 


### PR DESCRIPTION
For `speakeasy configure publishing`:
- Automatically skip the target selection if there's only one target
- Actually show the keys which control the target multiselect in the keymap

![CleanShot 2024-08-06 at 12 52 44@2x](https://github.com/user-attachments/assets/376c7468-00be-45cb-bd0e-8f5b84d57f7a)

https://linear.app/speakeasy/issue/SPE-3890/bug-speakeasy-configure-publishing-sets-up-all-targets-regardless-of