### PR TITLE
fix: studio handle clicking on "listening on ..." message

### DIFF
--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -71,6 +71,7 @@ func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {
 	}
 
 	mux := http.NewServeMux()
+	mux.HandleFunc("/", handler(handlers.root))
 	mux.HandleFunc("/health", handler(handlers.health))
 
 	mux.HandleFunc("/run", func(w http.ResponseWriter, r *http.Request) {
@@ -98,14 +99,14 @@ func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {
 
 	serverURL := auth.GetWorkspaceBaseURL(ctx)
 
-	url := fmt.Sprintf("%s/studio/%d#%s", serverURL, port, secret)
+	handlers.StudioURL = fmt.Sprintf("%s/studio/%d#%s", serverURL, port, secret)
 
 	listeningMessage := fmt.Sprintf("Listening on http://localhost:%d\n", port)
 
-	if err := browser.OpenURL(url); err != nil {
-		fmt.Println(listeningMessage+"Please open the following URL in your browser:\n\t", url)
+	if err := browser.OpenURL(handlers.StudioURL); err != nil {
+		fmt.Println(listeningMessage+"Please open the following URL in your browser: ", handlers.StudioURL)
 	} else {
-		fmt.Println(listeningMessage+"Opening URL in your browser:\n\t", url)
+		fmt.Println(listeningMessage+"Opening URL in your browser: ", handlers.StudioURL)
 	}
 
 	// After ten seconds, if the health check hasn't been seen then kill the server

--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -144,7 +144,7 @@ func corsMiddleware(next http.Handler) http.Handler {
 
 func authMiddleware(secret string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Header.Get("X-Secret-Key") != secret {
+		if r.Header.Get("X-Secret-Key") != secret && r.URL.Path != "/" {
 			http.Error(w, "Unauthorized", http.StatusUnauthorized)
 			return
 		}

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -35,6 +35,7 @@ type StudioHandlers struct {
 	SourceID       string
 	OverlayPath    string
 	Ctx            context.Context
+	StudioURL      string
 
 	mutex           sync.Mutex
 	mutexCondition  *sync.Cond
@@ -203,6 +204,12 @@ func (h *StudioHandlers) health(ctx context.Context, w http.ResponseWriter, r *h
 	// This keeps the connection open while the client is still connected
 	<-ctx.Done()
 
+	return nil
+}
+
+func (h *StudioHandlers) root(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
+	// In case the user navigates to the root of the studio, redirect them to the studio URL
+	http.Redirect(w, r, h.StudioURL, http.StatusSeeOther)
 	return nil
 }
 


### PR DESCRIPTION
We now output

```
Listening on http://localhost:3333
Opening URL in your browser:  https://app.speakeasy.com/org/speakeasy-self/speakeasy-self/studio/3333#stu-e6e482886b6a4e913a183c61fed1d248
```

They could click on the localhost one so we redirect in that case