### PR TITLE
chore: integration test registry interactions

### DIFF
--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -329,7 +329,6 @@ func TestSpecWorkflows(t *testing.T) {
 }
 
 func TestFallbackCodeSamplesWorkflow(t *testing.T) {
-	t.Parallel()
 	spec := `{
 		"openapi": "3.0.0",
 		"info": {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -253,7 +253,7 @@ func copyZipToOutDir(zipReader *zip.Reader, outDir string) error {
 			defer fileReader.Close()
 		}
 
-		targetFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, file.Mode())
+		targetFile, err := os.OpenFile(filePath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0o660)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Makes it such that the error in https://github.com/speakeasy-api/speakeasy/pull/868 can't happen again