### PR TITLE
feat: unify MVS with studio modifications overlay

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -22,7 +22,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.18.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5
-	github.com/speakeasy-api/speakeasy-core v0.14.0
+	github.com/speakeasy-api/speakeasy-core v0.14.1
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,8 @@ github.com/speakeasy-api/sdk-gen-config v1.18.0 h1:iRhMDkZQV/uWJhf4XUi5mVNHft3qO
 github.com/speakeasy-api/sdk-gen-config v1.18.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5 h1:B1PZcFT/gK+2Ry47mcfSPGwMWqUU8Mcxd4flUAehDhY=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.14.0 h1:fDIDgfXsc7Rt7FfcNWVMfp0spv84beuO7KK8GMthOw4=
-github.com/speakeasy-api/speakeasy-core v0.14.0/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
+github.com/speakeasy-api/speakeasy-core v0.14.1 h1:RsLUhnNYjoq5Nk+d7LwErjrXgUGwqzsqZ9zsfUKRZzA=
+github.com/speakeasy-api/speakeasy-core v0.14.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/charm/styles/markdown.go
+++ b/internal/charm/styles/markdown.go
@@ -1,9 +1,8 @@
-package log
+package styles
 
 import (
 	"fmt"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"regexp"
 	"strings"
 )
@@ -12,7 +11,7 @@ var (
 	patternToStyle = map[string]lipgloss.Style{
 		"\\*": lipgloss.NewStyle().Bold(true),
 		"_":   lipgloss.NewStyle().Italic(true),
-		"`":   styles.HeavilyEmphasized,
+		"`":   HeavilyEmphasized,
 	}
 )
 

--- a/internal/charm/styles/styles.go
+++ b/internal/charm/styles/styles.go
@@ -140,6 +140,9 @@ func MakeBold(s string) string {
 }
 
 func MakeBoxed(s string, borderColor lipgloss.AdaptiveColor, alignment lipgloss.Position) string {
+	// We need to do this before boxing things because the sizing can change
+	s = InjectMarkdownStyles(s)
+
 	termWidth := TerminalWidth() - 2     // Leave room for padding (if the terminal is too small to fit, we need to wrap)
 	stringWidth := lipgloss.Width(s) + 2 // Account for padding (on the other hand, if the terminal is wide enough, add back in the space so it doesn't needlessly wrap)
 	w := min(termWidth, stringWidth)

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -270,7 +270,7 @@ func (l Logger) Fprint(w io.Writer, s string) {
 		s = l.style.Render(s)
 	}
 
-	s = InjectMarkdownStyles(s)
+	s = styles.InjectMarkdownStyles(s)
 
 	fmt.Fprint(w, s)
 }

