### PR TITLE
chore: fix broken --schema arg

### DIFF
--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -172,13 +172,14 @@ func quickstartBaseForm(ctx context.Context, quickstart *Quickstart) (*Quickstar
 
 	if quickstart.Defaults.SchemaPath != nil {
 		fileLocation = *quickstart.Defaults.SchemaPath
+	} else {
+		if err := getOASLocation(&fileLocation, &authHeader, true); err != nil {
+			return nil, err
+		}
 	}
 
 	orgSlug := auth.GetOrgSlugFromContext(ctx)
 
-	if err := getOASLocation(&fileLocation, &authHeader, true); err != nil {
-		return nil, err
-	}
 
 	isUsingSampleSpec := strings.TrimSpace(fileLocation) == ""
 


### PR DESCRIPTION
We don't need to prompt for an OAS location if the `--schema` arg is passed into quickstart.

Prior code path had the CLI crash