### PR TITLE
chore: add vscode debug configuration for cli

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,6 @@
 dist/
 bin/
 .idea/
-.vscode/
 *.iml
 summary.md
 /.speakeasy/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,8 +1,7 @@
-// .vscode/tasks.json
 {
   "configurations": [
       {
-          "name": "Attach to CLI",
+          "name": "Debug CLI",
           "type": "go",
           "debugAdapter": "dlv-dap",
           "request": "attach",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+// .vscode/tasks.json
+{
+  "configurations": [
+      {
+          "name": "Attach to CLI",
+          "type": "go",
+          "debugAdapter": "dlv-dap",
+          "request": "attach",
+          "mode": "remote",
+          "remotePath": "${workspaceFolder}",
+          "port": 2345,
+          "host": "127.0.0.1",
+          "preLaunchTask": "Run headless dlv" 
+      }
+  ]
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,19 +16,7 @@
               "--",
               "${input:command}"
           ],
-          "isBackground": true,
-          "problemMatcher": {
-              "owner": "go",
-              "fileLocation": "relative",
-              "pattern": {
-                  "regexp": "^couldn't start listener:", // error if matched
-              },
-              "background": {
-                  "activeOnStart": true,
-                  "beginsPattern": "^API server listening at:",
-                  "endsPattern": "^Got a connection, launched process" // success if matched
-              }
-          }
+          "isBackground": true
       }
   ],
   "inputs": [

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,42 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+      {
+          "label": "Run headless dlv",
+          "type": "process",
+          "command": [
+              "dlv",
+          ],
+          "args": [
+              "debug",
+              "--headless",
+              "--listen=:2345",
+              "--api-version=2",
+              "${workspaceFolder}/main.go",
+              "--",
+              "${input:command}"
+          ],
+          "isBackground": true,
+          "problemMatcher": {
+              "owner": "go",
+              "fileLocation": "relative",
+              "pattern": {
+                  "regexp": "^couldn't start listener:", // error if matched
+              },
+              "background": {
+                  "activeOnStart": true,
+                  "beginsPattern": "^API server listening at:",
+                  "endsPattern": "^Got a connection, launched process" // success if matched
+              }
+          }
+      }
+  ],
+  "inputs": [
+    {
+        "id": "command",
+        "type": "promptString",
+        "default": "quickstart",
+        "description": "CLI command to debug"
+    }
+  ]
+}


### PR DESCRIPTION
Adds a custom debug configuration that allows debugging of the bubbletea application via a headless dlv instance