--- a/internal/run/minimumViableSpec.go
+++ b/internal/run/minimumViableSpec.go
@@ -1,0 +1,94 @@
+package run
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/speakeasy-core/openapi"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/download"
+	"github.com/speakeasy-api/speakeasy/internal/studio/modifications"
+	"github.com/speakeasy-api/speakeasy/internal/transform"
+	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
+	"os"
+	"path/filepath"
+)
+
+func (w *Workflow) retryWithMinimumViableSpec(ctx context.Context, parentStep *workflowTracking.WorkflowStep, sourceID, targetID string, viableOperations []string) (string, *SourceResult, error) {
+	substep := parentStep.NewSubstep("Retrying with minimum viable document")
+	source := w.workflow.Sources[sourceID]
+	baseLocation := source.Inputs[0].Location
+	workingDir := workflow.GetTempDir()
+
+	// This is intended to only be used from quickstart, we must assume a singular input document
+	if len(source.Inputs)+len(source.Overlays) > 1 {
+		return "", nil, errors.New("multiple inputs are not supported for minimum viable spec")
+	}
+
+	tempBase := fmt.Sprintf("downloaded_%s%s", randStringBytes(10), filepath.Ext(baseLocation))
+
+	if source.Inputs[0].IsRemote() {
+		outResolved, err := download.ResolveRemoteDocument(ctx, source.Inputs[0], tempBase)
+		if err != nil {
+			return "", nil, err
+		}
+
+		baseLocation = outResolved
+	}
+
+	overlayOut := filepath.Join(workingDir, fmt.Sprintf("mvs_overlay_%s.yaml", randStringBytes(10)))
+	overlayFile, err := os.Create(overlayOut)
+	if err != nil {
+		return "", nil, err
+	}
+	defer overlayFile.Close()
+
+	failedRetry := false
+	defer func() {
+		os.Remove(overlayOut)
+		os.Remove(filepath.Join(workingDir, tempBase))
+		if failedRetry {
+			source.Overlays = []workflow.Overlay{}
+			w.workflow.Sources[sourceID] = source
+		}
+	}()
+
+	_, _, model, err := openapi.LoadDocument(ctx, source.Inputs[0].Location)
+	if err != nil {
+		return "", nil, err
+	}
+
+	overlay := transform.BuildFilterOperationsOverlay(model, true, viableOperations)
+	if err = modifications.UpsertOverlay(&source, overlay); err != nil {
+		return "", nil, err
+	}
+
+	w.workflow.Sources[sourceID] = source
+
+	sourcePath, sourceRes, err := w.RunSource(ctx, substep, sourceID, targetID)
+	if err != nil {
+		failedRetry = true
+		return "", nil, err
+	}
+
+	if err := workflow.Save(w.ProjectDir, &w.workflow); err != nil {
+		return "", nil, err
+	}
+
+	return sourcePath, sourceRes, err
+}
+
+func groupInvalidOperations(input []string) []string {
+	var result []string
+	for _, op := range input[0:7] {
+		joined := styles.DimmedItalic.Render(fmt.Sprintf("- %s", op))
+		result = append(result, joined)
+	}
+
+	if len(input) > 7 {
+		result = append(result, styles.DimmedItalic.Render(fmt.Sprintf("- ... see %s", modifications.OverlayPath)))
+	}
+
+	return result
+}

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -66,7 +66,7 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 				cliEvent := events.GetTelemetryEventFromContext(ctx)
 				if cliEvent != nil {
 					cliEvent.GenerateNumberOfOperationsIgnored = new(int64)
-					*cliEvent.GenerateNumberOfOperationsIgnored = int64(len(sourceRes.LintResult.InvalidOperation))
+					*cliEvent.GenerateNumberOfOperationsIgnored = int64(len(sourceRes.LintResult.InvalidOperations))
 				}
 
 				retriedPath, retriedRes, retriedErr := w.retryWithMinimumViableSpec(ctx, rootStep, t.Source, target, sourceRes.LintResult.ValidOperations)
@@ -76,7 +76,7 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 					return nil, nil, err
 				}
 
