### PR TITLE
feat: non root directory configure github/publishing

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -377,7 +377,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		if err := promptForWorkflowFileDir(workingDir, &workflowFileDir); err != nil {
 			return err
 		}
-		workflowFile, _, _ = workflow.Load(workflowFileDir)
+		workflowFile, _, _ = workflow.Load(filepath.Join(workingDir, workflowFileDir))
 	}
 
 	if workflowFile == nil {
@@ -446,7 +446,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		}
 	}
 
-	if err := workflow.Save(workingDir, workflowFile); err != nil {
+	if err := workflow.Save(filepath.Join(workingDir, workflowFileDir), workflowFile); err != nil {
 		return errors.Wrapf(err, "failed to save workflow file")
 	}
 
@@ -460,7 +460,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		secretPath = fmt.Sprintf("%s/settings/secrets/actions", remoteURL)
 	}
 
-	_, workflowFilePath, err := workflow.Load(workingDir)
+	_, workflowFilePath, err := workflow.Load(filepath.Join(workingDir, workflowFileDir))
 	if err != nil {
 		return errors.Wrapf(err, "failed to load workflow file")
 	}
@@ -527,7 +527,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		if err := promptForWorkflowFileDir(workingDir, &workflowFileDir); err != nil {
 			return err
 		}
-		workflowFile, _, _ = workflow.Load(workflowFileDir)
+		workflowFile, _, _ = workflow.Load(filepath.Join(workingDir, workflowFileDir))
 	}
 
 	if workflowFile == nil {
@@ -605,7 +605,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		}
 	}
 
-	if err := workflow.Save(workingDir, workflowFile); err != nil {
+	if err := workflow.Save(filepath.Join(workingDir, workflowFileDir), workflowFile); err != nil {
 		return errors.Wrapf(err, "failed to save workflow file")
 	}
 
@@ -624,7 +624,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		secretPath = fmt.Sprintf("%s/settings/secrets/actions", remoteURL)
 	}
 
-	_, workflowFilePath, err := workflow.Load(workingDir)
+	_, workflowFilePath, err := workflow.Load(filepath.Join(workingDir, workflowFileDir))
 	if err != nil {
 		return errors.Wrapf(err, "failed to load workflow file")
 	}

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -371,7 +371,15 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		return err
 	}
 
+	var workflowFileDir string
 	workflowFile, _, _ := workflow.Load(workingDir)
+	if workflowFile == nil {
+		if err := promptForWorkflowFileDir(workingDir, &workflowFileDir); err != nil {
+			return err
+		}
+		workflowFile, _, _ = workflow.Load(workflowFileDir)
+	}
+
 	if workflowFile == nil {
 		return fmt.Errorf("you cannot run configure when a speakeasy workflow does not exist, make sure you are in your SDK directory")
 	}
