### PR TITLE
fix: file completions in current working directory

### DIFF
--- a/internal/charm/utils.go
+++ b/internal/charm/utils.go
@@ -62,16 +62,8 @@ const pathSeparator string = string(os.PathSeparator)
 var relPath = fmt.Sprintf(".%s", pathSeparator)
 
 // Populates tab complete for schema files in the relative directory
-func SchemaFilesInCurrentDir(relativeDir string, fileExtensions []string) []string {
-	var validFiles []string
-	workingDir, err := os.Getwd()
-	if err != nil {
-		return validFiles
-	}
-
-	targetDir := filepath.Join(workingDir, relativeDir)
-
-	files, err := os.ReadDir(targetDir)
+func SchemaFilesInCurrentDir(path string, fileExtensions []string) (validFiles []string) {
+	files, err := os.ReadDir(path)
 	if err != nil {
 		return validFiles
 	}
@@ -80,14 +72,10 @@ func SchemaFilesInCurrentDir(relativeDir string, fileExtensions []string) []stri
 		if !file.Type().IsDir() {
 			for _, ext := range fileExtensions {
 				if strings.HasSuffix(file.Name(), ext) {
-					if !strings.HasSuffix(relativeDir, pathSeparator) {
-						relativeDir += pathSeparator
-					}
-					fileSuggestion := filepath.Join(relativeDir, file.Name())
+					fileSuggestion := filepath.Join(path, file.Name())
 
-					// allows us to support current directory relative paths
-					if strings.HasPrefix(relativeDir, relPath) {
-						fileSuggestion = relativeDir + file.Name()
+					if strings.HasPrefix(path, relPath) {
+						fileSuggestion = relPath + fileSuggestion
 					}
 					validFiles = append(validFiles, fileSuggestion)
 				}
@@ -120,12 +108,13 @@ func DirsInCurrentDir(relativeDir string) []string {
 			if !strings.HasSuffix(relativeDir, pathSeparator) {
 				relativeDir += pathSeparator
 			}
+
 			fileSuggestion := filepath.Join(relativeDir, file.Name())
 
-			// allows us to support current directory relative paths
 			if strings.HasPrefix(relativeDir, relPath) {
-				fileSuggestion = relativeDir + file.Name()
+				fileSuggestion = relativeDir + file.Name() + pathSeparator
 			}
+
 			validDirs = append(validDirs, fileSuggestion)
 		}
 	}


### PR DESCRIPTION
Fixes file based auto completions for the current directory. e.g previously it wouldn't complete `.myfile.yaml` (even though it would autocomplete `./myfile.yaml`) but now it does. The path completion logic is actually quite complex once you get into absolute paths and supporting `~/` so we should aim to iterate on this in the future to support these variants.

I did a spot check of the other places using this method (`SchemaFilesInCurrentDir`) and it seems fine. I don't think 