### PR TITLE
fix: summary and toc readme sections positioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.1
-	github.com/speakeasy-api/openapi-generation/v2 v2.407.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.407.1
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.19.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.12.5

--- a/go.sum
+++ b/go.sum
@@ -518,10 +518,8 @@ github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xH
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826 h1:IT86QeGi61zmS/iKkf5rSzxYMO1TDLN/to4ZWP2DyeI=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826/go.mod h1:EjqZbDvviAL4wH/7DF43JuA17D1YTIydhs8qZmjYrWo=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.11 h1:OZv898QZFE5uP+4H5spPY223FRwvaK8qANiLxA7LJ/o=
-github.com/speakeasy-api/openapi-generation/v2 v2.404.11/go.mod h1:HzV4utTRLRRLvtctlGuCvaxg7JVgh3XkNDqa/YFv/Js=
-github.com/speakeasy-api/openapi-generation/v2 v2.407.0 h1:ESjVCq68H1S6FRi8uJ/ytzyNY3Y2GZ7Hdpa66S7NZdM=
-github.com/speakeasy-api/openapi-generation/v2 v2.407.0/go.mod h1:HzV4utTRLRRLvtctlGuCvaxg7JVgh3XkNDqa/YFv/Js=
+github.com/speakeasy-api/openapi-generation/v2 v2.407.1 h1:6yvNrvNmxqDeaK9Kk93zpOQuF69vUTd0Lf+2e+qb3jY=
+github.com/speakeasy-api/openapi-generation/v2 v2.407.1/go.mod h1:HzV4utTRLRRLvtctlGuCvaxg7JVgh3XkNDqa/YFv/Js=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.19.0 h1:g77cZfjVPrnjh+P5QU2HcgcXc/rAqK6+bXT/xVAGcqw=


### PR DESCRIPTION
https://github.com/speakeasy-api/openapi-generation/pull/1584

This PR prevents newly added `Summary` and `Table of Contents` Readme sections to be templated at the bottom of existing `README.md` files