### PR TITLE
feat: set default env var prefix for supported languages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.1
-	github.com/speakeasy-api/openapi-generation/v2 v2.404.9
+	github.com/speakeasy-api/openapi-generation/v2 v2.404.11
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.19.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5

--- a/go.sum
+++ b/go.sum
@@ -518,10 +518,8 @@ github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xH
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826 h1:IT86QeGi61zmS/iKkf5rSzxYMO1TDLN/to4ZWP2DyeI=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826/go.mod h1:EjqZbDvviAL4wH/7DF43JuA17D1YTIydhs8qZmjYrWo=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.3 h1:0v7bdrFKe5JYCi07hcMAD/7gLqV2H7/yI8CVXTXI1Mg=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.3/go.mod h1:fSXXtngF0WtOV5Ysx3pJ59jg48SROvgcwTBM8rkdoHI=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.9 h1:p9WJZ/Fd+cq8pzZ8cT0ElZEfnm9MW9xyq07JLnQKwdw=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.9/go.mod h1:fSXXtngF0WtOV5Ysx3pJ59jg48SROvgcwTBM8rkdoHI=
+github.com/speakeasy-api/openapi-generation/v2 v2.404.11 h1:OZv898QZFE5uP+4H5spPY223FRwvaK8qANiLxA7LJ/o=
+github.com/speakeasy-api/openapi-generation/v2 v2.404.11/go.mod h1:HzV4utTRLRRLvtctlGuCvaxg7JVgh3XkNDqa/YFv/Js=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.19.0 h1:g77cZfjVPrnjh+P5QU2HcgcXc/rAqK6+bXT/xVAGcqw=

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -3,11 +3,12 @@ package prompts
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"regexp"
 	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 
 	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
@@ -161,6 +162,7 @@ func PromptForTargetConfig(targetName string, wf *workflow.Workflow, target *wor
 	// default dev containers on for new SDKs
 	if isQuickstart {
 		setDevContainerDefaults(output, wf, target)
+		setEnvVarPrefixDefaults(output, target, sdkClassName)
 	}
 
 	return output, nil
@@ -179,6 +181,14 @@ func setDevContainerDefaults(output *config.Configuration, wf *workflow.Workflow
 				Enabled:    true,
 				SchemaPath: schemaPath,
 			}
+		}
+	}
+}
+
+func setEnvVarPrefixDefaults(output *config.Configuration, target *workflow.Target, sdkClassName string) {
+	if target.Target == "go" || target.Target == "typescript" || target.Target == "python" {
+		if cfg, ok := output.Languages[target.Target]; ok && cfg.Cfg != nil {
+			cfg.Cfg["envVarPrefix"] = strings.ToUpper(sdkClassName)
 		}
 	}
 }


### PR DESCRIPTION
Sets a default envVarPrefix in quickstart for supported languages.
https://linear.app/speakeasy/issue/SPE-4026/set-envvarprefix-out-of-the-box-during-quickstart