### PR TITLE
fix: studio listening message

### DIFF
--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -6,17 +6,18 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
-	"github.com/samber/lo"
-	"github.com/speakeasy-api/speakeasy-core/suggestions"
-	"github.com/speakeasy-api/speakeasy/internal/env"
-	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"golang.org/x/exp/maps"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
 	"syscall"
 	"time"
+
+	"github.com/samber/lo"
+	"github.com/speakeasy-api/speakeasy-core/suggestions"
+	"github.com/speakeasy-api/speakeasy/internal/env"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"golang.org/x/exp/maps"
 
 	"github.com/speakeasy-api/speakeasy-core/auth"
 
@@ -99,10 +100,12 @@ func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {
 
 	url := fmt.Sprintf("%s/studio/%d#%s", serverURL, port, secret)
 
+	listeningMessage := fmt.Sprintf("Listening on http://localhost:%d\n", port)
+
 	if err := browser.OpenURL(url); err != nil {
-		fmt.Println("Please open the following URL in your browser:", url)
+		fmt.Println(listeningMessage+"Please open the following URL in your browser:\n\t", url)
 	} else {
-		fmt.Println("Opening URL in your browser:", url)
+		fmt.Println(listeningMessage+"Opening URL in your browser:\n\t", url)
 	}
 
 	// After ten seconds, if the health check hasn't been seen then kill the server


### PR DESCRIPTION
For users like @LukeHagar who use a virtual env to develop locally port forwarding is needed to be able to use the studio. Simply printing a `Listening on ...`, is good enough for clever terminals like VSCode to pick up this message and suggest port forwarding 🥳 