### PR TITLE
chore: add dlv problem matcher

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,7 +16,19 @@
               "--",
               "${input:command}"
           ],
-          "isBackground": true
+          "isBackground": true,
+          "problemMatcher": {
+              "owner": "go",
+              "fileLocation": "relative",
+              "pattern": {
+                  "regexp": "^couldn't start listener:", // error if matched
+              },
+              "background": {
+                  "activeOnStart": true,
+                  "beginsPattern": "^API server listening at:",
+                  "endsPattern": "^Got a connection, launched process" // success if matched
+              }
+          }
       }
   ],
   "inputs": [


### PR DESCRIPTION
It turns out that we do need the problem matcher in order for the debug task to be configured successfully.