### PR TITLE
feat: linting performance improvements

### DIFF
--- a/cmd/lint.go
+++ b/cmd/lint.go
@@ -117,7 +117,7 @@ func lintOpenapi(ctx context.Context, flags LintOpenapiFlags) error {
 		return err
 	}
 
-	if _, err := validation.ValidateOpenAPI(ctx, "", flags.SchemaPath, flags.Header, flags.Token, &limits, flags.Ruleset, wd, false); err != nil {
+	if _, err := validation.ValidateOpenAPI(ctx, "", flags.SchemaPath, flags.Header, flags.Token, &limits, flags.Ruleset, wd, false, false); err != nil {
 		rootCmd.SilenceUsage = true
 
 		return err
@@ -141,7 +141,7 @@ func lintOpenapiInteractive(ctx context.Context, flags LintOpenapiFlags) error {
 		return err
 	}
 
-	if _, err := validation.ValidateWithInteractivity(ctx, flags.SchemaPath, flags.Header, flags.Token, &limits, flags.Ruleset, wd); err != nil {
+	if _, err := validation.ValidateWithInteractivity(ctx, flags.SchemaPath, flags.Header, flags.Token, &limits, flags.Ruleset, wd, false); err != nil {
 		return err
 	}
 

--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -37,7 +37,7 @@ func mergeExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := merge.MergeOpenAPIDocuments(cmd.Context(), inSchemas, outFile, "speakeasy-recommended", ""); err != nil {
+	if err := merge.MergeOpenAPIDocuments(cmd.Context(), inSchemas, outFile, "speakeasy-recommended", "", false); err != nil {
 		return err
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -24,9 +24,9 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.1
-	github.com/speakeasy-api/openapi-generation/v2 v2.409.8
+	github.com/speakeasy-api/openapi-generation/v2 v2.411.2
 	github.com/speakeasy-api/openapi-overlay v0.9.0
-	github.com/speakeasy-api/sdk-gen-config v1.19.0
+	github.com/speakeasy-api/sdk-gen-config v1.20.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0
 	github.com/speakeasy-api/speakeasy-core v0.15.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -518,12 +518,12 @@ github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xH
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826 h1:IT86QeGi61zmS/iKkf5rSzxYMO1TDLN/to4ZWP2DyeI=
 github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826/go.mod h1:EjqZbDvviAL4wH/7DF43JuA17D1YTIydhs8qZmjYrWo=
-github.com/speakeasy-api/openapi-generation/v2 v2.409.8 h1:ptVO8ZVMB2uhOSmT1XwWsremF0hm5OM9VLRXchNfh2o=
-github.com/speakeasy-api/openapi-generation/v2 v2.409.8/go.mod h1:/E00EpPcEzg4h9Rr9ZVd0uSGPf1mEK+Ok4pAP/5Eoo0=
+github.com/speakeasy-api/openapi-generation/v2 v2.411.2 h1:hKqU5bq58NigvEm5v9dmaxtaq1Y/NlFjv1Y5Jk9UGFg=
+github.com/speakeasy-api/openapi-generation/v2 v2.411.2/go.mod h1:8jdytQI7+ZxahfDJgsmMRM/tDompdMwPOUqZMhWiCL4=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.19.0 h1:g77cZfjVPrnjh+P5QU2HcgcXc/rAqK6+bXT/xVAGcqw=
-github.com/speakeasy-api/sdk-gen-config v1.19.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
+github.com/speakeasy-api/sdk-gen-config v1.20.0 h1:4fuemOZKmJ9toTVLyfuHG5DcSscVlkOIWrF7M3t9zVo=
+github.com/speakeasy-api/sdk-gen-config v1.20.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0 h1:MLLjjf2x2h9HFZY1Awfl/FO5AqCMPxb+0xPwvbQQ49w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.15.0 h1:GzJdvi6L+CMiFdRafAu5RtMXyAuVQ4UYWSbHvomIX3I=

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -174,7 +174,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 
 		mergeStep.NewSubstep(fmt.Sprintf("Merge %d documents", len(source.Inputs)))
 
-		if err := mergeDocuments(ctx, inSchemas, mergeLocation, rulesetToUse, w.ProjectDir); err != nil {
+		if err := mergeDocuments(ctx, inSchemas, mergeLocation, rulesetToUse, w.ProjectDir, w.SkipGenerateLintReport); err != nil {
 			return "", nil, err
 		}
 
@@ -237,6 +237,14 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 	// Emit once before linting as that can be slow
 	w.OnSourceResult(sourceRes)
 
+	if !w.SkipLinting {
+		sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.ProjectDir)
+		w.OnSourceResult(sourceRes)
+		if err != nil {
+			return "", sourceRes, &LintingError{Err: err, Document: currentDocument}
+		}
+	}
+
 	if !w.SkipSnapshot {
 		err = w.snapshotSource(ctx, rootStep, sourceID, source, currentDocument)
 		if err != nil && !errors.Is(err, ocicommon.ErrAccessGated) {
@@ -262,13 +270,6 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 			Key:          "openapi_change_summary",
 			Priority:     5,
 		})
-	}
-
-	if !w.SkipLinting {
-		sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.ProjectDir)
-		if err != nil {
-			return "", sourceRes, &LintingError{Err: err, Document: currentDocument}
-		}
 	}
 
 	step := rootStep.NewSubstep("Diagnosing OpenAPI")
@@ -368,7 +369,7 @@ func (w *Workflow) validateDocument(ctx context.Context, parentStep *workflowTra
 		MaxWarns:  1000,
 	}
 
-	res, err := validation.ValidateOpenAPI(ctx, source, schemaPath, "", "", limits, defaultRuleset, projectDir, w.FromQuickstart)
+	res, err := validation.ValidateOpenAPI(ctx, source, schemaPath, "", "", limits, defaultRuleset, projectDir, w.FromQuickstart, w.SkipGenerateLintReport)
 
 	w.validatedDocuments = append(w.validatedDocuments, schemaPath)
 
@@ -693,12 +694,12 @@ func (w *Workflow) printSourceSuccessMessage(ctx context.Context) {
 	}
 }
 
-func mergeDocuments(ctx context.Context, inSchemas []string, outFile, defaultRuleset, workingDir string) error {
+func mergeDocuments(ctx context.Context, inSchemas []string, outFile, defaultRuleset, workingDir string, skipGenerateLintReport bool) error {
 	if err := os.MkdirAll(filepath.Dir(outFile), os.ModePerm); err != nil {
 		return err
 	}
 
-	if err := merge.MergeOpenAPIDocuments(ctx, inSchemas, outFile, defaultRuleset, workingDir); err != nil {
+	if err := merge.MergeOpenAPIDocuments(ctx, inSchemas, outFile, defaultRuleset, workingDir, skipGenerateLintReport); err != nil {
 		return err
 	}
 

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -235,17 +235,15 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 
 	sourceRes.OutputPath = currentDocument
 
-	// Emit once before linting as that can be slow
-	w.OnSourceResult(sourceRes, "Linting")
-
 	if !w.SkipLinting {
+		w.OnSourceResult(sourceRes, "Linting")
 		sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.ProjectDir)
-		fmt.Println("after lint", w.RootStep.LastStepToString())
-		w.OnSourceResult(sourceRes, "Uploading spec")
 		if err != nil {
 			return "", sourceRes, &LintingError{Err: err, Document: currentDocument}
 		}
 	}
+
+	w.OnSourceResult(sourceRes, "Uploading spec")
 
 	if !w.SkipSnapshot {
 		err = w.snapshotSource(ctx, rootStep, sourceID, source, currentDocument)

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -72,8 +72,9 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		Diagnosis: suggestions.Diagnosis{},
 	}
 	defer func() {
-		w.OnSourceResult(sourceRes)
+		w.OnSourceResult(sourceRes, "")
 	}()
+	w.OnSourceResult(sourceRes, "Overlaying")
 
 	rulesetToUse := "speakeasy-generation"
 	if source.Ruleset != nil {
@@ -235,11 +236,12 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 	sourceRes.OutputPath = currentDocument
 
 	// Emit once before linting as that can be slow
-	w.OnSourceResult(sourceRes)
+	w.OnSourceResult(sourceRes, "Linting")
 
 	if !w.SkipLinting {
 		sourceRes.LintResult, err = w.validateDocument(ctx, rootStep, sourceID, currentDocument, rulesetToUse, w.ProjectDir)
-		w.OnSourceResult(sourceRes)
+		fmt.Println("after lint", w.RootStep.LastStepToString())
+		w.OnSourceResult(sourceRes, "Uploading spec")
 		if err != nil {
 			return "", sourceRes, &LintingError{Err: err, Document: currentDocument}
 		}

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -50,7 +50,7 @@ type Workflow struct {
 	computedChanges map[string]bool
 	SourceResults   map[string]*SourceResult
 	TargetResults   map[string]*TargetResult
-	OnSourceResult  func(*SourceResult)
+	OnSourceResult  func(*SourceResult, string)
 	Duration        time.Duration
 	criticalWarns   []string
 	Error           error
@@ -93,7 +93,7 @@ func NewWorkflow(
 		ForceGeneration:  false,
 		SourceResults:    make(map[string]*SourceResult),
 		TargetResults:    make(map[string]*TargetResult),
-		OnSourceResult:   func(*SourceResult) {},
+		OnSourceResult:   func(*SourceResult, string) {},
 		computedChanges:  make(map[string]bool),
 		lockfile:         lockfile,
 		lockfileOld:      lockfileOld,

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -15,24 +15,25 @@ import (
 
 type Workflow struct {
 	// Opts
-	Target             string
-	Source             string
-	Repo               string
-	SetVersion         string
-	Debug              bool
-	ShouldCompile      bool
-	Verbose            bool
-	ForceGeneration    bool
-	FrozenWorkflowLock bool
-	SkipVersioning     bool
-	SkipLinting        bool
-	SkipChangeReport   bool
-	SkipSnapshot       bool
-	SkipCleanup        bool
-	FromQuickstart     bool
-	RepoSubDirs        map[string]string
-	InstallationURLs   map[string]string
-	RegistryTags       []string
+	Target                 string
+	Source                 string
+	Repo                   string
+	SetVersion             string
+	Debug                  bool
+	ShouldCompile          bool
+	Verbose                bool
+	ForceGeneration        bool
+	FrozenWorkflowLock     bool
+	SkipVersioning         bool
+	SkipLinting            bool
+	SkipChangeReport       bool
+	SkipSnapshot           bool
+	SkipCleanup            bool
+	FromQuickstart         bool
+	SkipGenerateLintReport bool
+	RepoSubDirs            map[string]string
+	InstallationURLs       map[string]string
+	RegistryTags           []string
 
 	// Internal
 	workflowName       string
@@ -204,6 +205,12 @@ func WithSkipLinting() Opt {
 func WithLinting() Opt {
 	return func(w *Workflow) {
 		w.SkipLinting = false
+	}
+}
+
+func WithSkipGenerateLintReport() Opt {
+	return func(w *Workflow) {
+		w.SkipGenerateLintReport = true
 	}
 }
 

--- a/internal/studio/oas_studio.yaml
+++ b/internal/studio/oas_studio.yaml
@@ -87,6 +87,12 @@ components:
       type: object
       description: Map of target run summaries
       properties:
+        step:
+            type: string
+            description: Step of the run
+        isPartial:
+          type: boolean
+          description: Whether the run was partial
         lintingReportLink:
           type: string
           description: Link to the linting report
@@ -109,12 +115,6 @@ components:
         error:
           type: string
           description: Error message if the run failed
-        isPartial:
-          type: boolean
-          description: Whether the run was partial
-        step:
-          type: string
-          description: Step of the run
       required:
         - sourceResult
         - targetResults

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -4,12 +4,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 
 	"github.com/AlekSi/pointer"
 	vErrs "github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
@@ -119,7 +120,7 @@ func (h *StudioHandlers) reRun(ctx context.Context, w http.ResponseWriter, r *ht
 		return fmt.Errorf("error updating source: %w", err)
 	}
 
-	cloned, err := h.WorkflowRunner.Clone(h.Ctx, run.WithSkipCleanup(), run.WithLinting())
+	cloned, err := h.WorkflowRunner.Clone(h.Ctx, run.WithSkipCleanup(), run.WithLinting(), run.WithSkipGenerateLintReport())
 	if err != nil {
 		return fmt.Errorf("error cloning workflow runner: %w", err)
 	}

--- a/internal/workflowTracking/workflowTracking.go
+++ b/internal/workflowTracking/workflowTracking.go
@@ -157,10 +157,10 @@ func (w *WorkflowStep) ListenForSubsteps(c chan log.Msg) {
 func (w *WorkflowStep) LastStepToString() string {
 	step := w
 	var status Status = StatusSucceeded
-	var stringNames = []string{}
+	var stepNames = []string{}
 
 	for {
-		stringNames = append(stringNames, step.name)
+		stepNames = append(stepNames, step.name)
 		status = step.status
 
 		if len(step.substeps) == 0 {
@@ -169,7 +169,7 @@ func (w *WorkflowStep) LastStepToString() string {
 		step = step.substeps[len(step.substeps)-1]
 	}
 
-	return fmt.Sprintf("%s: %s", status, strings.Join(stringNames, " -> "))
+	return fmt.Sprintf("%s: %s", status, strings.Join(stepNames, " -> "))
 }
 
 func (w *WorkflowStep) toString(parentIndent, indent int) string {

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -22,7 +22,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-func MergeOpenAPIDocuments(ctx context.Context, inFiles []string, outFile, defaultRuleset, workingDir string) error {
+func MergeOpenAPIDocuments(ctx context.Context, inFiles []string, outFile, defaultRuleset, workingDir string, skipGenerateLintReport bool) error {
 	inSchemas := make([][]byte, len(inFiles))
 
 	// TODO at some point we prob want to support remote schemas
@@ -32,7 +32,7 @@ func MergeOpenAPIDocuments(ctx context.Context, inFiles []string, outFile, defau
 			return err
 		}
 
-		if err := validate(ctx, inFile, data, defaultRuleset, workingDir); err != nil {
+		if err := validate(ctx, inFile, data, defaultRuleset, workingDir, skipGenerateLintReport); err != nil {
 			log.From(ctx).Error(fmt.Sprintf("failed validating spec %s", inFile), zap.Error(err))
 		}
 
@@ -53,7 +53,7 @@ func MergeOpenAPIDocuments(ctx context.Context, inFiles []string, outFile, defau
 	return nil
 }
 
-func validate(ctx context.Context, schemaPath string, schema []byte, defaultRuleset, workingDir string) error {
+func validate(ctx context.Context, schemaPath string, schema []byte, defaultRuleset, workingDir string, skipGenerateLintReport bool) error {
 	logger := log.From(ctx)
 	logger.Info(fmt.Sprintf("Validating OpenAPI spec %s...\n", schemaPath))
 
@@ -63,7 +63,7 @@ func validate(ctx context.Context, schemaPath string, schema []byte, defaultRule
 		MaxWarns: 10,
 	}
 
-	res, err := validation.Validate(ctx, logger, schema, schemaPath, limits, false, defaultRuleset, workingDir, false)
+	res, err := validation.Validate(ctx, logger, schema, schemaPath, limits, false, defaultRuleset, workingDir, false, skipGenerateLintReport)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
**Why:** we were facing laggy editing of the spec file in the studio
**What:** 
* Update openapi-generation to skip unnecessary work when linting. 
* Don't upload linting reports for every run of the studio. The first run of the workflow will upload the linting report as usual but subsequent runs will not upload a report.
* Slightly unrelated, added better "step" when emitting `OnSourceResult`