### PR TITLE
feat: initialize git repository during quickstart

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -12,11 +12,13 @@ import (
 	"github.com/pkg/browser"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/config"
+	"github.com/speakeasy-api/speakeasy/internal/git"
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"github.com/speakeasy-api/speakeasy/internal/studio"
 
+	gitc "github.com/go-git/go-git/v5"
 	"github.com/speakeasy-api/huh"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 
@@ -80,6 +82,14 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	workingDir, err := os.Getwd()
 	if err != nil {
 		return err
+	}
+
+	_, err = git.InitLocalRepository(workingDir)
+
+	if err != nil && !errors.Is(err, gitc.ErrRepositoryAlreadyExists) {
+		log.From(ctx).Warnf("Encountered issue initializing git repository: %s", err.Error())
+	} else if err == nil {
+		log.From(ctx).Infof("Initialized git repository in %s", workingDir)
 	}
 
 	if workflowFile, _, _ := workflow.Load(workingDir); workflowFile != nil {

--- a/internal/git/repository.go
+++ b/internal/git/repository.go
@@ -12,6 +12,8 @@ type Repository struct {
 	repo *gitc.Repository
 }
 
+// NewLocalRepository will attempt to open a pre-existing git repository in the given directory
+// If no repository is found, it will return an empty Repository
 func NewLocalRepository(dir string) (*Repository, error) {
 	repo, err := gitc.PlainOpenWithOptions(dir, &gitc.PlainOpenOptions{
 		DetectDotGit: true,
@@ -20,6 +22,19 @@ func NewLocalRepository(dir string) (*Repository, error) {
 		return &Repository{}, nil
 	} else if err != nil {
 		return &Repository{}, fmt.Errorf("git: %w", err)
+	}
+
+	return &Repository{repo: repo}, nil
+}
+
+// InitLocalRepository will initialize a new git repository in the given directory
+func InitLocalRepository(dir string) (*Repository, error) {
+	repo, err := gitc.PlainInitWithOptions(dir, &gitc.PlainInitOptions{
+		Bare: false,
+	})
+
+	if err != nil {
+		return &Repository{}, err
 	}
 
 	return &Repository{repo: repo}, nil


### PR DESCRIPTION
Initialises a new git repository locally at the beginning of quickstart if one doesn't previously exist in the working directory.