### PR TITLE
fix: studio fixes

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -352,6 +352,10 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
 	}
 
+	if flags.LaunchStudio {
+		opts = append(opts, run.WithSkipCleanup())
+	}
+
 	workflow, err := run.NewWorkflow(
 		ctx,
 		opts...,

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.23.0
 
-// point at local core
-replace github.com/speakeasy-api/speakeasy-core => ../speakeasy-core
-
 // Can be removed once https://github.com/pb33f/libopenapi/pull/319 is merged and the dependency is updated here
 replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826
 

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/inkeep/ai-api-go v0.3.1
 	github.com/pb33f/openapi-changes v0.0.61
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/samber/lo v1.47.0
 	github.com/speakeasy-api/versioning-reports v0.6.0
 	github.com/stoewer/go-strcase v1.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.23.0
 
+// point at local core
+replace github.com/speakeasy-api/speakeasy-core => ../speakeasy-core
+
 // Can be removed once https://github.com/pb33f/libopenapi/pull/319 is merged and the dependency is updated here
 replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826
 

--- a/go.sum
+++ b/go.sum
@@ -482,6 +482,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f h1:MvTmaQdww/z0Q4wrYjDSCcZ78NoftLQyHBSLW/Cx79Y=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
@@ -526,8 +528,6 @@ github.com/speakeasy-api/sdk-gen-config v1.20.0 h1:4fuemOZKmJ9toTVLyfuHG5DcSscVl
 github.com/speakeasy-api/sdk-gen-config v1.20.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0 h1:MLLjjf2x2h9HFZY1Awfl/FO5AqCMPxb+0xPwvbQQ49w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.15.0 h1:GzJdvi6L+CMiFdRafAu5RtMXyAuVQ4UYWSbHvomIX3I=
-github.com/speakeasy-api/speakeasy-core v0.15.0/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-core v0.15.1 h1:HKl/lJ7mDJE8yxQNs0hzCTgsOYqwoenN2jKogcyqaB4=
 github.com/speakeasy-api/speakeasy-core v0.15.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,6 @@ github.com/speakeasy-api/sdk-gen-config v1.20.0 h1:4fuemOZKmJ9toTVLyfuHG5DcSscVl
 github.com/speakeasy-api/sdk-gen-config v1.20.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0 h1:MLLjjf2x2h9HFZY1Awfl/FO5AqCMPxb+0xPwvbQQ49w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.15.1 h1:HKl/lJ7mDJE8yxQNs0hzCTgsOYqwoenN2jKogcyqaB4=
-github.com/speakeasy-api/speakeasy-core v0.15.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/speakeasy-api/sdk-gen-config v1.20.0 h1:4fuemOZKmJ9toTVLyfuHG5DcSscVl
 github.com/speakeasy-api/sdk-gen-config v1.20.0/go.mod h1:7FsPqdsh//6Z0OcO/jQPD66l6/m1YVvK5tmt0+KRpdo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0 h1:MLLjjf2x2h9HFZY1Awfl/FO5AqCMPxb+0xPwvbQQ49w=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.13.0/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
+github.com/speakeasy-api/speakeasy-core v0.15.1 h1:HKl/lJ7mDJE8yxQNs0hzCTgsOYqwoenN2jKogcyqaB4=
+github.com/speakeasy-api/speakeasy-core v0.15.1/go.mod h1:m10zRjzdzbTcBBb9e+RweBZ4OIowXCvvvxFB3UEmWYs=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -243,6 +243,14 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		}
 	}
 
+	step := rootStep.NewSubstep("Diagnosing OpenAPI")
+	sourceRes.Diagnosis, err = suggest.Diagnose(ctx, currentDocument)
+	if err != nil {
+		step.Fail()
+		return "", sourceRes, err
+	}
+	step.Succeed()
+
 	w.OnSourceResult(sourceRes, "Uploading spec")
 
 	if !w.SkipSnapshot {
@@ -271,14 +279,6 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 			Priority:     5,
 		})
 	}
-
-	step := rootStep.NewSubstep("Diagnosing OpenAPI")
-	sourceRes.Diagnosis, err = suggest.Diagnose(ctx, currentDocument)
-	if err != nil {
-		step.Fail()
-		return "", sourceRes, err
-	}
-	step.Succeed()
 
 	rootStep.SucceedWorkflow()
 

