### PR TITLE
feat: support simple markdown rendering in CLI log statements

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -22,6 +22,7 @@ import (
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	config "github.com/speakeasy-api/sdk-gen-config"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	errors2 "github.com/speakeasy-api/speakeasy-core/errors"
 	"github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/run"
 	"github.com/speakeasy-api/speakeasy/prompts"
@@ -67,6 +68,11 @@ var quickstartCmd = &model.ExecutableCommand[QuickstartFlags]{
 	},
 }
 
+const ErrWorkflowExists = errors2.Error("You cannot run quickstart when a speakeasy workflow already exists. \n" +
+	"To create a brand _new_ SDK directory: `cd ..` and then `speakeasy quickstart`. \n" +
+	"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
+	"To regenerate the current workflow: `speakeasy run`.")
+
 func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	workingDir, err := os.Getwd()
 	if err != nil {
@@ -74,17 +80,11 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	}
 
 	if workflowFile, _, _ := workflow.Load(workingDir); workflowFile != nil {
-		return fmt.Errorf("You cannot run quickstart when a speakeasy workflow already exists. \n" +
-			"To create a brand new SDK directory: `cd ..` and then `speakeasy quickstart`. \n" +
-			"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
-			"To regenerate the current workflow: `speakeasy run`.")
+		return ErrWorkflowExists
 	}
 
 	if prompts.HasExistingGeneration(workingDir) {
-		return fmt.Errorf("You cannot run quickstart when a speakeasy workflow already exists. \n" +
-			"To create a brand new SDK directory: cd .. and then `speakeasy quickstart`. \n" +
-			"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
-			"To regenerate the current workflow: `speakeasy run`.")
+		return ErrWorkflowExists
 	}
 
 	log.From(ctx).PrintfStyled(styles.DimmedItalic, "\nYour first SDK is a few short questions away...\n")

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -22,7 +22,7 @@ import (
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	config "github.com/speakeasy-api/sdk-gen-config"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
-	errors2 "github.com/speakeasy-api/speakeasy-core/errors"
+	speakeasyErrors "github.com/speakeasy-api/speakeasy-core/errors"
 	"github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/run"
 	"github.com/speakeasy-api/speakeasy/prompts"
@@ -68,7 +68,7 @@ var quickstartCmd = &model.ExecutableCommand[QuickstartFlags]{
 	},
 }
 
-const ErrWorkflowExists = errors2.Error("You cannot run quickstart when a speakeasy workflow already exists. \n" +
+const ErrWorkflowExists = speakeasyErrors.Error("You cannot run quickstart when a speakeasy workflow already exists. \n" +
 	"To create a brand _new_ SDK directory: `cd ..` and then `speakeasy quickstart`. \n" +
 	"To add an additional SDK to this workflow: `speakeasy configure`. \n" +
 	"To regenerate the current workflow: `speakeasy run`.")

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -342,6 +342,8 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		return err
 	}
 
