### PR TITLE
fix: studio: improve cli <-> integration

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -319,7 +319,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		browser.OpenURL(overviewURL)
 	}
 
-	return nil
+	return err
 }
 
 func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, initialTarget, outDir string, skipCompile bool) (bool, error) {
@@ -392,7 +392,7 @@ func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bo
 		return false
 	}
 
-	// TODO: include anyDiagnostics into here if we want to launch the studio after run when we detect issues
+	// TODO: include more relevant diagnostics as we go!
 	numDiagnostics := lo.SumBy(lo.Values(sourceResult.Diagnosis), func(x []suggestions.Diagnostic) int {
 		return len(x)
 	})
@@ -407,7 +407,7 @@ func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bo
 	message := fmt.Sprintf("We've detected %d potential improvements for your SDK. Would you like to launch the studio?", numDiagnostics)
 
 	if offerDeclineOption {
-		return interactivity.SimpleConfirm(message)
+		return interactivity.SimpleConfirm(message, true)
 	}
 
 	interactivity.SimpleConfirmWithOnlyAccept(message)

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -312,7 +312,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		logger.Println(styles.RenderWarningMessage("! ATTENTION DO THIS !", changeDirMsg))
 	}
 
-	if shouldLaunchStudio(ctx, wf, true) {
+	if shouldLaunchStudio(ctx, wf, true, nil) {
 		err = studio.LaunchStudio(ctx, wf)
 	} else if len(wf.SDKOverviewURLs) == 1 { // There should only be one target after quickstart
 		overviewURL := wf.SDKOverviewURLs[initialTarget]

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -361,6 +361,11 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 }
 
 func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bool) bool {
+	// TODO: Remove this when ready to launch for everyone
+	if !config.IsAdminUnsafe() {
+		return false
+	}
+
 	// Only one source at a time is supported in the studio at the moment
 	// If the source has a linting result then it was loaded successfully, so we can show something in the studio
 	canLaunch := len(wf.SourceResults) == 1 && maps.Values(wf.SourceResults)[0].LintResult != nil

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -404,11 +404,9 @@ func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bo
 		return interactivity.SimpleConfirm(message, true)
 	}
 