@@ -408,7 +416,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 	secrets := make(map[string]string)
 	var publishPaths, generationWorkflowFilePaths []string
 	if len(workflowFile.Targets) == 1 {
-		generationWorkflow, generationWorkflowFilePath, newPaths, err := writePublishingFile(workflowFile, workingDir, nil)
+		generationWorkflow, generationWorkflowFilePath, newPaths, err := writePublishingFile(workflowFile, workingDir, workflowFileDir, nil)
 		if err != nil {
 			return err
 		}
@@ -423,7 +431,7 @@ func configurePublishing(ctx context.Context, _flags ConfigureGithubFlags) error
 		generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
 	} else if len(workflowFile.Targets) > 1 {
 		for _, name := range chosenTargets {
-			generationWorkflow, generationWorkflowFilePath, newPaths, err := writePublishingFile(workflowFile, workingDir, &name)
+			generationWorkflow, generationWorkflowFilePath, newPaths, err := writePublishingFile(workflowFile, workingDir, workflowFileDir, &name)
 			if err != nil {
 				return err
 			}
@@ -513,7 +521,15 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	orgSlug := core.GetOrgSlugFromContext(ctx)
 	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
 
+	var workflowFileDir string
 	workflowFile, _, _ := workflow.Load(workingDir)
+	if workflowFile == nil {
+		if err := promptForWorkflowFileDir(workingDir, &workflowFileDir); err != nil {
+			return err
+		}
+		workflowFile, _, _ = workflow.Load(workflowFileDir)
+	}
+
 	if workflowFile == nil {
 		return fmt.Errorf("you cannot run configure when a speakeasy workflow does not exist, make sure you are in your SDK directory")
 	}
@@ -557,7 +573,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	var generationWorkflowFilePaths []string
 
 	if len(workflowFile.Targets) <= 1 {
-		generationWorkflow, generationWorkflowFilePath, err := writeGenerationFile(workflowFile, workingDir, nil)
+		generationWorkflow, generationWorkflowFilePath, err := writeGenerationFile(workflowFile, workingDir, workflowFileDir, nil)
 		if err != nil {
 			return err
 		}
@@ -569,7 +585,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 		generationWorkflowFilePaths = append(generationWorkflowFilePaths, generationWorkflowFilePath)
 	} else {
 		for name := range workflowFile.Targets {
-			generationWorkflow, generationWorkflowFilePath, err := writeGenerationFile(workflowFile, workingDir, &name)
+			generationWorkflow, generationWorkflowFilePath, err := writeGenerationFile(workflowFile, workingDir, workflowFileDir, &name)
 			if err != nil {
 				return err
 			}
@@ -667,7 +683,7 @@ func configureGithub(ctx context.Context, _flags ConfigureGithubFlags) error {
 	return nil
 }
 
-func writeGenerationFile(workflowFile *workflow.Workflow, workingDir string, target *string) (*config.GenerateWorkflow, string, error) {
+func writeGenerationFile(workflowFile *workflow.Workflow, workingDir, workflowFileDir string, target *string) (*config.GenerateWorkflow, string, error) {
 	generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
 	if target != nil {
 		sanitizedName := strings.ReplaceAll(strings.ToLower(*target), "-", "_")
@@ -684,7 +700,7 @@ func writeGenerationFile(workflowFile *workflow.Workflow, workingDir string, tar
 	generationWorkflow := &config.GenerateWorkflow{}
 	prompts.ReadGenerationFile(generationWorkflow, generationWorkflowFilePath)
 
-	generationWorkflow, err := prompts.ConfigureGithub(generationWorkflow, workflowFile, target)
+	generationWorkflow, err := prompts.ConfigureGithub(generationWorkflow, workflowFile, workflowFileDir, target)
 	if err != nil {
 		return nil, "", err
 	}
@@ -696,7 +712,7 @@ func writeGenerationFile(workflowFile *workflow.Workflow, workingDir string, tar
 	return generationWorkflow, generationWorkflowFilePath, nil
 }
 
-func writePublishingFile(workflowFile *workflow.Workflow, workingDir string, name *string) (*config.GenerateWorkflow, string, []string, error) {
+func writePublishingFile(workflowFile *workflow.Workflow, workingDir, workflowFileDir string, name *string) (*config.GenerateWorkflow, string, []string, error) {
 	generationWorkflowFilePath := filepath.Join(workingDir, ".github/workflows/sdk_generation.yaml")
 	if name != nil {
 		sanitizedName := strings.ReplaceAll(strings.ToLower(*name), "-", "_")
@@ -720,7 +736,7 @@ func writePublishingFile(workflowFile *workflow.Workflow, workingDir string, nam
 		output = workflowFile.Targets[*name].Output
 	}
 
-	generationWorkflow, publishPaths, err := prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, name, output)
+	generationWorkflow, publishPaths, err := prompts.WritePublishing(generationWorkflow, workflowFile, workingDir, workflowFileDir, name, output)
 	if err != nil {
 		return nil, "", nil, errors.Wrapf(err, "failed to write publishing configs")
 	}
@@ -795,4 +811,15 @@ func configureGithubRepo(ctx context.Context, org, repo string) bool {
 	}
 
 	return res.StatusCode == http.StatusOK
+}
+
+func promptForWorkflowFileDir(workingDir string, dirOutput *string) error {
+	_, err := charm.NewForm(huh.NewForm(huh.NewGroup(charm.NewInput().
+		Title("What directory is your speakeasy workflow file in?").
+		Suggestions(charm.DirsInCurrentDir(workingDir)).
+		SetSuggestionCallback(charm.SuggestionCallback(charm.SuggestionCallbackConfig{IsDirectories: true})).
+		Value(dirOutput))),
+		charm.WithTitle("Find your Speakeasy workflow file.")).
+		ExecuteForm()
+	return err
 }

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -429,6 +429,10 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 			publishingFile.On.Push.Paths = []string{fmt.Sprintf("%s/RELEASES.md", releaseDirectory)}
 		}
 
+		if workflowFileDir != "" {
+			publishingFile.Jobs.Publish.With["working_directory"] = workflowFileDir
+		}
+
 		for name, value := range secrets {
 			publishingFile.Jobs.Publish.Secrets[name] = value
 		}

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -430,7 +430,9 @@ func WritePublishing(genWorkflow *config.GenerateWorkflow, workflowFile *workflo
 		}
 
 		if workflowFileDir != "" {
-			publishingFile.Jobs.Publish.With["working_directory"] = workflowFileDir
+			publishingFile.Jobs.Publish.With = map[string]any{
+				"working_directory": workflowFileDir,
+			}
 		}
 
 		for name, value := range secrets {


### PR DESCRIPTION
We will now allow customers to do github generations when the .speakeasy workflow is not in the root directory of their repo. 

Although, this will be an uncommon setup we should also allow them to set up these workflow files from `configure github/publishing`. In this case where it is not being run where a workflow file is present they will be asked to provide the directory.