### PR TITLE
fix: TUI tab border styles

### DIFF
--- a/internal/interactivity/tabs.go
+++ b/internal/interactivity/tabs.go
@@ -91,8 +91,16 @@ func tabBorderWithBottom(left, middle, right string) lipgloss.Border {
 	return border
 }
 
+func inactiveTabBorderWithBottom(left, middle, right string) lipgloss.Border {
+	border := lipgloss.HiddenBorder()
+	border.BottomLeft = left
+	border.Bottom = middle
+	border.BottomRight = right
+	return border
+}
+
 var (
-	inactiveTabBorder = tabBorderWithBottom("┴", "─", "┴")
+	inactiveTabBorder = inactiveTabBorderWithBottom("─", "─", "─")
 	activeTabBorder   = tabBorderWithBottom("┘", " ", "└")
 	highlightColor    = lipgloss.AdaptiveColor{Light: "#874BFD", Dark: "#7D56F4"}
 	inactiveTabStyle  = lipgloss.NewStyle().Border(inactiveTabBorder, true).BorderForeground(highlightColor).Padding(0, 1)
@@ -124,7 +132,7 @@ func (m *tabsModel) View() string {
 		if isFirst && isActive {
 			border.BottomLeft = "│"
 		} else if isFirst && !isActive {
-			border.BottomLeft = "├"
+			border.BottomLeft = "╭"
 		}
 
 		style = style.Border(border)


### PR DESCRIPTION
The interactive tabs in the terminal currently try to use unicode box drawings to render active/inactive rounded tabs. Unfortunately for the inactive tabs, the active color spills into the active tab styles (see screenshots). I don't think that it is possible to fix this issue with the current styles with our glyph borders, so I think personally it's nicer if we render a hidden border for the inactive tabs

Before:

![CleanShot 2024-09-20 at 14 25 44@2x](https://github.com/user-attachments/assets/b150ebff-3de8-4fc6-829c-cb5a2d99d004)

After:

![CleanShot 2024-09-20 at 14 25 12@2x](https://github.com/user-attachments/assets/5d855bf2-6414-45ff-80ce-9f8cae012597)
