### PR TITLE
fix: Make update prompt readable on all terminals

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,27 +1,27 @@
 package cmd
 
 import (
-    "context"
-    "fmt"
-    "os"
-    "slices"
-    "strings"
+	"context"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
 
-    "github.com/speakeasy-api/speakeasy/cmd/generate"
+	"github.com/speakeasy-api/speakeasy/cmd/generate"
 
-    "github.com/speakeasy-api/speakeasy-core/events"
+	"github.com/speakeasy-api/speakeasy-core/events"
 
-    "github.com/speakeasy-api/speakeasy/internal/model"
+	"github.com/speakeasy-api/speakeasy/internal/model"
 
-    "github.com/speakeasy-api/speakeasy/internal/charm/styles"
-    "github.com/speakeasy-api/speakeasy/internal/interactivity"
-    "github.com/speakeasy-api/speakeasy/internal/updates"
-    "github.com/speakeasy-api/speakeasy/internal/utils"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
+	"github.com/speakeasy-api/speakeasy/internal/updates"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 
-    "github.com/speakeasy-api/speakeasy/internal/config"
-    "github.com/speakeasy-api/speakeasy/internal/log"
-    "github.com/spf13/cobra"
-    "go.uber.org/zap"
+	"github.com/speakeasy-api/speakeasy/internal/config"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/spf13/cobra"
+	"go.uber.org/zap"
 )
 
 const rootLong = `# Speakeasy 
@@ -45,151 +45,151 @@ Visit [Speakeasy](https://www.speakeasy.com/) for more information
 `
 
 var rootCmd = &cobra.Command{
-    Use:   "speakeasy",
-    Short: "The Speakeasy CLI tool provides access to the Speakeasy.com platform",
-    Long:  utils.RenderMarkdown(rootLong),
-    RunE:  rootExec,
+	Use:   "speakeasy",
+	Short: "The Speakeasy CLI tool provides access to the Speakeasy.com platform",
+	Long:  utils.RenderMarkdown(rootLong),
+	RunE:  rootExec,
 }
 
 var l = log.New().WithLevel(log.LevelInfo)
 
 func init() {
-    // We want our commands to be sorted in defined order, not alphabetically
-    cobra.EnableCommandSorting = false
-    if err := config.Load(); err != nil {
-        l.Error("", zap.Error(err))
-        os.Exit(1)
-    }
+	// We want our commands to be sorted in defined order, not alphabetically
+	cobra.EnableCommandSorting = false
+	if err := config.Load(); err != nil {
+		l.Error("", zap.Error(err))
+		os.Exit(1)
+	}
 }
 
 func Init(version, artifactArch string) {
-    rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
+	rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
 
-    // TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
-    addCommand(rootCmd, statusCmd)
-    addCommand(rootCmd, quickstartCmd)
-    addCommand(rootCmd, runCmd)
-    addCommand(rootCmd, configureCmd)
-    addCommand(rootCmd, generate.GenerateCmd)
-    addCommand(rootCmd, lintCmd)
-    addCommand(rootCmd, openapiCmd)
-    addCommand(rootCmd, migrateCmd)
+	// TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
+	addCommand(rootCmd, statusCmd)
+	addCommand(rootCmd, quickstartCmd)
+	addCommand(rootCmd, runCmd)
+	addCommand(rootCmd, configureCmd)
+	addCommand(rootCmd, generate.GenerateCmd)
+	addCommand(rootCmd, lintCmd)
+	addCommand(rootCmd, openapiCmd)
+	addCommand(rootCmd, migrateCmd)
 
-    authInit()
-    mergeInit()
-    addCommand(rootCmd, overlayCmd)
-    addCommand(rootCmd, suggestCmd)
-    addCommand(rootCmd, defaultCodeSamplesCmd)
-    updateInit(version, artifactArch)
-    proxyInit()
-    apiInit()
-    languageServerInit(version)
-    bumpInit()
-    addCommand(rootCmd, tagCmd)
-    addCommand(rootCmd, cleanCmd)
+	authInit()
+	mergeInit()
+	addCommand(rootCmd, overlayCmd)
+	addCommand(rootCmd, suggestCmd)
+	addCommand(rootCmd, defaultCodeSamplesCmd)
+	updateInit(version, artifactArch)
+	proxyInit()
+	apiInit()
+	languageServerInit(version)
+	bumpInit()
+	addCommand(rootCmd, tagCmd)
+	addCommand(rootCmd, cleanCmd)
 
-    addCommand(rootCmd, AskCmd)
+	addCommand(rootCmd, AskCmd)
 }
 
 func addCommand(cmd *cobra.Command, command model.Command) {
-    c, err := command.Init()
-    if err != nil {
-        l.Error("", zap.Error(err))
-        os.Exit(1)
-    }
-    cmd.AddCommand(c)
+	c, err := command.Init()
+	if err != nil {
+		l.Error("", zap.Error(err))
+		os.Exit(1)
+	}
+	cmd.AddCommand(c)
 }
 
 func CmdForTest(version, artifactArch string) *cobra.Command {
-    setupRootCmd(version, artifactArch)
+	setupRootCmd(version, artifactArch)
 
-    return rootCmd
+	return rootCmd
 }
 
 func Execute(version, artifactArch string) {
-    setupRootCmd(version, artifactArch)
+	setupRootCmd(version, artifactArch)
 
-    if err := rootCmd.Execute(); err != nil {
-        l.Error("", zap.Error(err))
-        os.Exit(1)
-    }
+	if err := rootCmd.Execute(); err != nil {
+		l.Error("", zap.Error(err))
+		os.Exit(1)
+	}
 }
 
 func setupRootCmd(version, artifactArch string) {
-    rootCmd.Version = version + "\n" + artifactArch
-    rootCmd.SilenceErrors = true
-    rootCmd.SilenceUsage = true
-    rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-        ctx := context.WithValue(cmd.Context(), updates.ArtifactArchContextKey, artifactArch)
-        ctx = events.SetSpeakeasyVersionInContext(ctx, version)
-        cmd.SetContext(ctx)
+	rootCmd.Version = version + "\n" + artifactArch
+	rootCmd.SilenceErrors = true
+	rootCmd.SilenceUsage = true
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		ctx := context.WithValue(cmd.Context(), updates.ArtifactArchContextKey, artifactArch)
+		ctx = events.SetSpeakeasyVersionInContext(ctx, version)
+		cmd.SetContext(ctx)
 
-        if !slices.Contains([]string{"update", "language-server"}, cmd.Name()) {
-            checkForUpdate(ctx, version, artifactArch)
-        }
+		if !slices.Contains([]string{"update", "language-server"}, cmd.Name()) {
+			checkForUpdate(ctx, version, artifactArch)
+		}
 
-        return setLogLevel(cmd)
-    }
+		return setLogLevel(cmd)
+	}
 
