### PR TITLE
chore: Update goreleaser configuration for snapshot.name_template deprecation

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -22,7 +22,7 @@ archives:
 checksum:
   name_template: "checksums.txt"
 snapshot:
-  name_template: "{{ incpatch .Version }}-next"
+  version_template: "{{ incpatch .Version }}-next"
 changelog:
   sort: asc
   filters:


### PR DESCRIPTION
Reference: https://goreleaser.com/deprecations#snapshotnametemplate

Previously during release:

```
  • setting defaults
    • DEPRECATED: snapshot.name_template should not be used anymore, check https://goreleaser.com/deprecations#snapshotnametemplate for more info
```