### PR TITLE
feat: dont launch studio for json inputs

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -355,16 +355,24 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 		run.WithShouldCompile(!skipCompile),
 	)
 
+	if err != nil {
+		return true, err
+	}
+
 	err = wf.RunWithVisualization(ctx)
 
 	return true, err
 }
 
 func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bool) bool {
-	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf)
+	canLaunch, reason := studio.CanLaunch(ctx, wf)
+
 	if !canLaunch {
+		log.From(ctx).PrintfStyled(styles.Warning, "\nWarning: "+reason+" Skipping Studio launch")
 		return false
 	}
+
+	numDiagnostics := studio.DiagnosticCount(ctx, wf)
 
 	offerDeclineOption := !fromQuickstart && config.SeenStudio()
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -399,8 +399,15 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 }
 
 func maybeLaunchStudio(ctx context.Context, wf *run.Workflow, flags RunFlags) error {
-	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf)
-	if canLaunch && flags.Watch {
+	canLaunch, reason := studio.CanLaunch(ctx, wf)
+
+	if !canLaunch {
+		log.From(ctx).PrintfStyled(styles.Warning, "\nWarning: "+reason+" Skipping Studio launch")
+		return nil
+	}
+	numDiagnostics := studio.DiagnosticCount(ctx, wf)
+
+	if flags.Watch {
 		return studio.LaunchStudio(ctx, wf)
 	} else if numDiagnostics > 1 {
 		log.From(ctx).PrintfStyled(styles.Info, "\nWe've detected `%d` potential improvements for your SDK.\nGet automatic fixes in the Studio with `speakeasy run --watch`", numDiagnostics)


### PR DESCRIPTION
Skip launching the Studio in `--watch` mode for JSON input specifications