### PR TITLE
chore: add frozen-workflow-lockfile and skip-versioning arguments, alongside making the schema registry stable

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -81,6 +81,6 @@ jobs:
         run: go build ./...
 
       - name: ${{ matrix.test-group }}
-        run: go test -json -v -p 1 -run ./... | gotestfmt
+        run: go test -json -v -p 1 ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/cmd/generate/sdk.go
+++ b/cmd/generate/sdk.go
@@ -96,6 +96,7 @@ func genSDKs(ctx context.Context, flags GenerateFlags) error {
 		false,
 		flags.Force,
 		"",
+		false,
 	)
 
 	return err

--- a/cmd/openapi.go
+++ b/cmd/openapi.go
@@ -263,7 +263,7 @@ func processRegistryBundles(ctx context.Context, flags OpenAPIDiffFlags) (bool, 
 			Location: oldSchema,
 		}
 
-		output := document.GetTempRegistryDir(workflow.GetTempDir())
+		output := workflow.GetTempDir()
 		oldSchemaResult, err := registry.ResolveSpeakeasyRegistryBundle(ctx, document, output)
 		if err != nil {
 			return false, "", "", err
@@ -285,7 +285,7 @@ func processRegistryBundles(ctx context.Context, flags OpenAPIDiffFlags) (bool, 
 			Location: newSchema,
 		}
 
-		output := document.GetTempRegistryDir(workflow.GetTempDir())
+		output := workflow.GetTempDir()
 		newSchemaResult, err := registry.ResolveSpeakeasyRegistryBundle(ctx, document, output)
 		if err != nil {
 			return false, "", "", err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -288,11 +288,11 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 		run.WithInstallationURLs(flags.InstallationURLs),
 		run.WithDebug(flags.Debug),
 		run.WithShouldCompile(!flags.SkipCompile),
-		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
 		run.WithSkipVersioning(flags.SkipVersioning),
 		run.WithForceGeneration(flags.Force),
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
+		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
 	)
 	if err != nil {
 		return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -20,21 +20,23 @@ import (
 )
 
 type RunFlags struct {
-	Target           string            `json:"target"`
-	Source           string            `json:"source"`
-	InstallationURL  string            `json:"installationURL"`
-	InstallationURLs map[string]string `json:"installationURLs"`
-	Debug            bool              `json:"debug"`
-	Repo             string            `json:"repo"`
-	RepoSubdir       string            `json:"repo-subdir"`
-	RepoSubdirs      map[string]string `json:"repo-subdirs"`
-	SkipCompile      bool              `json:"skip-compile"`
-	Force            bool              `json:"force"`
-	Output           string            `json:"output"`
-	Pinned           bool              `json:"pinned"`
-	RegistryTags     []string          `json:"registry-tags"`
-	SetVersion       string            `json:"set-version"`
-	LaunchStudio     bool              `json:"launch-studio"`
+	Target             string            `json:"target"`
+	Source             string            `json:"source"`
+	InstallationURL    string            `json:"installationURL"`
+	InstallationURLs   map[string]string `json:"installationURLs"`
+	Debug              bool              `json:"debug"`
+	Repo               string            `json:"repo"`
+	RepoSubdir         string            `json:"repo-subdir"`
+	RepoSubdirs        map[string]string `json:"repo-subdirs"`
+	SkipCompile        bool              `json:"skip-compile"`
+	SkipVersioning     bool              `json:"skip-versioning"`
+	FrozenWorkflowLock bool              `json:"frozen-workflow-lock"`
+	Force              bool              `json:"force"`
+	Output             string            `json:"output"`
+	Pinned             bool              `json:"pinned"`
+	RegistryTags       []string          `json:"registry-tags"`
+	SetVersion         string            `json:"set-version"`
+	LaunchStudio       bool              `json:"launch-studio"`
 	GitHub           bool              `json:"github"`
 }
 
@@ -98,6 +100,17 @@ A full workflow is capable of running the following steps:
 		flag.BooleanFlag{
 			Name:        "skip-compile",
 			Description: "skip compilation when generating the SDK",
+		},
+		flag.BooleanFlag{
+			Name:         "skip-versioning",
+			Description:  "skip automatic SDK version increments",
+			DefaultValue: false,
+		},
+		flag.BooleanFlag{
+			Name:         "frozen-workflow-lock",
+			Description:  "executes using the stored inputs from the workflow.lock, such that no OAS change occurs",
+			DefaultValue: false,
+			Hidden:       true, // we are unaware of any use cases for this flag outside of upgrade regression testing, which we execute internally
 		},
 		flag.BooleanFlag{
 			Name:        "force",
@@ -275,6 +288,8 @@ func runFunc(ctx context.Context, flags RunFlags) error {
 		run.WithInstallationURLs(flags.InstallationURLs),
 		run.WithDebug(flags.Debug),
 		run.WithShouldCompile(!flags.SkipCompile),
+		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
+		run.WithSkipVersioning(flags.SkipVersioning),
 		run.WithForceGeneration(flags.Force),
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
@@ -300,6 +315,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 	opts := []run.Opt{
 		run.WithTarget(flags.Target),
 		run.WithSource(flags.Source),
+		run.WithSkipVersioning(flags.SkipVersioning),
 		run.WithRepo(flags.Repo),
 		run.WithRepoSubDirs(flags.RepoSubdirs),
 		run.WithInstallationURLs(flags.InstallationURLs),
@@ -308,6 +324,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithForceGeneration(flags.Force),
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
+		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
 	}
 
 	// Don't cleanup if we're launching studio, we need the temp output

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,7 +30,7 @@ type RunFlags struct {
 	RepoSubdirs        map[string]string `json:"repo-subdirs"`
 	SkipCompile        bool              `json:"skip-compile"`
 	SkipVersioning     bool              `json:"skip-versioning"`
-	FrozenWorkflowLock bool              `json:"frozen-workflow-lock"`
+	FrozenWorkflowLock bool              `json:"frozen-workflow-lockfile"`
 	Force              bool              `json:"force"`
 	Output             string            `json:"output"`
 	Pinned             bool              `json:"pinned"`
@@ -107,7 +107,7 @@ A full workflow is capable of running the following steps:
 			DefaultValue: false,
 		},
 		flag.BooleanFlag{
-			Name:         "frozen-workflow-lock",
+			Name:         "frozen-workflow-lockfile",
 			Description:  "executes using the stored inputs from the workflow.lock, such that no OAS change occurs",
 			DefaultValue: false,
 			Hidden:       true, // we are unaware of any use cases for this flag outside of upgrade regression testing, which we execute internally

--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,8 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.22.4
 
-replace github.com/speakeasy-api/speakeasy-core v0.12.2 => ../speakeasy-core
+replace github.com/speakeasy-api/speakeasy-core v0.13.1 => ../speakeasy-core
+replace github.com/speakeasy-api/sdk-gen-config v1.17.1 => ../sdk-gen-config
 
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4

--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.18.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5
-	github.com/speakeasy-api/speakeasy-core v0.13.1
+	github.com/speakeasy-api/speakeasy-core v0.14.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.22.4
 
-replace github.com/speakeasy-api/speakeasy-core v0.13.1 => ../speakeasy-core
-replace github.com/speakeasy-api/sdk-gen-config v1.17.1 => ../sdk-gen-config
-
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4
 	github.com/charmbracelet/bubbles v0.18.0
@@ -23,7 +20,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.1
 	github.com/speakeasy-api/openapi-generation/v2 v2.399.0
 	github.com/speakeasy-api/openapi-overlay v0.9.0
-	github.com/speakeasy-api/sdk-gen-config v1.17.1
+	github.com/speakeasy-api/sdk-gen-config v1.18.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5
 	github.com/speakeasy-api/speakeasy-core v0.13.1
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.22.4
 
+replace github.com/speakeasy-api/speakeasy-core v0.12.2 => ../speakeasy-core
+
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4
 	github.com/charmbracelet/bubbles v0.18.0

--- a/go.sum
+++ b/go.sum
@@ -498,14 +498,10 @@ github.com/speakeasy-api/huh v1.1.1 h1:tSBHezk8MRHBwtWqjMB/fepU6HcFWu9esyZxAKw/X
 github.com/speakeasy-api/huh v1.1.1/go.mod h1:iBavR3Ieq/4upEcdq+VXQyeShcoC9cOhsQbhc/cMuLU=
 github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xHR62pM24=
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
-github.com/speakeasy-api/openapi-generation/v2 v2.396.0 h1:C508flSHG7ilNEVD3f+oXUrEJGXAS2CnsmQkj1UqJqs=
-github.com/speakeasy-api/openapi-generation/v2 v2.396.0/go.mod h1:SyAOAmw08IdSxib03itQGPDSgblwulNXNk0PC3MXq1g=
 github.com/speakeasy-api/openapi-generation/v2 v2.399.0 h1:RDVuyCdxT7WLOlIkJ3UpDqHxAPns1+mPfdJfvEk47dM=
 github.com/speakeasy-api/openapi-generation/v2 v2.399.0/go.mod h1:TThE6Pr3xMunJdKz5pW0KMtZV93yllNoEEVCAEXZpZU=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.16.3-0.20240729110508-03297b5219a8 h1:vPHo2M26wafMdQC2KI5iPdwYm23CyntzKZmFLalyC/I=
-github.com/speakeasy-api/sdk-gen-config v1.16.3-0.20240729110508-03297b5219a8/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/sdk-gen-config v1.17.1 h1:tnSULwGwbIt+1/UC6gTS1AGXsQD3BliPBJhtBWr3zEw=
 github.com/speakeasy-api/sdk-gen-config v1.17.1/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5 h1:B1PZcFT/gK+2Ry47mcfSPGwMWqUU8Mcxd4flUAehDhY=

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/speakeasy-api/sdk-gen-config v1.18.0 h1:iRhMDkZQV/uWJhf4XUi5mVNHft3qO
 github.com/speakeasy-api/sdk-gen-config v1.18.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5 h1:B1PZcFT/gK+2Ry47mcfSPGwMWqUU8Mcxd4flUAehDhY=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.13.1 h1:bKgdq///fqDAQINywUd9Dv+AyYeVjvz+Mv0kuWUEh0A=
-github.com/speakeasy-api/speakeasy-core v0.13.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
+github.com/speakeasy-api/speakeasy-core v0.14.0 h1:fDIDgfXsc7Rt7FfcNWVMfp0spv84beuO7KK8GMthOw4=
+github.com/speakeasy-api/speakeasy-core v0.14.0/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/go.sum
+++ b/go.sum
@@ -502,8 +502,8 @@ github.com/speakeasy-api/openapi-generation/v2 v2.399.0 h1:RDVuyCdxT7WLOlIkJ3UpD
 github.com/speakeasy-api/openapi-generation/v2 v2.399.0/go.mod h1:TThE6Pr3xMunJdKz5pW0KMtZV93yllNoEEVCAEXZpZU=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.17.1 h1:tnSULwGwbIt+1/UC6gTS1AGXsQD3BliPBJhtBWr3zEw=
-github.com/speakeasy-api/sdk-gen-config v1.17.1/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
+github.com/speakeasy-api/sdk-gen-config v1.18.0 h1:iRhMDkZQV/uWJhf4XUi5mVNHft3qONyOQb4baaEDDMc=
+github.com/speakeasy-api/sdk-gen-config v1.18.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5 h1:B1PZcFT/gK+2Ry47mcfSPGwMWqUU8Mcxd4flUAehDhY=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.13.1 h1:bKgdq///fqDAQINywUd9Dv+AyYeVjvz+Mv0kuWUEh0A=

--- a/integration/overlay_test.go
+++ b/integration/overlay_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -28,5 +29,15 @@ func TestOverlayMatchesSnapshot(t *testing.T) {
 	require.NoError(t, cmdErr)
 	readBytes, err := os.ReadFile(outputPath)
 	require.NoError(t, err)
-	require.Equal(t, string(expectedBytes), string(readBytes))
+
+	// Normalize line endings for both expected and actual content
+	expectedNormalized := normalizeLineEndings(string(expectedBytes))
+	actualNormalized := normalizeLineEndings(string(readBytes))
+
+	require.Equal(t, expectedNormalized, actualNormalized)
+}
+
+// normalizeLineEndings replaces all occurrences of \r\n with \n
+func normalizeLineEndings(s string) string {
+	return strings.ReplaceAll(s, "\r\n", "\n")
 }

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -1,0 +1,99 @@
+package integration_tests
+
+import (
+	"crypto/md5"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFrozenWorkflowLock(t *testing.T) {
+	t.Parallel()
+	temp := setupTestDir(t)
+
+	// Create a basic workflow file
+	workflowFile := &workflow.Workflow{
+		Version: workflow.WorkflowVersion,
+		Sources: map[string]workflow.Source{
+			"test-source": {
+				Inputs: []workflow.Document{
+					{Location: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.yaml"},
+				},
+			},
+		},
+		Targets: map[string]workflow.Target{
+			"test-target": {
+				Target: "go",
+				Source: "test-source",
+			},
+		},
+	}
+
+	err := os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755)
+	require.NoError(t, err)
+	err = workflow.Save(temp, workflowFile)
+	require.NoError(t, err)
+
+	// Run the initial generation
+	initialArgs := []string{"run", "-t", "all"}
+	cmdErr := executeI(t, temp, initialArgs...).Run()
+	require.NoError(t, cmdErr)
+
+	// Calculate checksums of generated files
+	initialChecksums, err := calculateChecksums(temp)
+	require.NoError(t, err)
+
+	// Modify the source OpenAPI spec to simulate a change
+	// Shouldn't do anything; we'll validate that later.
+	err = modifyOpenAPISpec(temp)
+	require.NoError(t, err)
+
+	// Run with --frozen-workflow-lock
+	frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lock"}
+	cmdErr = executeI(t, temp, frozenArgs...).Run()
+	require.NoError(t, cmdErr)
+
+	// Calculate checksums after frozen run
+	frozenChecksums, err := calculateChecksums(temp)
+	require.NoError(t, err)
+
+	// Compare checksums
+	require.Equal(t, initialChecksums, frozenChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+}
+
+func calculateChecksums(dir string) (map[string]string, error) {
+	checksums := make(map[string]string)
+	err := filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if !info.IsDir() {
+			data, err := os.ReadFile(path)
+			if err != nil {
+				return err
+			}
+			relPath, _ := filepath.Rel(dir, path)
+			checksums[relPath] = fmt.Sprintf("%x", md5.Sum(data))
+		}
+		return nil
+	})
+	return checksums, err
+}
+
+func modifyOpenAPISpec(dir string) error {
+	specPath := filepath.Join(dir, ".speakeasy", "workflow.lock")
+	data, err := os.ReadFile(specPath)
+	if err != nil {
+		return err
+	}
+
+	// Modify the spec content (this is a simplistic change, you might want to do something more sophisticated)
+	modifiedData := strings.Replace(string(data), "Swagger Petstore", "Modified Petstore", 1)
+
+	return os.WriteFile(specPath, []byte(modifiedData), 0644)
+}

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestFrozenWorkflowLock(t *testing.T) {
+func TestStabilityFrozenWorkflowLock(t *testing.T) {
 	t.Parallel()
 	temp := setupTestDir(t)
 
@@ -47,6 +47,14 @@ func TestFrozenWorkflowLock(t *testing.T) {
 	// Calculate checksums of generated files
 	initialChecksums, err := calculateChecksums(temp)
 	require.NoError(t, err)
+
+	// Re-run the generation. We should have stable digests.
+	cmdErr = executeI(t, temp, initialArgs...).Run()
+	require.NoError(t, cmdErr)
+	rerunChecksums, err := calculateChecksums(temp)
+	require.NoError(t, err)
+	require.Equal(t, initialChecksums, rerunChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+
 
 	// Modify the source OpenAPI spec to simulate a change
 	// Shouldn't do anything; we'll validate that later.

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -40,7 +40,7 @@ func TestStability(t *testing.T) {
 
 	// Run the initial generation
 	var initialChecksums map[string]string
-	initialArgs := []string{"run", "-t", "all", "--force", "--skip-versioning", "--skip-compile"}
+	initialArgs := []string{"run", "-t", "all", "--force", "--pinned", "--skip-versioning", "--skip-compile"}
 	cmdErr := execute(t, temp, initialArgs...).Run()
 	require.NoError(t, cmdErr)
 

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -60,7 +60,7 @@ func TestStability(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run with --frozen-workflow-lock
-	frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lockfile", "--skip-compile"}
+	frozenArgs := []string{"run", "-t", "all", "--pinned", "--frozen-workflow-lockfile", "--skip-compile"}
 	cmdErr = execute(t, temp, frozenArgs...).Run()
 	require.NoError(t, cmdErr)
 

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -40,7 +40,7 @@ func TestStabilityFrozenWorkflowLock(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run the initial generation
-	initialArgs := []string{"run", "-t", "all"}
+	initialArgs := []string{"run", "-t", "all", "--force", "--skip-versioning"}
 	cmdErr := executeI(t, temp, initialArgs...).Run()
 	require.NoError(t, cmdErr)
 

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -27,7 +27,7 @@ func TestStability(t *testing.T) {
 		},
 		Targets: map[string]workflow.Target{
 			"test-target": {
-				Target: "go",
+				Target: "typescript",
 				Source: "test-source",
 			},
 		},
@@ -39,38 +39,44 @@ func TestStability(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run the initial generation
+	var initialChecksums map[string]string
 	initialArgs := []string{"run", "-t", "all", "--force", "--skip-versioning"}
-	cmdErr := execute(t, temp, initialArgs...).Run()
-	require.NoError(t, cmdErr)
+	t.Run("Initial generation", func(t *testing.T) {
+		cmdErr := execute(t, temp, initialArgs...).Run()
+		require.NoError(t, cmdErr)
 
-	// Calculate checksums of generated files
-	initialChecksums, err := calculateChecksums(temp)
-	require.NoError(t, err)
+		// Calculate checksums of generated files
+		initialChecksums, err = calculateChecksums(temp)
+		require.NoError(t, err)
+	})
 
 	// Re-run the generation. We should have stable digests.
-	cmdErr = execute(t, temp, initialArgs...).Run()
-	require.NoError(t, cmdErr)
-	rerunChecksums, err := calculateChecksums(temp)
-	require.NoError(t, err)
-	require.Equal(t, initialChecksums, rerunChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+	t.Run("Re-run generation, validate stability", func(t *testing.T) {
+		cmdErr := execute(t, temp, initialArgs...).Run()
+		require.NoError(t, cmdErr)
+		rerunChecksums, err := calculateChecksums(temp)
+		require.NoError(t, err)
+		require.Equal(t, initialChecksums, rerunChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+	})
 
+	t.Run("Modify the workflow file, then run it with --frozen-workflow-lockfile", func(t *testing.T) {
+		// Modify the workflow file to simulate a change
+		// Shouldn't do anything; we'll validate that later.
+		workflowFile.Sources["test-source"].Inputs[0].Location = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/petstore.yaml"
+		require.NoError(t, err)
 
-	// Modify the workflow file to simulate a change
-	// Shouldn't do anything; we'll validate that later.
-	workflowFile.Sources["test-source"].Inputs[0].Location = "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.1/petstore.yaml"
-	require.NoError(t, err)
+		// Run with --frozen-workflow-lock
+		frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lockfile"}
+		cmdErr := execute(t, temp, frozenArgs...).Run()
+		require.NoError(t, cmdErr)
 
-	// Run with --frozen-workflow-lock
-	frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lockfile"}
-	cmdErr = execute(t, temp, frozenArgs...).Run()
-	require.NoError(t, cmdErr)
+		// Calculate checksums after frozen run
+		frozenChecksums, err := calculateChecksums(temp)
+		require.NoError(t, err)
 
-	// Calculate checksums after frozen run
-	frozenChecksums, err := calculateChecksums(temp)
-	require.NoError(t, err)
-
-	// Compare checksums
-	require.Equal(t, initialChecksums, frozenChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+		// Compare checksums
+		require.Equal(t, initialChecksums, frozenChecksums, "Generated files should be identical when using --frozen-workflow-lock")
+	})
 }
 
 func calculateChecksums(dir string) (map[string]string, error) {

--- a/integration/workflow_registry_test.go
+++ b/integration/workflow_registry_test.go
@@ -40,7 +40,7 @@ func TestStability(t *testing.T) {
 
 	// Run the initial generation
 	var initialChecksums map[string]string
-	initialArgs := []string{"run", "-t", "all", "--force", "--skip-versioning"}
+	initialArgs := []string{"run", "-t", "all", "--force", "--skip-versioning", "--skip-compile"}
 	cmdErr := execute(t, temp, initialArgs...).Run()
 	require.NoError(t, cmdErr)
 
@@ -60,7 +60,7 @@ func TestStability(t *testing.T) {
 	require.NoError(t, err)
 
 	// Run with --frozen-workflow-lock
-	frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lockfile"}
+	frozenArgs := []string{"run", "-t", "all", "--frozen-workflow-lockfile", "--skip-compile"}
 	cmdErr = execute(t, temp, frozenArgs...).Run()
 	require.NoError(t, cmdErr)
 

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -120,7 +120,7 @@ func TestGenerationWorkflows(t *testing.T) {
 			require.NoError(t, err)
 			err = workflow.Save(temp, workflowFile)
 			require.NoError(t, err)
-			args := []string{"run", "-t", "all", "--pinned"}
+			args := []string{"run", "-t", "all", "--pinned", "--skip-compile"}
 			if tt.withForce {
 				args = append(args, "--force", "true")
 			}
@@ -282,7 +282,7 @@ func TestSpecWorkflows(t *testing.T) {
 			require.NoError(t, err)
 			err = workflow.Save(temp, workflowFile)
 			require.NoError(t, err)
-			args := []string{"run", "-s", "all", "--pinned"}
+			args := []string{"run", "-s", "all", "--pinned", "--skip-compile"}
 			cmdErr := execute(t, temp, args...).Run()
 			require.NoError(t, cmdErr)
 
@@ -397,7 +397,7 @@ func TestFallbackCodeSamplesWorkflow(t *testing.T) {
 	})
 	require.NoError(t, cmdErr)
 	require.NotNil(t, reports)
-	require.Greater(t, reports.Reports, 0)
+	require.True(t, len(reports.Reports) > 0, "must have version reports")
 	require.Truef(t, reports.MustGenerate(), "must have gen.lock")
 
 	require.NoError(t, cmdErr)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -397,7 +397,7 @@ func TestFallbackCodeSamplesWorkflow(t *testing.T) {
 	})
 	require.NoError(t, cmdErr)
 	require.NotNil(t, reports)
-	require.Len(t, reports.Reports, 2)
+	require.Len(t, reports.Reports, 1)
 	require.Truef(t, reports.MustGenerate(), "must have gen.lock")
 
 	require.NoError(t, cmdErr)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -397,7 +397,7 @@ func TestFallbackCodeSamplesWorkflow(t *testing.T) {
 	})
 	require.NoError(t, cmdErr)
 	require.NotNil(t, reports)
-	require.Len(t, reports.Reports, 1)
+	require.Greater(t, reports.Reports, 0)
 	require.Truef(t, reports.MustGenerate(), "must have gen.lock")
 
 	require.NoError(t, cmdErr)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -397,7 +397,7 @@ func TestFallbackCodeSamplesWorkflow(t *testing.T) {
 	})
 	require.NoError(t, cmdErr)
 	require.NotNil(t, reports)
-	require.Len(t, reports.Reports, 1)
+	require.Len(t, reports.Reports, 2)
 	require.Truef(t, reports.MustGenerate(), "must have gen.lock")
 
 	require.NoError(t, cmdErr)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -395,6 +395,7 @@ func TestFallbackCodeSamplesWorkflow(t *testing.T) {
 		err := execute(t, temp, args...).Run()
 		return true, err
 	})
+	require.NoError(t, cmdErr)
 	require.NotNil(t, reports)
 	require.Len(t, reports.Reports, 1)
 	require.Truef(t, reports.MustGenerate(), "must have gen.lock")

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -155,10 +155,17 @@ func DownloadRegistryOpenAPIBundle(ctx context.Context, document workflow.Speake
 		return nil, err
 	}
 
+	shortDigest := bundleResult.BlobDigest[8:14]
+	outPath = filepath.Join(outPath, shortDigest)
+
 	var outputFileName string
 	if fileName, _ := bundleResult.BundleAnnotations[ocicommon.AnnotationBundleRoot]; fileName != "" {
 		cleanName := filepath.Clean(fileName)
 		outputFileName = filepath.Join(outPath, cleanName)
+		err = os.MkdirAll(filepath.Dir(outputFileName), os.ModePerm)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create output directory: %w", err)
+		}
 	} else {
 		return nil, fmt.Errorf("no root openapi file found in bundle")
 	}

--- a/internal/overlay/overlay_test.go
+++ b/internal/overlay/overlay_test.go
@@ -3,6 +3,7 @@ package overlay
 import (
 	"github.com/stretchr/testify/require"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,5 +62,10 @@ func test(t *testing.T, schemaFile string, expectedFile string, yamlOut bool) {
 
 	println(string(actualContent))
 
-	assert.Equal(t, string(expectedContent), string(actualContent))
+	normalizeLineEndings := func(s string) string {
+		// Important on Windows
+		return strings.ReplaceAll(s, "\r\n", "\n")
+	}
+
+	assert.Equal(t, normalizeLineEndings(string(expectedContent)), normalizeLineEndings(string(actualContent)))
 }

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -182,7 +182,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 				}
 			} else if overlay.FallbackCodeSamples != nil {
 				// Make temp file for the overlay output
-				overlayFilePath := filepath.Join(workflow.GetTempDir(), fmt.Sprintf("fallback_code_samples_overlay_%s.yaml", randStringBytes(10)))
+				overlayFilePath = filepath.Join(workflow.GetTempDir(), fmt.Sprintf("fallback_code_samples_overlay_%s.yaml", randStringBytes(10)))
 				if err := os.MkdirAll(filepath.Dir(overlayFilePath), 0o755); err != nil {
 					return "", nil, err
 				}

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -166,6 +166,7 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 		w.ShouldCompile,
 		w.ForceGeneration,
 		target,
+		w.SkipVersioning,
 	)
 	if err != nil {
 		return nil, nil, err

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -14,21 +14,23 @@ import (
 
 type Workflow struct {
 	// Opts
-	Target           string
-	Source           string
-	Repo             string
-	SetVersion       string
-	Debug            bool
-	ShouldCompile    bool
-	ForceGeneration  bool
-	SkipLinting      bool
-	SkipChangeReport bool
-	SkipSnapshot     bool
+	Target             string
+	Source             string
+	Repo               string
+	SetVersion         string
+	Debug              bool
+	ShouldCompile      bool
+	ForceGeneration    bool
+	FrozenWorkflowLock bool
+	SkipVersioning     bool
+	SkipLinting        bool
+	SkipChangeReport   bool
+	SkipSnapshot       bool
 	SkipCleanup      bool
-	FromQuickstart   bool
-	RepoSubDirs      map[string]string
-	InstallationURLs map[string]string
-	RegistryTags     []string
+	FromQuickstart     bool
+	RepoSubDirs        map[string]string
+	InstallationURLs   map[string]string
+	RegistryTags       []string
 
 	// Internal
 	workflowName       string
@@ -106,6 +108,28 @@ func WithWorkflowName(name string) Opt {
 func WithSource(source string) Opt {
 	return func(w *Workflow) {
 		w.Source = source
+	}
+}
+
+func WithFrozenWorkflowLock(frozen bool) Opt {
+	return func(w *Workflow) {
+		w.FrozenWorkflowLock = frozen
+		if frozen {
+			// Implies force generation -- workflow.lock being unchanged should mean we skip generation
+			w.ForceGeneration = true
+			// Implies No auto versioning -- workflow.lock being unchanged should mean we skip versioning
+			w.SkipVersioning = true
+			// Implies no snapshot
+			w.SkipSnapshot = true
+			// Implies no change report
+			w.SkipChangeReport = true
+		}
+	}
+}
+
+func WithSkipVersioning(skipVersioning bool) Opt {
+	return func(w *Workflow) {
+		w.SkipVersioning = skipVersioning
 	}
 }
 

--- a/internal/schema/document.go
+++ b/internal/schema/document.go
@@ -28,7 +28,7 @@ func ResolveDocument(ctx context.Context, d workflow.Document, outputLocation *s
 			return "", fmt.Errorf("schema registry is not enabled for this workspace")
 		}
 
-		location := d.GetTempRegistryDir(workflow.GetTempDir())
+		location := workflow.GetTempDir()
 		if outputLocation != nil {
 			location = *outputLocation
 		}

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -111,7 +111,7 @@ func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, he
 		opts = append(opts, generate.WithOutputTests())
 	}
 	if skipVersioning {
-		opts = append(opts, generate.WithSkipVersioning())
+		opts = append(opts, generate.WithSkipVersioning(skipVersioning))
 	}
 
 	g, err := generate.New(opts...)

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -30,7 +30,7 @@ type GenerationAccess struct {
 	Level         *shared.Level
 }
 
-func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, header, token, outDir, cliVersion, installationURL string, debug, autoYes, published, outputTests bool, repo, repoSubDir string, compile, force bool, targetName string) (*GenerationAccess, error) {
+func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, header, token, outDir, cliVersion, installationURL string, debug, autoYes, published, outputTests bool, repo, repoSubDir string, compile, force bool, targetName string, skipVersioning bool) (*GenerationAccess, error) {
 	if !generate.CheckLanguageSupported(lang) {
 		return nil, fmt.Errorf("language not supported: %s", lang)
 	}
@@ -109,6 +109,9 @@ func Generate(ctx context.Context, customerID, workspaceID, lang, schemaPath, he
 	// Enable outputting of internal tests for internal speakeasy use cases
 	if outputTests {
 		opts = append(opts, generate.WithOutputTests())
+	}
+	if skipVersioning {
+		opts = append(opts, generate.WithSkipVersioning())
 	}
 
 	g, err := generate.New(opts...)

--- a/registry/utils.go
+++ b/registry/utils.go
@@ -32,7 +32,7 @@ func ResolveSpeakeasyRegistryBundle(ctx context.Context, d workflow.Document, ou
 	}
 
 	keyForWorkspace := config.GetWorkspaceAPIKey(organizationSlug, workspaceSlug)
-	if keyForWorkspace == "" {
+	if keyForWorkspace == "" && organizationSlug != "speakeasy-self" {
 		if registryBreakdown.OrganizationSlug != organizationSlug {
 			return nil, fmt.Errorf("organization mismatch: %s != %s", registryBreakdown.OrganizationSlug, organizationSlug)
 		}


### PR DESCRIPTION
 * Adds two extra args to `speakeasy run` `--frozen-workflow-lockfile` and `--skip-versioning`
 * Adds an admin user pass-through for schema registry entries (these come with Readonly claims on our server). This is important as we'll shortly start using enterprise customer's latest specifications through the schema registry to validate our changes to generation (as opposed to what we do now, which is manually updated snapshots).
 * Supports new version of sdk-gen-config, which has stable locations for schema registry + URL downloads