### PR TITLE
chore: refactor workflow runInner to be easier to read

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/inkeep/ai-api-go v0.3.1
 	github.com/pb33f/openapi-changes v0.0.61
 	github.com/pkg/browser v0.0.0-20240102092130-5ac0b6a4141c
+	github.com/samber/lo v1.47.0
 	github.com/speakeasy-api/versioning-reports v0.6.0
 	github.com/stoewer/go-strcase v1.3.0
 )

--- a/go.sum
+++ b/go.sum
@@ -482,6 +482,8 @@ github.com/sagikazarmark/slog-shim v0.1.0 h1:diDBnUNK9N/354PgrxMywXnAwEr1QZcOr6g
 github.com/sagikazarmark/slog-shim v0.1.0/go.mod h1:SrcSrq8aKtyuqEI1uvTDTK1arOWRIczQRv+GVI1AkeQ=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f h1:MvTmaQdww/z0Q4wrYjDSCcZ78NoftLQyHBSLW/Cx79Y=
 github.com/sahilm/fuzzy v0.1.1-0.20230530133925-c48e322e2a8f/go.mod h1:VFvziUEIMCrT6A6tw2RFIXPXXmzXbOsSHF0DOI8ZK9Y=
+github.com/samber/lo v1.47.0 h1:z7RynLwP5nbyRscyvcD043DWYoOcYRv3mV8lBeqOCLc=
+github.com/samber/lo v1.47.0/go.mod h1:RmDH9Ct32Qy3gduHQuKJ3gW1fMHAnE/fAzQuf6He5cU=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1 h1:lZUw3E0/J3roVtGQ+SCrUrg3ON6NgVqpn3+iol9aGu4=
 github.com/santhosh-tekuri/jsonschema/v5 v5.3.1/go.mod h1:uToXkOrWAZ6/Oc07xWQrPOhJotwFIyu2bBVN41fcDUY=
 github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -170,8 +170,11 @@ func TestInputOnlyWorkflow(t *testing.T) {
 	err = workflow.Save(temp, workflowFile)
 	require.NoError(t, err)
 	args := []string{"run", "-s", "first-source", "--pinned", "--skip-compile"}
-
 	cmdErr := execute(t, temp, args...).Run()
+	require.NoError(t, cmdErr)
+
+	args = []string{"run", "-s", "all", "--pinned", "--skip-compile"}
+	cmdErr = execute(t, temp, args...).Run()
 	require.NoError(t, cmdErr)
 
 	checkForExpectedFiles(t, temp, expectedFilesByLanguage("go"))

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -176,8 +176,6 @@ func TestInputOnlyWorkflow(t *testing.T) {
 	args = []string{"run", "-s", "all", "--pinned", "--skip-compile"}
 	cmdErr = execute(t, temp, args...).Run()
 	require.NoError(t, cmdErr)
-
-	checkForExpectedFiles(t, temp, expectedFilesByLanguage("go"))
 }
 
 type Runnable interface {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -160,15 +160,12 @@ func TestInputOnlyWorkflow(t *testing.T) {
 	workflowFile.Sources["first-source"] = workflow.Source{
 		Inputs: []workflow.Document{
 			{
-				Location: "spec.yaml",
+				Location: "https://raw.githubusercontent.com/OAI/OpenAPI-Specification/main/examples/v3.0/petstore.json",
 			},
 		},
 	}
 
-	err := copyFile("resources/spec.yaml", fmt.Sprintf("%s/spec.yaml", temp))
-	require.NoError(t, err)
-
-	err = os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755)
+	err := os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755)
 	require.NoError(t, err)
 	err = workflow.Save(temp, workflowFile)
 	require.NoError(t, err)

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -147,6 +147,39 @@ func TestGenerationWorkflows(t *testing.T) {
 	}
 }
 