--- a/internal/studio/modifications/overlay.go
+++ b/internal/studio/modifications/overlay.go
@@ -60,6 +60,11 @@ func UpsertOverlay(overlayPath string, source *workflow.Source, o overlay.Overla
 			Info: overlay.Info{
 				Title:   overlayTitle,
 				Version: "0.0.0", // bumped later
+				Extensions: overlay.Extensions{
+					"x-speakeasy-metadata": suggestions.ModificationExtension{
+						Type: "speakeasy-modifications",
+					},
+				},
 			},
 		}
 	} else {

--- a/internal/studio/oas_studio.yaml
+++ b/internal/studio/oas_studio.yaml
@@ -14,6 +14,15 @@ paths:
       summary: Health Check
       description: Check the CLI health and return relevant information.
       operationId: checkHealth
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                tabID:
+                  type: string
+                  description: The tab ID of the studio
       responses:
         "200":
           description: Successful response

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -541,7 +541,7 @@ func isStudioModificationsOverlay(overlay workflow.Overlay) (string, error) {
 		return "", err
 	}
 
-	looksLikeStudioModifications := strings.Contains(asString, "x-speakeasy-metadata") || strings.Contains(asString, "title: speakeasy-studio-modifications")
+	looksLikeStudioModifications := strings.Contains(asString, "x-speakeasy-metadata")
 	if !looksLikeStudioModifications {
 		return "", nil
 	}

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
-	"github.com/speakeasy-api/speakeasy/internal/log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+
+	"github.com/speakeasy-api/openapi-overlay/pkg/loader"
+	"github.com/speakeasy-api/speakeasy/internal/log"
 
 	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
 
@@ -265,14 +266,22 @@ func (h *StudioHandlers) suggestMethodNames(ctx context.Context, w http.Response
 		return fmt.Errorf("error suggesting method names: %w", err)
 	}
 
+	x, err := yaml.Marshal(suggestOverlay.Actions)
+	fmt.Println("suggestOverlay\n", string(x))
+
 	if h.OverlayPath != "" {
 		existingOverlay, err := loader.LoadOverlay(h.OverlayPath)
+		x, err = yaml.Marshal(existingOverlay.Actions)
+		fmt.Println("existingOverlay\n", string(x))
 		if err != nil {
 			log.From(ctx).Warnf("error loading existing overlay: %s", err.Error())
 		} else {
-			suggestOverlay.Actions = modifications.RemoveDuplicates(suggestOverlay.Actions, existingOverlay.Actions)
+			suggestOverlay.Actions = modifications.RemoveDuplicates(append(existingOverlay.Actions, suggestOverlay.Actions...))
 		}
 	}
+
+	x, err = yaml.Marshal(suggestOverlay.Actions)
+	fmt.Println("suggestOverlay:after\n", string(x))
 
 	yamlBytes, err := yaml.Marshal(suggestOverlay)
 	if err != nil {

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -266,22 +266,14 @@ func (h *StudioHandlers) suggestMethodNames(ctx context.Context, w http.Response
 		return fmt.Errorf("error suggesting method names: %w", err)
 	}
 
-	x, err := yaml.Marshal(suggestOverlay.Actions)
-	fmt.Println("suggestOverlay\n", string(x))
-
 	if h.OverlayPath != "" {
 		existingOverlay, err := loader.LoadOverlay(h.OverlayPath)
-		x, err = yaml.Marshal(existingOverlay.Actions)
-		fmt.Println("existingOverlay\n", string(x))
 		if err != nil {
 			log.From(ctx).Warnf("error loading existing overlay: %s", err.Error())
 		} else {
-			suggestOverlay.Actions = modifications.RemoveDuplicates(append(existingOverlay.Actions, suggestOverlay.Actions...))
+			suggestOverlay.Actions = modifications.RemoveAlreadySuggested(existingOverlay.Actions, suggestOverlay.Actions)
 		}
 	}
-
-	x, err = yaml.Marshal(suggestOverlay.Actions)
-	fmt.Println("suggestOverlay:after\n", string(x))
 
 	yamlBytes, err := yaml.Marshal(suggestOverlay)
 	if err != nil {


### PR DESCRIPTION
Fixes
* Fix deduplicate already suggested suggestions
* Fix WithSkipCleanup is needed otherwise spec fails to launch in the studio
* Move diagnosing the spec above `OnSourceResult`
* Write `x-speakeasy-metadata` to the studio modifications overlay info so we can identify empty overlay files and don't end up creating new ones all the time
