### PR TITLE
fix: deduplicate suggestions

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.20.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0
-	github.com/speakeasy-api/speakeasy-core v0.15.0
+	github.com/speakeasy-api/speakeasy-core v0.15.1
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0 h1:MLLjjf2x2h9HFZY1A
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
 github.com/speakeasy-api/speakeasy-core v0.15.0 h1:GzJdvi6L+CMiFdRafAu5RtMXyAuVQ4UYWSbHvomIX3I=
 github.com/speakeasy-api/speakeasy-core v0.15.0/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
+github.com/speakeasy-api/speakeasy-core v0.15.1 h1:HKl/lJ7mDJE8yxQNs0hzCTgsOYqwoenN2jKogcyqaB4=
+github.com/speakeasy-api/speakeasy-core v0.15.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/suggest/suggest.go
+++ b/internal/suggest/suggest.go
@@ -129,16 +129,11 @@ func printSuggestions(ctx context.Context, overlay *overlay.Overlay) {
 	var rhs []string
 
 	for _, action := range overlay.Actions {
-		modificationExtension := action.Extensions["x-speakeasy-metadata"]
-		if modificationExtension == nil {
+		modification := suggestions.GetModificationExtension(action)
+		if modification == nil {
 			continue
 		}
 
-		modificationE := modificationExtension.(map[string]interface{})
-		modification := suggestions.ModificationExtension{
-			Before: modificationE["before"].(string),
-			After:  modificationE["after"].(string),
-		}
 		before := changedStyle.Render(modification.Before)
 		after := styles.Success.Render(modification.After)
 


### PR DESCRIPTION
Adds support for deduplicating suggestions before upserting the modifications overlay. Also deduplicates the results of Suggest itself based on the existing contents of the overlay if one exists

https://speakeasyapi.slack.com/archives/C07C7QUB53L/p1725655028783219