### PR TITLE
fix: return filterOperations to its original functionality

### DIFF
--- a/internal/transform/cleanupPaths.go
+++ b/internal/transform/cleanupPaths.go
@@ -1,0 +1,52 @@
+package transform
+
+import (
+	"context"
+	"fmt"
+	"github.com/pb33f/libopenapi"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/pb33f/libopenapi/orderedmap"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"io"
+)
+
+func CleanupDocument(ctx context.Context, schemaPath string, w io.Writer) error {
+	return transformer[interface{}]{
+		schemaPath:  schemaPath,
+		transformFn: Cleanup,
+		w:           w,
+	}.Do(ctx)
+}
+
+func Cleanup(ctx context.Context, doc libopenapi.Document, _ *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
+	_, doc, model, errs := doc.RenderAndReload()
+	// remove nil errs
+	var nonNilErrs []error
+	for _, e := range errs {
+		if e != nil {
+			nonNilErrs = append(nonNilErrs, e)
+		}
+	}
+	if len(nonNilErrs) > 0 {
+		return nil, nil, fmt.Errorf("failed to render and reload document: %v", errs)
+	}
+
+	pathItems := model.Model.Paths.PathItems
+	var pathsToDelete []string
+
+	for pathPair := orderedmap.First(pathItems); pathPair != nil; pathPair = pathPair.Next() {
+		path := pathPair.Key()
+		pathVal := pathPair.Value()
+		operations := pathVal.GetOperations()
+		if operations.Len() == 0 {
+			pathsToDelete = append(pathsToDelete, path)
+		}
+	}
+
+	for _, path := range pathsToDelete {
+		log.From(ctx).Printf("dropped %s\n", path)
+		pathItems.Delete(path)
+	}
+
+	return doc, model, nil
+}

--- a/internal/transform/cleanupPaths.go
+++ b/internal/transform/cleanupPaths.go
@@ -2,7 +2,6 @@ package transform
 
 import (
 	"context"
-	"fmt"
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
@@ -18,19 +17,7 @@ func CleanupDocument(ctx context.Context, schemaPath string, w io.Writer) error 
 	}.Do(ctx)
 }
 