-    Init(version, artifactArch)
+	Init(version, artifactArch)
 }
 
 func GetRootCommand() *cobra.Command {
-    return rootCmd
+	return rootCmd
 }
 
 func checkForUpdate(ctx context.Context, currentVersion, artifactArch string) {
-    // Don't display if piping to a file for example or running locally during development
-    if !utils.IsInteractive() { //TODO || env.IsLocalDev() {
-        return
-    }
+	// Don't display if piping to a file for example or running locally during development
+	if !utils.IsInteractive() { //TODO || env.IsLocalDev() {
+		return
+	}
 
-    newerVersion, err := updates.GetNewerVersion(ctx, artifactArch, currentVersion)
-    if err != nil {
-        return // Don't display error to user
-    }
+	newerVersion, err := updates.GetNewerVersion(ctx, artifactArch, currentVersion)
+	if err != nil {
+		return // Don't display error to user
+	}
 
-    if newerVersion == nil {
-        return
-    }
+	if newerVersion == nil {
+		return
+	}
 
-    mainStyle := styles.Emphasized.Background(styles.Colors.SpeakeasyPrimary).Foreground(styles.Colors.SpeakeasySecondary)
-    inverseStyle := styles.Emphasized.Background(styles.Colors.SpeakeasySecondary).Foreground(styles.Colors.SpeakeasyPrimary)
+	mainStyle := styles.Emphasized.Background(styles.Colors.SpeakeasyPrimary).Foreground(styles.Colors.SpeakeasySecondary)
+	inverseStyle := styles.Emphasized.Background(styles.Colors.SpeakeasySecondary).Foreground(styles.Colors.SpeakeasyPrimary)
 
-    versionString := fmt.Sprintf("A new version of the Speakeasy CLI is available: v%s", newerVersion.String())
-    updateString := fmt.Sprintf("Run %s%s", inverseStyle.Render("speakeasy update"), mainStyle.Render(" to update to the latest version"))
+	versionString := fmt.Sprintf("A new version of the Speakeasy CLI is available: v%s", newerVersion.String())
+	updateString := fmt.Sprintf("Run %s%s", inverseStyle.Render("speakeasy update"), mainStyle.Render(" to update to the latest version"))
 
-    l := log.From(ctx)
-    l.PrintfStyled(mainStyle.Padding(1, 2), "%s\n%s", versionString, updateString)
-    l.Println("\n")
+	l := log.From(ctx)
+	l.PrintfStyled(mainStyle.Padding(1, 2), "%s\n%s", versionString, updateString)
+	l.Println("\n")
 
-    return
+	return
 }
 
 func setLogLevel(cmd *cobra.Command) error {
-    logLevel, err := cmd.Flags().GetString("logLevel")
-    if err != nil {
-        return err
-    }
-    if !slices.Contains(log.Levels, logLevel) {
-        return fmt.Errorf("log level must be one of: %s", strings.Join(log.Levels, ", "))
-    }
+	logLevel, err := cmd.Flags().GetString("logLevel")
+	if err != nil {
+		return err
+	}
+	if !slices.Contains(log.Levels, logLevel) {
+		return fmt.Errorf("log level must be one of: %s", strings.Join(log.Levels, ", "))
+	}
 
-    l = l.WithLevel(log.Level(logLevel))
-    ctx := log.With(cmd.Context(), l)
-    cmd.SetContext(ctx)
+	l = l.WithLevel(log.Level(logLevel))
+	ctx := log.With(cmd.Context(), l)
+	cmd.SetContext(ctx)
 
-    return nil
+	return nil
 }
 
 func rootExec(cmd *cobra.Command, args []string) error {
-    if !utils.IsInteractive() {
-        return cmd.Help()
-    }
+	if !utils.IsInteractive() {
+		return cmd.Help()
+	}
 
-    l := log.From(cmd.Context()).WithInteractiveOnly()
-    l.PrintfStyled(styles.HeavilyEmphasized, "Welcome to the Speakeasy CLI!\n")
-    l.PrintfStyled(styles.DimmedItalic, "This is interactive mode. For usage, run speakeasy -h instead.\n")
+	l := log.From(cmd.Context()).WithInteractiveOnly()
+	l.PrintfStyled(styles.HeavilyEmphasized, "Welcome to the Speakeasy CLI!\n")
+	l.PrintfStyled(styles.DimmedItalic, "This is interactive mode. For usage, run speakeasy -h instead.\n")
 
-    return interactivity.InteractiveExec(cmd, args, "Select a command to run")
+	return interactivity.InteractiveExec(cmd, args, "Select a command to run")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -139,8 +139,8 @@ func GetRootCommand() *cobra.Command {
 }
 
 func checkForUpdate(ctx context.Context, currentVersion, artifactArch string) {
-	// Don't display if piping to a file for example or running locally during development
-	if !utils.IsInteractive() { //TODO || env.IsLocalDev() {
+	// Don't display if piping to a file for example
+	if !utils.IsInteractive() {
 		return
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,29 +1,27 @@
 package cmd
 
 import (
-	"context"
-	"fmt"
-	"os"
-	"slices"
-	"strings"
+    "context"
+    "fmt"
+    "os"
+    "slices"
+    "strings"
 
-	"github.com/speakeasy-api/speakeasy/internal/env"
+    "github.com/speakeasy-api/speakeasy/cmd/generate"
 
-	"github.com/speakeasy-api/speakeasy/cmd/generate"
+    "github.com/speakeasy-api/speakeasy-core/events"
 
-	"github.com/speakeasy-api/speakeasy-core/events"
+    "github.com/speakeasy-api/speakeasy/internal/model"
 
-	"github.com/speakeasy-api/speakeasy/internal/model"
+    "github.com/speakeasy-api/speakeasy/internal/charm/styles"
+    "github.com/speakeasy-api/speakeasy/internal/interactivity"
+    "github.com/speakeasy-api/speakeasy/internal/updates"
+    "github.com/speakeasy-api/speakeasy/internal/utils"
 
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"github.com/speakeasy-api/speakeasy/internal/interactivity"
-	"github.com/speakeasy-api/speakeasy/internal/updates"
-	"github.com/speakeasy-api/speakeasy/internal/utils"
-
-	"github.com/speakeasy-api/speakeasy/internal/config"
-	"github.com/speakeasy-api/speakeasy/internal/log"
-	"github.com/spf13/cobra"
-	"go.uber.org/zap"
+    "github.com/speakeasy-api/speakeasy/internal/config"
+    "github.com/speakeasy-api/speakeasy/internal/log"
+    "github.com/spf13/cobra"
+    "go.uber.org/zap"
 )
 
 const rootLong = `# Speakeasy 
@@ -47,149 +45,151 @@ Visit [Speakeasy](https://www.speakeasy.com/) for more information
 `
 
 var rootCmd = &cobra.Command{
-	Use:   "speakeasy",
-	Short: "The Speakeasy CLI tool provides access to the Speakeasy.com platform",
-	Long:  utils.RenderMarkdown(rootLong),
-	RunE:  rootExec,
+    Use:   "speakeasy",
+    Short: "The Speakeasy CLI tool provides access to the Speakeasy.com platform",
+    Long:  utils.RenderMarkdown(rootLong),
+    RunE:  rootExec,
 }
 
 var l = log.New().WithLevel(log.LevelInfo)
 
 func init() {
-	// We want our commands to be sorted in defined order, not alphabetically
-	cobra.EnableCommandSorting = false
-	if err := config.Load(); err != nil {
-		l.Error("", zap.Error(err))
-		os.Exit(1)
-	}
+    // We want our commands to be sorted in defined order, not alphabetically
+    cobra.EnableCommandSorting = false
+    if err := config.Load(); err != nil {
+        l.Error("", zap.Error(err))
+        os.Exit(1)
+    }
 }
 
 func Init(version, artifactArch string) {
-	rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
+    rootCmd.PersistentFlags().String("logLevel", string(log.LevelInfo), fmt.Sprintf("the log level (available options: [%s])", strings.Join(log.Levels, ", ")))
 
-	// TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
-	addCommand(rootCmd, statusCmd)
-	addCommand(rootCmd, quickstartCmd)
-	addCommand(rootCmd, runCmd)
-	addCommand(rootCmd, configureCmd)
-	addCommand(rootCmd, generate.GenerateCmd)
-	addCommand(rootCmd, lintCmd)
-	addCommand(rootCmd, openapiCmd)
-	addCommand(rootCmd, migrateCmd)
+    // TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
+    addCommand(rootCmd, statusCmd)
+    addCommand(rootCmd, quickstartCmd)
+    addCommand(rootCmd, runCmd)
+    addCommand(rootCmd, configureCmd)
+    addCommand(rootCmd, generate.GenerateCmd)
+    addCommand(rootCmd, lintCmd)
+    addCommand(rootCmd, openapiCmd)
+    addCommand(rootCmd, migrateCmd)
 
-	authInit()
-	mergeInit()
-	addCommand(rootCmd, overlayCmd)
-	addCommand(rootCmd, suggestCmd)
-	addCommand(rootCmd, defaultCodeSamplesCmd)
-	updateInit(version, artifactArch)
-	proxyInit()
-	apiInit()
-	languageServerInit(version)
-	bumpInit()
-	addCommand(rootCmd, tagCmd)
-	addCommand(rootCmd, cleanCmd)
+    authInit()
+    mergeInit()
+    addCommand(rootCmd, overlayCmd)
+    addCommand(rootCmd, suggestCmd)
+    addCommand(rootCmd, defaultCodeSamplesCmd)
+    updateInit(version, artifactArch)
+    proxyInit()
+    apiInit()
+    languageServerInit(version)
+    bumpInit()
+    addCommand(rootCmd, tagCmd)
+    addCommand(rootCmd, cleanCmd)
 
-	addCommand(rootCmd, AskCmd)
+    addCommand(rootCmd, AskCmd)
 }
 
 func addCommand(cmd *cobra.Command, command model.Command) {
-	c, err := command.Init()
-	if err != nil {
-		l.Error("", zap.Error(err))
-		os.Exit(1)
-	}
-	cmd.AddCommand(c)
+    c, err := command.Init()
+    if err != nil {
+        l.Error("", zap.Error(err))
+        os.Exit(1)
+    }
+    cmd.AddCommand(c)
 }
 
 func CmdForTest(version, artifactArch string) *cobra.Command {
-	setupRootCmd(version, artifactArch)
+    setupRootCmd(version, artifactArch)
 
-	return rootCmd
+    return rootCmd
 }
 
 func Execute(version, artifactArch string) {
-	setupRootCmd(version, artifactArch)
+    setupRootCmd(version, artifactArch)
 
-	if err := rootCmd.Execute(); err != nil {
-		l.Error("", zap.Error(err))
-		os.Exit(1)
-	}
+    if err := rootCmd.Execute(); err != nil {
+        l.Error("", zap.Error(err))
+        os.Exit(1)
+    }
 }
 
 func setupRootCmd(version, artifactArch string) {
-	rootCmd.Version = version + "\n" + artifactArch
-	rootCmd.SilenceErrors = true
-	rootCmd.SilenceUsage = true
-	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
-		ctx := context.WithValue(cmd.Context(), updates.ArtifactArchContextKey, artifactArch)
-		ctx = events.SetSpeakeasyVersionInContext(ctx, version)
-		cmd.SetContext(ctx)
+    rootCmd.Version = version + "\n" + artifactArch
+    rootCmd.SilenceErrors = true
+    rootCmd.SilenceUsage = true
+    rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+        ctx := context.WithValue(cmd.Context(), updates.ArtifactArchContextKey, artifactArch)
+        ctx = events.SetSpeakeasyVersionInContext(ctx, version)
+        cmd.SetContext(ctx)
 
-		if !slices.Contains([]string{"update", "language-server"}, cmd.Name()) {
-			checkForUpdate(ctx, version, artifactArch)
-		}
+        if !slices.Contains([]string{"update", "language-server"}, cmd.Name()) {
+            checkForUpdate(ctx, version, artifactArch)
+        }
 
-		return setLogLevel(cmd)
-	}
+        return setLogLevel(cmd)
+    }
 
-	Init(version, artifactArch)
+    Init(version, artifactArch)
 }
 
 func GetRootCommand() *cobra.Command {
-	return rootCmd
+    return rootCmd
 }
 
 func checkForUpdate(ctx context.Context, currentVersion, artifactArch string) {
-	// Don't display if piping to a file for example or running locally during development
-	if !utils.IsInteractive() || env.IsLocalDev() {
-		return
-	}
+    // Don't display if piping to a file for example or running locally during development
+    if !utils.IsInteractive() { //TODO || env.IsLocalDev() {
+        return
+    }
 
-	newerVersion, err := updates.GetNewerVersion(ctx, artifactArch, currentVersion)
-	if err != nil {
-		return // Don't display error to user
-	}
+    newerVersion, err := updates.GetNewerVersion(ctx, artifactArch, currentVersion)
+    if err != nil {
+        return // Don't display error to user
+    }
 
-	if newerVersion == nil {
-		return
-	}
+    if newerVersion == nil {
+        return
+    }
 
-	versionString := fmt.Sprintf("A new version of the Speakeasy CLI is available: v%s", newerVersion.String())
-	updateString := "Run `speakeasy update` to update to the latest version"
+    mainStyle := styles.Emphasized.Background(styles.Colors.SpeakeasyPrimary).Foreground(styles.Colors.SpeakeasySecondary)
+    inverseStyle := styles.Emphasized.Background(styles.Colors.SpeakeasySecondary).Foreground(styles.Colors.SpeakeasyPrimary)
 
-	l := log.From(ctx)
-	style := styles.Emphasized.Background(styles.Colors.SpeakeasyPrimary).Foreground(styles.Colors.SpeakeasySecondary).Padding(1, 2)
-	l.PrintfStyled(style, "%s\n%s", versionString, updateString)
-	l.Println("\n")
+    versionString := fmt.Sprintf("A new version of the Speakeasy CLI is available: v%s", newerVersion.String())
+    updateString := fmt.Sprintf("Run %s%s", inverseStyle.Render("speakeasy update"), mainStyle.Render(" to update to the latest version"))
 
-	return
+    l := log.From(ctx)
+    l.PrintfStyled(mainStyle.Padding(1, 2), "%s\n%s", versionString, updateString)
+    l.Println("\n")
+
+    return
 }
 
 func setLogLevel(cmd *cobra.Command) error {
-	logLevel, err := cmd.Flags().GetString("logLevel")
-	if err != nil {
-		return err
-	}
-	if !slices.Contains(log.Levels, logLevel) {
-		return fmt.Errorf("log level must be one of: %s", strings.Join(log.Levels, ", "))
-	}
+    logLevel, err := cmd.Flags().GetString("logLevel")
+    if err != nil {
+        return err
+    }
+    if !slices.Contains(log.Levels, logLevel) {
+        return fmt.Errorf("log level must be one of: %s", strings.Join(log.Levels, ", "))
+    }
 
-	l = l.WithLevel(log.Level(logLevel))
-	ctx := log.With(cmd.Context(), l)
-	cmd.SetContext(ctx)
+    l = l.WithLevel(log.Level(logLevel))
+    ctx := log.With(cmd.Context(), l)
+    cmd.SetContext(ctx)
 
-	return nil
+    return nil
 }
 
 func rootExec(cmd *cobra.Command, args []string) error {
-	if !utils.IsInteractive() {
-		return cmd.Help()
-	}
+    if !utils.IsInteractive() {
+        return cmd.Help()
+    }
 
-	l := log.From(cmd.Context()).WithInteractiveOnly()
-	l.PrintfStyled(styles.HeavilyEmphasized, "Welcome to the Speakeasy CLI!\n")
-	l.PrintfStyled(styles.DimmedItalic, "This is interactive mode. For usage, run speakeasy -h instead.\n")
+    l := log.From(cmd.Context()).WithInteractiveOnly()
+    l.PrintfStyled(styles.HeavilyEmphasized, "Welcome to the Speakeasy CLI!\n")
+    l.PrintfStyled(styles.DimmedItalic, "This is interactive mode. For usage, run speakeasy -h instead.\n")
 
-	return interactivity.InteractiveExec(cmd, args, "Select a command to run")
+    return interactivity.InteractiveExec(cmd, args, "Select a command to run")
 }


### PR DESCRIPTION
Also re-enables showing the update message to speakeasy devs. This has been hidden for a while which means we missed the styling issue for a while

![CleanShot 2024-09-19 at 08 27 36@2x](https://github.com/user-attachments/assets/37b57a7f-fdb2-4d5f-9638-37b6e5f1f576)
![CleanShot 2024-09-19 at 08 27 05@2x](https://github.com/user-attachments/assets/f3f3ea4e-0b46-4539-9e77-57eb675d21b7)