-	message := fmt.Sprintf("We've detected %d potential improvements for your SDK we will launch the studio to help you fix them.", numDiagnostics)
-	// TODO: Make this just a button
-	interactivity.SimpleConfirmWithOnlyAccept(message)
-	return true
-
+	message := fmt.Sprintf("\nWe've detected %d potential improvements for your SDK. The Speakeasy Studio can help you fix them.\n", numDiagnostics)
+	log.From(ctx).PrintfStyled(styles.HeavilyEmphasized, message)
+	return interactivity.SimpleButton("↵ Launch Studio")
 }
 
 func printSampleSpecMessage(absSchemaPath string) {

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -368,11 +368,12 @@ func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bo
 
 	// Only one source at a time is supported in the studio at the moment
 	// If the source has a linting result then it was loaded successfully, so we can show something in the studio
-	canLaunch := len(wf.SourceResults) == 1 && maps.Values(wf.SourceResults)[0].LintResult != nil
+	sourceResults := maps.Values(wf.SourceResults)
+	canLaunch := len(sourceResults) == 1 && sourceResults[0].LintResult != nil
 
 	shouldLaunch := fromQuickstart || !config.SeenStudio() || config.IsAdminUnsafe()
 
-	diagnosis := maps.Values(wf.SourceResults)[0].Diagnosis
+	diagnosis := sourceResults[0].Diagnosis
 	anyDiagnostics := len(diagnosis) > 0
 
 	return canLaunch && shouldLaunch && anyDiagnostics

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,7 +37,7 @@ type RunFlags struct {
 	Verbose            bool              `json:"verbose"`
 	RegistryTags       []string          `json:"registry-tags"`
 	SetVersion         string            `json:"set-version"`
-	LaunchStudio       bool              `json:"launch-studio"`
+	LaunchStudio       *bool             `json:"launch-studio"`
 	GitHub             bool              `json:"github"`
 }
 
@@ -149,6 +149,7 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 		flag.BooleanFlag{
 			Name:        "launch-studio",
 			Description: "launch the web studio for iterating on the generated SDK",
+			Required:    false,
 		},
 		flag.BooleanFlag{
 			Name:        "github",
@@ -303,10 +304,7 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
-	}
-
-	if flags.LaunchStudio {
-		opts = append(opts, run.WithSkipCleanup())
+		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 
 	workflow, err := run.NewWorkflow(
@@ -314,18 +312,26 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		opts...,
 	)
 
-	if err != nil && !flags.LaunchStudio {
+	defer func() {
+		workflow.Cleanup()
+	}()
+
+	if err != nil {
 		return err
 	}
 
 	err = workflow.Run(ctx)
 
+	if err != nil {
+		log.From(ctx).Error(err.Error())
+	}
+
 	workflow.RootStep.Finalize(err == nil)
 
 	github.GenerateWorkflowSummary(ctx, workflow.RootStep)
 
-	if flags.LaunchStudio {
-		return studio.LaunchStudio(ctx, workflow)
+	if shouldLaunchStudio(ctx, workflow, false, flags.LaunchStudio) {
+		err = studio.LaunchStudio(ctx, workflow)
 	}
 
 	return err
@@ -388,11 +394,11 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 
 	if err != nil {
 		log.From(ctx).Error(err.Error())
+	} else {
+		workflow.PrintSuccessSummary(ctx)
 	}
 
-	workflow.PrintSuccessSummary(ctx)
-
-	if flags.LaunchStudio || shouldLaunchStudio(ctx, workflow, false) {
+	if shouldLaunchStudio(ctx, workflow, false, flags.LaunchStudio) {
 		err = studio.LaunchStudio(ctx, workflow)
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -152,10 +152,6 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 			Required:    false,
 		},
 		flag.BooleanFlag{
-			Name:        "never-launch-studio",
-			Description: "never launch the web studio",
-		},
-		flag.BooleanFlag{
 			Name:        "github",
 			Description: "kick off a generation run in GitHub",
 		},

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -350,10 +350,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
-	}
-
-	if flags.LaunchStudio {
-		opts = append(opts, run.WithSkipCleanup())
+		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 
 	workflow, err := run.NewWorkflow(
@@ -395,8 +392,8 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 
 	workflow.PrintSuccessSummary(ctx)
 
-	if shouldLaunchStudio(ctx, workflow) {
-		return studio.LaunchStudio(ctx, workflow)
+	if flags.LaunchStudio || shouldLaunchStudio(ctx, workflow, false) {
+		err = studio.LaunchStudio(ctx, workflow)
 	}
 
 	return err

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -37,8 +37,7 @@ type RunFlags struct {
 	Verbose            bool              `json:"verbose"`
 	RegistryTags       []string          `json:"registry-tags"`
 	SetVersion         string            `json:"set-version"`
-	LaunchStudio       *bool             `json:"launch-studio"`
-	NeverLaunchStudio  bool              `json:"never-launch-studio"`
+	LaunchStudio       bool              `json:"launch-studio"`
 	GitHub             bool              `json:"github"`
 }
 
@@ -197,14 +196,6 @@ func preRun(cmd *cobra.Command, flags *RunFlags) error {
 		flags.Target = targets[0]
 	}
 
-	// This is a workaround for optional boolean flags - TODO: find a better way to handle this
-	if !*flags.LaunchStudio {
-		flags.LaunchStudio = nil
-	}
-	if flags.NeverLaunchStudio {
-		flags.LaunchStudio = new(bool)
-	}
-
 	// Needed later
 	if err := cmd.Flags().Set("target", flags.Target); err != nil {
 		return err
@@ -343,7 +334,7 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 
 	github.GenerateWorkflowSummary(ctx, workflow.RootStep)
 
-	if shouldLaunchStudio(ctx, workflow, false, flags.LaunchStudio) {
+	if flags.LaunchStudio || shouldLaunchStudio(ctx, workflow, false) {
 		err = studio.LaunchStudio(ctx, workflow)
 	}
 
@@ -411,7 +402,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		workflow.PrintSuccessSummary(ctx)
 	}
 
-	if shouldLaunchStudio(ctx, workflow, false, flags.LaunchStudio) {
+	if shouldLaunchStudio(ctx, workflow, false) {
 		err = studio.LaunchStudio(ctx, workflow)
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -38,6 +38,7 @@ type RunFlags struct {
 	RegistryTags       []string          `json:"registry-tags"`
 	SetVersion         string            `json:"set-version"`
 	LaunchStudio       *bool             `json:"launch-studio"`
+	NeverLaunchStudio  bool              `json:"never-launch-studio"`
 	GitHub             bool              `json:"github"`
 }
 
@@ -148,8 +149,12 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 		},
 		flag.BooleanFlag{
 			Name:        "launch-studio",
-			Description: "launch the web studio for iterating on the generated SDK",
+			Description: "launch the web studio for improving the quality of the generated SDK",
 			Required:    false,
+		},
+		flag.BooleanFlag{
+			Name:        "never-launch-studio",
+			Description: "never launch the web studio",
 		},
 		flag.BooleanFlag{
 			Name:        "github",
@@ -190,6 +195,14 @@ func preRun(cmd *cobra.Command, flags *RunFlags) error {
 
 	if flags.Target == "all" && len(targets) == 1 {
 		flags.Target = targets[0]
+	}
+
+	// This is a workaround for optional boolean flags - TODO: find a better way to handle this
+	if !*flags.LaunchStudio {
+		flags.LaunchStudio = nil
+	}
+	if flags.NeverLaunchStudio {
+		flags.LaunchStudio = new(bool)
 	}
 
 	// Needed later

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -398,7 +398,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		workflow.PrintSuccessSummary(ctx)
 	}
 
-	if shouldLaunchStudio(ctx, workflow, false) {
+	if flags.LaunchStudio || shouldLaunchStudio(ctx, workflow, false) {
 		err = studio.LaunchStudio(ctx, workflow)
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -2,9 +2,6 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.23.0
 
-replace github.com/speakeasy-api/speakeasy-core => ../speakeasy-core
-
-
 // Can be removed once https://github.com/pb33f/libopenapi/pull/319 is merged and the dependency is updated here
 replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826
 

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,9 @@ module github.com/speakeasy-api/speakeasy
 
 go 1.23.0
 
+replace github.com/speakeasy-api/speakeasy-core => ../speakeasy-core
+
+
 // Can be removed once https://github.com/pb33f/libopenapi/pull/319 is merged and the dependency is updated here
 replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.0-20240814113924-cc96d2bc2826
 

--- a/internal/ask/ask.go
+++ b/internal/ask/ask.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -13,8 +14,6 @@ import (
 	"strings"
 
 	"github.com/inkeep/ai-api-go/models/sdkerrors"
-	"github.com/speakeasy-api/huh"
-	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 )
@@ -191,16 +190,8 @@ func RunInteractiveChatSession(ctx context.Context, message string, sessionID st
 
 func OfferChatSessionOnError(ctx context.Context, message string) {
 	logger := log.From(ctx)
-	var confirm bool
 
-	if _, err := charm_internal.NewForm(
-		huh.NewForm(charm_internal.NewBranchPrompt("Would you like to enter an interactive chat session with Speakeasy AI for help?", &confirm)),
-		charm_internal.WithTitle(fmt.Sprintf("Ask Speakeasy AI:")),
-	).
-		ExecuteForm(); err != nil {
-		logger.Printf("Failed to display confirmation prompt: %v", err)
-		return
-	}
+	confirm := interactivity.SimpleConfirm("Would you like to enter an interactive chat session with Speakeasy AI for help?")
 
 	if confirm {
 		if err := RunInteractiveChatSession(ctx, message, ""); err != nil {

--- a/internal/ask/ask.go
+++ b/internal/ask/ask.go
@@ -6,12 +6,13 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 
 	"github.com/inkeep/ai-api-go/models/sdkerrors"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
@@ -191,7 +192,7 @@ func RunInteractiveChatSession(ctx context.Context, message string, sessionID st
 func OfferChatSessionOnError(ctx context.Context, message string) {
 	logger := log.From(ctx)
 
-	confirm := interactivity.SimpleConfirm("Would you like to enter an interactive chat session with Speakeasy AI for help?")
+	confirm := interactivity.SimpleConfirm("Would you like to enter an interactive chat session with Speakeasy AI for help?", false)
 
 	if confirm {
 		if err := RunInteractiveChatSession(ctx, message, ""); err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/exp/maps"
 	"os"
 	"path/filepath"
+	"slices"
 
 	"github.com/spf13/viper"
 )
@@ -127,6 +128,20 @@ func ClearSpeakeasyAuthInfo() error {
 	vCfg.Set("speakeasy_customer_id", "")
 	vCfg.Set("speakeasy_studio_secret", "")
 	return save()
+}
+
+func SetSeenStudio() error {
+	vCfg.Set("seen_studio", true)
+	return save()
+}
+
+func SeenStudio() bool {
+	return vCfg.GetBool("seen_studio")
+}
+
+// IsAdminUnsafe is "unsafe" because anyone could set a key for "-self" in theory. We aren't actually checking the key is valid.
+func IsAdminUnsafe() bool {
+	return slices.Contains(GetAuthenticatedWorkspaces(), "speakeasy-self@speakeasy-self")
 }
 
 func save() error {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -130,13 +130,8 @@ func ClearSpeakeasyAuthInfo() error {
 	return save()
 }
 
-func SetSeenStudio() error {
-	vCfg.Set("seen_studio", true)
-	return save()
-}
-
 func SeenStudio() bool {
-	return vCfg.GetBool("seen_studio")
+	return GetStudioSecret() != ""
 }
 
 // IsAdminUnsafe is "unsafe" because anyone could set a key for "-self" in theory. We aren't actually checking the key is valid.

--- a/internal/interactivity/button.go
+++ b/internal/interactivity/button.go
@@ -1,8 +1,11 @@
 package interactivity
 
 import (
+	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"os"
 )
 
 var (
@@ -15,33 +18,17 @@ var (
 )
 
 type Button struct {
-	Label    string
-	Disabled bool
-	Hovered  bool
+	Label        string
+	Disabled     bool
+	Hovered      bool
+	Clicked      bool
+	ShowValidity bool
 }
 
 type ButtonWithHelperText struct {
 	Button
 	HelperText      string
 	ShowOnlyOnHover bool
-}
-
-func (b Button) View() string {
-	validnessIndicator := " ✔"
-	if b.Disabled {
-		validnessIndicator = " ✘"
-	}
-
-	style := blurredStyle
-	if b.Hovered {
-		style = validStyle
-
-		if b.Disabled {
-			style = invalidStyle
-		}
-	}
-
-	return style.Render(b.Label + validnessIndicator)
 }
 
 func (b ButtonWithHelperText) View() string {
@@ -59,4 +46,80 @@ func (b ButtonWithHelperText) View() string {
 	}
 
 	return b.Button.View() + "\n" + style.Render(helperText)
+}
+
+func NewSimpleButton(text string) Button {
+	m := Button{
+		Label:        text,
+		Disabled:     false,
+		Hovered:      true,
+		ShowValidity: false,
+	}
+
+	return m
+}
+
+func (b *Button) Init() tea.Cmd {
+	return nil
+}
+
+func (b *Button) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	return b, nil
+}
+
+func (b *Button) HandleKeypress(key string) tea.Cmd {
+	switch key {
+	case "enter":
+		b.Clicked = true
+		return tea.Quit
+	}
+
+	return nil
+}
+
+func (b *Button) SetWidth(width int) {}
+
+func (b *Button) Validate() error {
+	return nil
+}
+
+func (b *Button) View() string {
+	validnessIndicator := " ✔"
+	if b.Disabled {
+		validnessIndicator = " ✘"
+	}
+
+	if !b.ShowValidity {
+		validnessIndicator = ""
+	}
+
+	style := blurredStyle
+	if b.Hovered {
+		style = validStyle
+
+		if b.Disabled {
+			style = invalidStyle
+		}
+	}
+
+	return style.Render(b.Label + validnessIndicator)
+}
+
+func (b *Button) OnUserExit() {}
+
+// Run returns a map from input name to the input Value
+func (b *Button) Run() bool {
+	newM, err := charm_internal.RunModel(b)
+	if err != nil {
+		os.Exit(1)
+	}
+
+	resultingModel := newM.(*Button)
+
+	return resultingModel.Clicked
+}
+
+func SimpleButton(text string) bool {
+	button := NewSimpleButton(text)
+	return button.Run()
 }

--- a/internal/interactivity/simpleConfirm.go
+++ b/internal/interactivity/simpleConfirm.go
@@ -1,0 +1,19 @@
+package interactivity
+
+import (
+	"github.com/speakeasy-api/huh"
+	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
+)
+
+func SimpleConfirm(message string) bool {
+	var confirm bool
+
+	if _, err := charm_internal.NewForm(
+		huh.NewForm(charm_internal.NewBranchPrompt(message, &confirm)),
+	).
+		ExecuteForm(); err != nil {
+		return false
+	}
+
+	return confirm
+}

--- a/internal/interactivity/simpleConfirm.go
+++ b/internal/interactivity/simpleConfirm.go
@@ -17,3 +17,14 @@ func SimpleConfirm(message string) bool {
 
 	return confirm
 }
+
+func SimpleConfirmWithOnlyAccept(message string) {
+	form := huh.NewForm(huh.NewGroup(huh.NewConfirm().
+		Title(message).
+		Affirmative("Okay"),
+	))
+
+	if _, err := charm_internal.NewForm(form).ExecuteForm(); err != nil {
+		return
+	}
+}

--- a/internal/interactivity/simpleConfirm.go
+++ b/internal/interactivity/simpleConfirm.go
@@ -5,8 +5,8 @@ import (
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 )
 
-func SimpleConfirm(message string) bool {
-	var confirm bool
+func SimpleConfirm(message string, defaultValue bool) bool {
+	var confirm bool = defaultValue
 
 	if _, err := charm_internal.NewForm(
 		huh.NewForm(charm_internal.NewBranchPrompt(message, &confirm)),

--- a/internal/interactivity/simpleConfirm.go
+++ b/internal/interactivity/simpleConfirm.go
@@ -6,7 +6,7 @@ import (
 )
 
 func SimpleConfirm(message string, defaultValue bool) bool {
-	var confirm bool = defaultValue
+	confirm := defaultValue
 
 	if _, err := charm_internal.NewForm(
 		huh.NewForm(charm_internal.NewBranchPrompt(message, &confirm)),
@@ -16,15 +16,4 @@ func SimpleConfirm(message string, defaultValue bool) bool {
 	}
 
 	return confirm
-}
-
-func SimpleConfirmWithOnlyAccept(message string) {
-	form := huh.NewForm(huh.NewGroup(huh.NewConfirm().
-		Title(message).
-		Affirmative("Okay"),
-	))
-
-	if _, err := charm_internal.NewForm(form).ExecuteForm(); err != nil {
-		return
-	}
 }

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy-core/errors"
 	"os"
 	"os/exec"
 	"slices"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy-core/errors"
 
 	"github.com/fatih/structs"
 	"github.com/hashicorp/go-version"
@@ -221,6 +222,7 @@ func (c ExecutableCommand[F]) GetFlagValues(cmd *cobra.Command) (*F, error) {
 			return
 		}
 
+		fmt.Println("Parsing flag", f.Name, f.Value, f.Value.String())
 		v, err := flag.ParseValue(f.Value.String())
 		if err != nil {
 			panic(err)

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -222,7 +222,6 @@ func (c ExecutableCommand[F]) GetFlagValues(cmd *cobra.Command) (*F, error) {
 			return
 		}
 
-		fmt.Println("Parsing flag", f.Name, f.Value, f.Value.String())
 		v, err := flag.ParseValue(f.Value.String())
 		if err != nil {
 			panic(err)

--- a/internal/model/flag/booleanFlag.go
+++ b/internal/model/flag/booleanFlag.go
@@ -26,6 +26,5 @@ func (f BooleanFlag) GetName() string {
 }
 
 func (f BooleanFlag) ParseValue(v string) (interface{}, error) {
-	fmt.Println("Parsing boolean value", f.Name, v)
 	return strconv.ParseBool(v)
 }

--- a/internal/model/flag/booleanFlag.go
+++ b/internal/model/flag/booleanFlag.go
@@ -1,8 +1,10 @@
 package flag
 
 import (
-	"github.com/spf13/cobra"
+	"fmt"
 	"strconv"
+
+	"github.com/spf13/cobra"
 )
 
 type BooleanFlag struct {
@@ -24,5 +26,6 @@ func (f BooleanFlag) GetName() string {
 }
 
 func (f BooleanFlag) ParseValue(v string) (interface{}, error) {
+	fmt.Println("Parsing boolean value", f.Name, v)
 	return strconv.ParseBool(v)
 }

--- a/internal/model/flag/booleanFlag.go
+++ b/internal/model/flag/booleanFlag.go
@@ -1,7 +1,6 @@
 package flag
 
 import (
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"

--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -74,6 +74,8 @@ func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {
 		fmt.Println("Opening URL in your browser:", url)
 	}
 
+	_ = config.SetSeenStudio()
+
 	return startServer(ctx, server, workflow)
 }
 

--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -74,8 +74,6 @@ func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {
 		fmt.Println("Opening URL in your browser:", url)
 	}
 
-	_ = config.SetSeenStudio()
-
 	// After ten seconds, if the health check hasn't been seen then kill the server
 	go func() {
 		time.Sleep(10 * time.Second)

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -34,9 +34,11 @@ type StudioHandlers struct {
 	SourceID       string
 	OverlayPath    string
 	Ctx            context.Context
-	mutex          sync.Mutex
-	mutexCondition *sync.Cond
-	running        bool
+
+	mutex           sync.Mutex
+	mutexCondition  *sync.Cond
+	running         bool
+	healthCheckSeen bool
 }
 
 func NewStudioHandlers(ctx context.Context, workflowRunner *run.Workflow) (*StudioHandlers, error) {
@@ -172,6 +174,8 @@ func (h *StudioHandlers) health(ctx context.Context, w http.ResponseWriter, r *h
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
+
+	h.healthCheckSeen = true
 
 	flusher, ok := w.(http.Flusher)
 	if !ok {

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -123,7 +123,14 @@ func (h *StudioHandlers) reRun(ctx context.Context, w http.ResponseWriter, r *ht
 		return fmt.Errorf("error updating source: %w", err)
 	}
 
-	cloned, err := h.WorkflowRunner.Clone(h.Ctx, run.WithSkipCleanup(), run.WithLinting(), run.WithSkipGenerateLintReport())
+	cloned, err := h.WorkflowRunner.Clone(
+		h.Ctx,
+		run.WithSkipCleanup(),
+		run.WithLinting(),
+		run.WithSkipGenerateLintReport(),
+		run.WithSkipSnapshot(true),
+		run.WithSkipChangeReport(true),
+	)
 	if err != nil {
 		return fmt.Errorf("error cloning workflow runner: %w", err)
 	}

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -160,7 +160,7 @@ func (h *StudioHandlers) reRun(ctx context.Context, w http.ResponseWriter, r *ht
 		h.WorkflowRunner.OnSourceResult = func(*run.SourceResult, string) {}
 	}()
 
-	err = h.WorkflowRunner.Run(h.Ctx)
+	err = h.WorkflowRunner.RunWithVisualization(h.Ctx)
 	if err != nil {
 		fmt.Println("error running workflow:", err)
 	}


### PR DESCRIPTION
Fixes/improvements:
- If we haven't seen a health check 10 seconds after launching the studio, kill the server 
- Don't cleanup until after the studio has run
- Display the nice workflow viz rather than the "console" output
- Skip snapshotting and change reports during studio runs
- Launch studio when:
  - There's exactly one source result
  - AND We have useful diagnostics
  - AND:
    - We've just come from quickstart
    - OR the user is in `run` but has never seen the studio before
    - OR the user is an admin

![CleanShot 2024-09-09 at 12 18 27@2x](https://github.com/user-attachments/assets/7677e5c7-f1bf-4c07-81e8-70c1f5786534)
![CleanShot 2024-09-09 at 17 44 43@2x](https://github.com/user-attachments/assets/eb2c50a6-8b4e-4918-bb69-f0d4ce7f6dfb)