-				w.OperationsRemoved = sourceRes.LintResult.InvalidOperation
+				w.OperationsRemoved = sourceRes.LintResult.InvalidOperations
 				sourcePath = retriedPath
 				sourceRes = retriedRes
 			} else {

--- a/internal/studio/modifications/overlay.go
+++ b/internal/studio/modifications/overlay.go
@@ -1,0 +1,100 @@
+package modifications
+
+import (
+	"github.com/hashicorp/go-version"
+	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
+	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"os"
+	"slices"
+	"strconv"
+)
+
+const (
+	overlayTitle = "Speakeasy Modifications"
+	OverlayPath  = ".speakeasy/speakeasy-modifications-overlay.yaml"
+)
+
+func UpsertOverlay(source *workflow.Source, o overlay.Overlay) error {
+	// Open the file with read and write permissions
+	overlayFile, err := os.OpenFile(OverlayPath, os.O_RDWR|os.O_CREATE, 0644)
+	var baseOverlay *overlay.Overlay
+
+	// If the file exists, load the current overlay
+	if err == nil {
+		baseOverlay, err = loader.LoadOverlay(OverlayPath)
+		if err != nil {
+			return err
+		}
+	} else if os.IsNotExist(err) {
+		overlayFile, err = os.Create(OverlayPath)
+		if err != nil {
+			return err
+		}
+
+		baseOverlay = &overlay.Overlay{
+			Version: "1.0.0",
+			Info: overlay.Info{
+				Title:   overlayTitle,
+				Version: "0.0.0", // bumped later
+			},
+		}
+	} else {
+		return err
+	}
+
+	baseOverlay.Actions = append(baseOverlay.Actions, o.Actions...)
+	baseOverlay.Info.Version = bumpVersion(baseOverlay.Info.Version, o.Info.Version)
+
+	UpsertOverlayIntoSource(source)
+
+	return baseOverlay.Format(overlayFile)
+}
+
+func UpsertOverlayIntoSource(source *workflow.Source) {
+	if source == nil {
+		return
+	}
+
+	// Add the new overlay to the source, if not already present
+	if !slices.ContainsFunc(source.Overlays, func(o workflow.Overlay) bool { return o.Document.Location == OverlayPath }) {
+		source.Overlays = append(source.Overlays, workflow.Overlay{
+			Document: &workflow.Document{
+				Location: OverlayPath,
+			},
+		})
+	}
+}
+
+// If the new version is greater than the base version, return the new version
+// If the new version is less than the base version, return the base version with the patch incremented
+func bumpVersion(baseVersion, newVersion string) (v string) {
+	v = "0.0.1"
+
+	baseSemver, err := version.NewSemver(baseVersion)
+	if err != nil {
+		return
+	}
+
+	newSemver, err := version.NewSemver(baseVersion)
+	if err != nil {
+		return
+	}
+
+	if newSemver.GreaterThan(baseSemver) {
+		v = newVersion
+	} else {
+		segments := baseSemver.Segments()
+		segments[2]++
+
+		v = ""
+		for i, segment := range segments {
+			if i > 0 {
+				v += "."
+			}
+			v += strconv.Itoa(segment)
+		}
+	}
+
+	return
+}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -31,14 +31,14 @@ type OutputLimits struct {
 }
 
 type ValidationResult struct {
-	AllErrors        []error
-	Errors           []error
-	Warnings         []error
-	Infos            []error
-	Status           string
-	ValidOperations  []string
-	InvalidOperation []string
-	Report           *reports.ReportResult
+	AllErrors         []error
+	Errors            []error
+	Warnings          []error
+	Infos             []error
+	Status            string
+	ValidOperations   []string
+	InvalidOperations []string
+	Report            *reports.ReportResult
 }
 
 func ValidateWithInteractivity(ctx context.Context, schemaPath, header, token string, limits *OutputLimits, defaultRuleset, workingDir string) (*ValidationResult, error) {
@@ -338,14 +338,14 @@ func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schem
 	}
 
 	return &ValidationResult{
-		AllErrors:        errs,
-		Errors:           vErrs,
-		Warnings:         vWarns,
-		Infos:            vInfo,
-		Status:           status,
-		ValidOperations:  res.GetValidOperations(),
-		InvalidOperation: res.GetInvalidOperations(),
-		Report:           report,
+		AllErrors:         errs,
+		Errors:            vErrs,
+		Warnings:          vWarns,
+		Infos:             vInfo,
+		Status:            status,
+		ValidOperations:   res.GetValidOperations(),
+		InvalidOperations: res.GetInvalidOperations(),
+		Report:            report,
 	}, nil
 }
 


### PR DESCRIPTION
The most important change here is that it changes the implementation of "minimum viable spec" to create an overlay directly, rather than updating the source then running `overlay compare`

Note: we are no longer running `deleteUnused` as part of MVS, which may result in some extra linting infos for unused things

Needs https://github.com/speakeasy-api/speakeasy-core/pull/77