+func TestInputOnlyWorkflow(t *testing.T) {
+	t.Parallel()
+	temp := setupTestDir(t)
+
+	// Create workflow file and associated resources
+	workflowFile := &workflow.Workflow{
+		Version: workflow.WorkflowVersion,
+		Sources: make(map[string]workflow.Source),
+		Targets: make(map[string]workflow.Target),
+	}
+	workflowFile.Sources["first-source"] = workflow.Source{
+		Inputs: []workflow.Document{
+			{
+				Location: "spec.yaml",
+			},
+		},
+	}
+
+	err := copyFile("resources/spec.yaml", fmt.Sprintf("%s/spec.yaml", temp))
+	require.NoError(t, err)
+
+	err = os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755)
+	require.NoError(t, err)
+	err = workflow.Save(temp, workflowFile)
+	require.NoError(t, err)
+	args := []string{"run", "-s", "first-source", "--pinned", "--skip-compile"}
+
+	cmdErr := execute(t, temp, args...).Run()
+	require.NoError(t, cmdErr)
+
+	checkForExpectedFiles(t, temp, expectedFilesByLanguage("go"))
+}
+
 type Runnable interface {
 	Run() error
 }

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -162,12 +162,9 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 			continue
 		}
 
-		_, sourceRes, err := w.RunSource(ctx, w.RootStep, w.Source, "")
+		_, _, err := w.runTarget(ctx, w.Target)
 		if err != nil {
 			return err
-		}
-		if sourceRes != nil {
-			w.SourceResults[sourceRes.Source] = sourceRes
 		}
 	}
 

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/samber/lo"
-	lo "github.com/samber/lo"
 	"gopkg.in/yaml.v3"
 
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -162,7 +162,7 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 			continue
 		}
 
-		_, _, err := w.runTarget(ctx, w.Target)
+		_, _, err := w.runTarget(ctx, targetID)
 		if err != nil {
 			return err
 		}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -149,7 +149,7 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 			continue
 		}
 		if _, ok := w.workflow.Sources[sourceID]; !ok {
-			return fmt.Errorf("source %s not found", sourceID)
+			return fmt.Errorf("source '%s' not found", sourceID)
 		}
 		_, _, err := w.RunSource(ctx, w.RootStep, sourceID, "")
 		if err != nil {
@@ -162,7 +162,7 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 			continue
 		}
 		if _, ok := w.workflow.Targets[targetID]; !ok {
-			return fmt.Errorf("target %s not found", targetID)
+			return fmt.Errorf("target '%s' not found", targetID)
 		}
 		_, _, err := w.runTarget(ctx, targetID)
 		if err != nil {

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -161,7 +161,9 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 		if targetID == "" {
 			continue
 		}
-
+		if _, ok := w.workflow.Targets[targetID]; !ok {
+			return fmt.Errorf("target %s not found", targetID)
+		}
 		_, _, err := w.runTarget(ctx, targetID)
 		if err != nil {
 			return err

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -72,6 +72,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		Diagnosis: suggestions.Diagnosis{},
 	}
 	defer func() {
+		w.SourceResults[sourceID] = sourceRes
 		w.OnSourceResult(sourceRes, "")
 	}()
 	w.OnSourceResult(sourceRes, "Overlaying")

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -117,7 +117,6 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 		GenYamlPath: genConfig.ConfigPath,
 	}
 	defer func() {
-		w.SourceResults[sourceRes.Source] = sourceRes
 		w.TargetResults[target] = &targetResult
 	}()
 

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -112,6 +112,15 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 		return sourceRes, nil, err
 	}
 
+	targetResult := TargetResult{
+		OutputPath:  outDir,
+		GenYamlPath: genConfig.ConfigPath,
+	}
+	defer func() {
+		w.SourceResults[sourceRes.Source] = sourceRes
+		w.TargetResults[target] = &targetResult
+	}()
+
 	if w.SetVersion != "" && genConfig.Config != nil {
 		appliedVersion := w.SetVersion
 		if appliedVersion[0] == 'v' {
@@ -222,11 +231,6 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 	}
 
 	w.lockfile.Targets[target] = targetLock
-
-	targetResult := TargetResult{
-		OutputPath:  outDir,
-		GenYamlPath: genConfig.ConfigPath,
-	}
 
 	return sourceRes, &targetResult, nil
 }


### PR DESCRIPTION
We faced an incident where a [nil pointer was not checked](https://github.com/speakeasy-api/speakeasy/pull/920) in one case in `runInner`. This refactor introduces a test case which would have caught that case and makes runInner much simpler to read.