-func Cleanup(ctx context.Context, doc libopenapi.Document, _ *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
-	_, doc, model, errs := doc.RenderAndReload()
-	// remove nil errs
-	var nonNilErrs []error
-	for _, e := range errs {
-		if e != nil {
-			nonNilErrs = append(nonNilErrs, e)
-		}
-	}
-	if len(nonNilErrs) > 0 {
-		return nil, nil, fmt.Errorf("failed to render and reload document: %v", errs)
-	}
-
+func Cleanup(ctx context.Context, doc libopenapi.Document, model *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
 	pathItems := model.Model.Paths.PathItems
 	var pathsToDelete []string
 

--- a/internal/transform/filterOperations.go
+++ b/internal/transform/filterOperations.go
@@ -61,7 +61,7 @@ func filterOperations(ctx context.Context, doc libopenapi.Document, model *libop
 		return doc, model, err
 	}
 
-	_, model, err = Cleanup(ctx, doc, nil, nil)
+	_, model, err = Cleanup(ctx, doc, model, nil)
 	if err != nil {
 		return doc, model, err
 	}

--- a/internal/transform/filterOperations.go
+++ b/internal/transform/filterOperations.go
@@ -1,6 +1,7 @@
 package transform
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
@@ -15,21 +16,57 @@ import (
 )
 
 func FilterOperations(ctx context.Context, schemaPath string, includeOps []string, include bool, w io.Writer) error {
-	_, _, model, err := openapi.LoadDocument(ctx, schemaPath)
-	if err != nil {
-		return err
-	}
+	return transformer[args]{
+		schemaPath:  schemaPath,
+		transformFn: filterOperations,
+		w:           w,
+		args: args{
+			includeOps: includeOps,
+			include:    include,
+			schemaPath: schemaPath,
+		},
+	}.Do(ctx)
+}
 
-	overlay := BuildFilterOperationsOverlay(model, include, includeOps)
+type args struct {
+	includeOps []string
+	include    bool
+	schemaPath string
+}
+
+func filterOperations(ctx context.Context, doc libopenapi.Document, model *libopenapi.DocumentModel[v3.Document], args args) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
+	overlay := BuildFilterOperationsOverlay(model, args.include, args.includeOps)
 
 	root := model.Index.GetRootNode()
 	if err := overlay.ApplyTo(root); err != nil {
-		return err
+		return doc, model, err
 	}
 
-	enc := yaml.NewEncoder(w)
+	newSpec := bytes.Buffer{}
+	enc := yaml.NewEncoder(&newSpec)
 	enc.SetIndent(2)
-	return enc.Encode(root)
+	if err := enc.Encode(root); err != nil {
+		return doc, model, err
+	}
+
+	// Unfortunately, in order to remove orphans, we need to re-render the document.
+	updatedDoc, _, err := openapi.Load(newSpec.Bytes(), args.schemaPath)
+	if err != nil {
+		return doc, model, err
+	}
+	doc = *updatedDoc
+
+	_, model, err = RemoveOrphans(ctx, doc, nil, nil)
+	if err != nil {
+		return doc, model, err
+	}
+
+	_, model, err = Cleanup(ctx, doc, nil, nil)
+	if err != nil {
+		return doc, model, err
+	}
+
+	return doc, model, err
 }
 
 func BuildFilterOperationsOverlay(model *libopenapi.DocumentModel[v3.Document], include bool, ops []string) overlay.Overlay {

--- a/internal/transform/filterOperations_test.go
+++ b/internal/transform/filterOperations_test.go
@@ -1,0 +1,61 @@
+package transform
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFilterOperations(t *testing.T) {
+	// Create a buffer to store the filtered spec
+	var buf bytes.Buffer
+
+	// Call FilterOperations to remove the delete operation
+	err := FilterOperations(context.Background(), "../../integration/resources/part1.yaml", []string{"deletePet"}, false, &buf)
+	require.NoError(t, err)
+
+	// Parse the filtered spec
+	filteredDoc, err := libopenapi.NewDocument(buf.Bytes())
+	require.NoError(t, err)
+
+	model, errors := filteredDoc.BuildV3Model()
+	require.Empty(t, errors)
+
+	// Check that the delete operation is removed
+	paths := model.Model.Paths
+	petPath, ok := paths.PathItems.Get("/pet/{petId}")
+	require.True(t, ok)
+	assert.Nil(t, petPath.Delete, "Delete operation should be removed")
+
+	// Check that other operations still exist
+	assert.NotNil(t, petPath.Get, "Get operation should still exist")
+
+	// Check components
+	components := model.Model.Components
+
+	// Check schemas
+	pet, ok := components.Schemas.Get("Pet")
+	assert.True(t, ok, "Used schema 'Pet' should still exist")
+	assert.NotNil(t, pet)
+
+	// Check for removed schemas
+	order, ok := components.Schemas.Get("Order")
+	assert.False(t, ok, "Schema 'Order' should be removed")
+	assert.Nil(t, order)
+
+	user, ok := components.Schemas.Get("User")
+	assert.False(t, ok, "Schema 'User' should be removed")
+	assert.Nil(t, user)
+
+	// Check responses
+	unauthorized, ok := components.Responses.Get("Unauthorized")
+	assert.True(t, ok, "Response 'Unauthorized' should still exist")
+	assert.NotNil(t, unauthorized)
+
+	// Optional: Print the filtered spec for manual inspection
+	// fmt.Println(buf.String())
+}

--- a/internal/transform/removeUnused.go
+++ b/internal/transform/removeUnused.go
@@ -21,7 +21,7 @@ func RemoveUnused(ctx context.Context, schemaPath string, w io.Writer) error {
 	}.Do(ctx)
 }
 
-func RemoveOrphans(ctx context.Context, doc libopenapi.Document, model *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
+func RemoveOrphans(ctx context.Context, doc libopenapi.Document, _ *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
 	logger := log.From(ctx)
 	_, doc, model, errs := doc.RenderAndReload()
 	// remove nil errs

--- a/internal/transform/removeUnused.go
+++ b/internal/transform/removeUnused.go
@@ -3,14 +3,13 @@ package transform
 import (
 	"context"
 	"fmt"
-	"io"
-	"strings"
-
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/index"
 	"github.com/pb33f/libopenapi/orderedmap"
 	"github.com/speakeasy-api/speakeasy/internal/log"
+	"io"
+	"strings"
 )
 
 func RemoveUnused(ctx context.Context, schemaPath string, w io.Writer) error {
@@ -23,7 +22,9 @@ func RemoveUnused(ctx context.Context, schemaPath string, w io.Writer) error {
 
 func RemoveOrphans(ctx context.Context, doc libopenapi.Document, _ *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
 	logger := log.From(ctx)
+
 	_, doc, model, errs := doc.RenderAndReload()
+
 	// remove nil errs
 	var nonNilErrs []error
 	for _, e := range errs {
@@ -202,6 +203,7 @@ func RemoveOrphans(ctx context.Context, doc libopenapi.Document, _ *libopenapi.D
 	for _, key := range toDelete {
 		headers.Delete(key)
 	}
+
 	if anyRemoved {
 		return RemoveOrphans(ctx, doc, model, nil)
 	}

--- a/internal/transform/transformer.go
+++ b/internal/transform/transformer.go
@@ -2,12 +2,11 @@ package transform
 
 import (
 	"context"
-	"github.com/speakeasy-api/speakeasy-core/openapi"
-	"io"
-
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
+	"github.com/speakeasy-api/speakeasy-core/openapi"
+	"io"
 )
 
 type transformer[Args interface{}] struct {


### PR DESCRIPTION
Mistral was apparently using this and relying on the fact that it _also_ removed orphans and empty paths

This reintroduces that functionality at the cost of performance.