+	workflow.PrintSuccessSummary(ctx)
+
 	// Pass initial results to launch studio
 
 	if flags.LaunchStudio {

--- a/internal/charm/styles/styles.go
+++ b/internal/charm/styles/styles.go
@@ -21,9 +21,10 @@ var (
 
 	Emphasized = HeavilyEmphasized.Foreground(Colors.WhiteBlackAdaptive)
 
-	Info    = Emphasized.Foreground(Colors.Blue)
-	Warning = Emphasized.Foreground(Colors.Yellow)
-	Error   = Emphasized.Foreground(Colors.Red)
+	Success = lipgloss.NewStyle().Foreground(Colors.Green).Bold(true)
+	Info    = lipgloss.NewStyle().Foreground(Colors.Blue)
+	Warning = lipgloss.NewStyle().Foreground(Colors.Yellow)
+	Error   = lipgloss.NewStyle().Foreground(Colors.Red)
 
 	Focused       = lipgloss.NewStyle().Foreground(Colors.Yellow)
 	FocusedDimmed = Focused.Foreground(Colors.DimYellow)
@@ -31,8 +32,6 @@ var (
 	Dimmed       = lipgloss.NewStyle().Foreground(Colors.Grey)
 	DimmedItalic = Dimmed.Italic(true)
 	Help         = DimmedItalic
-
-	Success = Emphasized.Foreground(Colors.Green)
 
 	Cursor = FocusedDimmed
 	None   = lipgloss.NewStyle()

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -269,6 +269,9 @@ func (l Logger) Fprint(w io.Writer, s string) {
 	if l.style != nil {
 		s = l.style.Render(s)
 	}
+
+	s = StyleMarkdown(s)
+
 	fmt.Fprint(w, s)
 }
 
@@ -317,11 +320,11 @@ func PrefixedFormatter(l Logger, level Level, msg string, err error) string {
 
 	switch level {
 	case LevelInfo, LevelSuccess:
-		prefix = styles.Info.Render("INFO\t")
+		prefix = styles.Info.Bold(true).Render("INFO\t")
 	case LevelWarn:
-		prefix = styles.Warning.Render("WARN\t")
+		prefix = styles.Warning.Bold(true).Render("WARN\t")
 	case LevelErr:
-		prefix = styles.Error.Render("ERROR\t")
+		prefix = styles.Error.Bold(true).Render("ERROR\t")
 	}
 
 	return prefix + msg

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -270,7 +270,7 @@ func (l Logger) Fprint(w io.Writer, s string) {
 		s = l.style.Render(s)
 	}
 
-	s = StyleMarkdown(s)
+	s = InjectMarkdownStyles(s)
 
 	fmt.Fprint(w, s)
 }

--- a/internal/log/markdown.go
+++ b/internal/log/markdown.go
@@ -1,0 +1,35 @@
+package log
+
+import (
+	"fmt"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"golang.org/x/exp/maps"
+	"regexp"
+)
+
+var (
+	patternToStyle = map[string]lipgloss.Style{
+		"\\*": lipgloss.NewStyle().Bold(true),
+		"_":   lipgloss.NewStyle().Italic(true),
+		"`":   styles.HeavilyEmphasized,
+	}
+)
+
+func StyleMarkdown(s string) string {
+	// Extract the first style from the string, if present
+	parentStyleRegex := regexp.MustCompile(`\x1b\[.*?m`)
+	parentStyle := parentStyleRegex.FindString(s)
+
+	stopChars := "\\n"
+	for _, pattern := range maps.Keys(patternToStyle) {
+		stopChars += pattern
+	}
+
+	for pattern, style := range patternToStyle {
+		codeRx := regexp.MustCompile(fmt.Sprintf("%s([^%s]+)%s", pattern, pattern, pattern))
+		s = codeRx.ReplaceAllString(s, style.Render("$1")+parentStyle) // Resume parent style after
+	}
+
+	return s
+}

--- a/internal/log/markdown.go
+++ b/internal/log/markdown.go
@@ -15,7 +15,11 @@ var (
 	}
 )
 
-func StyleMarkdown(s string) string {
+// InjectMarkdownStyles parses the string for markdown patterns and applies the appropriate styles
+// For example, the string "*bold text*" will be rendered in bold with the asterisks stripped out
+// The "parent style" will then be resumed. Note that it is assumed there is only one "parent style."
+// Whatever the first style is will be used to resume the original style.
+func InjectMarkdownStyles(s string) string {
 	// Extract the first style from the string, if present
 	parentStyleRegex := regexp.MustCompile(`\x1b\[.*?m`)
 	parentStyle := parentStyleRegex.FindString(s)

--- a/internal/log/markdown.go
+++ b/internal/log/markdown.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"github.com/charmbracelet/lipgloss"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"golang.org/x/exp/maps"
 	"regexp"
 )
 
@@ -20,11 +19,6 @@ func StyleMarkdown(s string) string {
 	// Extract the first style from the string, if present
 	parentStyleRegex := regexp.MustCompile(`\x1b\[.*?m`)
 	parentStyle := parentStyleRegex.FindString(s)
-
-	stopChars := "\\n"
-	for _, pattern := range maps.Keys(patternToStyle) {
-		stopChars += pattern
-	}
 
 	for pattern, style := range patternToStyle {
 		codeRx := regexp.MustCompile(fmt.Sprintf("%s([^%s]+)%s", pattern, pattern, pattern))

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -565,15 +565,16 @@ func (w *Workflow) getRegistryTags(ctx context.Context, sourceID string) ([]stri
 	return tags, nil
 }
 
-func (w *Workflow) printSourceSuccessMessage(ctx context.Context, logger log.Logger) {
+func (w *Workflow) printSourceSuccessMessage(ctx context.Context) {
 	if len(w.SourceResults) == 0 {
 		return
 	}
 
+	logger := log.From(ctx)
 	logger.Println("") // Newline for better readability
 
 	for sourceID, sourceRes := range w.SourceResults {
-		heading := fmt.Sprintf("Source %s %s", styles.HeavilyEmphasized.Render(sourceID), styles.Success.Render("Compiled Successfully"))
+		heading := fmt.Sprintf("Source `%s` Compiled Successfully", sourceID)
 		var additionalLines []string
 
 		appendReportLocation := func(report reports.ReportResult) {
@@ -595,7 +596,7 @@ func (w *Workflow) printSourceSuccessMessage(ctx context.Context, logger log.Log
 			link = links.Shorten(ctx, link)
 
 			msg := fmt.Sprintf("%s %s", styles.Dimmed.Render(sourceRes.Diagnosis.Summarize()+"."), styles.DimmedItalic.Render(link))
-			additionalLines = append(additionalLines, styles.HeavilyEmphasized.Render(fmt.Sprintf("└─%s: ", "Improve with AI")+msg))
+			additionalLines = append(additionalLines, fmt.Sprintf("`└─Improve with AI:` %s", msg))
 		}
 
 		msg := fmt.Sprintf("%s\n%s\n", styles.Success.Render(heading), strings.Join(additionalLines, "\n"))

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -343,7 +343,7 @@ func (w *Workflow) snapshotCodeSamples(ctx context.Context, parentStep *workflow
 	return
 }
 
-func (w *Workflow) printTargetSuccessMessage(ctx context.Context, logger log.Logger) {
+func (w *Workflow) printTargetSuccessMessage(ctx context.Context) {
 	if len(w.SDKOverviewURLs) == 0 {
 		return
 	}
@@ -352,9 +352,9 @@ func (w *Workflow) printTargetSuccessMessage(ctx context.Context, logger log.Log
 	var additionalLines []string
 	for target, url := range w.SDKOverviewURLs {
 		link := links.Shorten(ctx, url)
-		additionalLines = append(additionalLines, styles.Success.Render(fmt.Sprintf("└─%s %s %s", styles.HeavilyEmphasized.Render(target), styles.Success.Render("overview:"), styles.Dimmed.Render(link))))
+		additionalLines = append(additionalLines, styles.Success.Render(fmt.Sprintf("└─`%s` overview: %s", target, styles.Dimmed.Render(link))))
 	}
 
 	msg := fmt.Sprintf("%s\n%s\n", styles.Success.Render(heading), strings.Join(additionalLines, "\n"))
-	logger.Println(msg)
+	log.From(ctx).Println(msg)
 }

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -3,6 +3,7 @@ package run
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/speakeasy-api/speakeasy-core/events"
@@ -39,11 +40,14 @@ type Workflow struct {
 	validatedDocuments []string
 	generationAccess   *sdkgen.GenerationAccess
 	OperationsRemoved  []string
-	computedChanges    map[string]bool
-	SourceResults      map[string]*SourceResult
-	TargetResults      map[string]*TargetResult
 	lockfile           *workflow.LockFile
 	lockfileOld        *workflow.LockFile // the lockfile as it was before the current run
+
+	computedChanges map[string]bool
+	SourceResults   map[string]*SourceResult
+	TargetResults   map[string]*TargetResult
+	duration        time.Duration
+	criticalWarns   []string
 }
 
 type Opt func(w *Workflow)

--- a/internal/workflowTracking/workflowTracking.go
+++ b/internal/workflowTracking/workflowTracking.go
@@ -186,14 +186,14 @@ func (w *WorkflowStep) toString(parentIndent, indent int) string {
 
 	s := fmt.Sprintf("%s%s", indentString, w.name)
 
-	style := styles.Info
+	style := styles.Info.Bold(true)
 	switch w.status {
 	case StatusFailed:
-		style = styles.Error
+		style = styles.Error.Bold(true)
 	case StatusRunning:
-		style = styles.Info
+		style = styles.Info.Bold(true)
 	case StatusSucceeded:
-		style = styles.Success
+		style = styles.Success.Bold(true)
 	case StatusSkipped:
 		style = styles.Dimmed
 	}


### PR DESCRIPTION
Output is mostly unchanged, the styling is just simpler to write

- Also slightly refactors the "success summary" message so that it also prints when running with `-o console`

![CleanShot 2024-08-14 at 12 13 08@2x](https://github.com/user-attachments/assets/800258ca-a025-4113-8103-c75505f39648)

![CleanShot 2024-08-14 at 12 14 14@2x](https://github.com/user-attachments/assets/1ebea355-1e7d-4f58-85e4-81e5acd73737)
