### PR TITLE
fix: override rulesets used for watch mode / studio

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -305,6 +305,7 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
+		run.WithRulesetOverride(flags.Watch),
 		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 
@@ -312,14 +313,6 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		ctx,
 		opts...,
 	)
-
-	// If we are in --watch mode (e.g explicitly running the studio), we want to
-	// run the recommended ruleset that also includes additional rules such as
-	// missing-examples, which are not enabled by default in the generation only
-	// ruleset.
-	if flags.Watch {
-		workflow.RulesetOverride = "speakeasy-recommended"
-	}
 
 	defer func() {
 		workflow.Cleanup()
@@ -366,6 +359,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
+		run.WithRulesetOverride(flags.Watch),
 		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -313,9 +313,10 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		opts...,
 	)
 
-	// If we are in --watch mode (e.g the studio), we want to run the recommended
-	// ruleset that also includes additional rules such as missing-examples, which
-	// are not enabled by default in the generation only ruleset.
+	// If we are in --watch mode (e.g explicitly running the studio), we want to
+	// run the recommended ruleset that also includes additional rules such as
+	// missing-examples, which are not enabled by default in the generation only
+	// ruleset.
 	if flags.Watch {
 		workflow.RulesetOverride = "speakeasy-recommended"
 	}
@@ -387,7 +388,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 
 	switch flags.Output {
 	case "summary":
-		err = workflow.RunWithVisualization(ctx, flags.Debug)
+		err = workflow.RunWithVisualization(ctx)
 	case "mermaid":
 		err = workflow.Run(ctx)
 		workflow.RootStep.Finalize(err == nil)
@@ -416,7 +417,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 }
 
 func maybeLaunchStudio(ctx context.Context, wf *run.Workflow, flags RunFlags) (error, bool) {
-	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf, flags.Debug)
+	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf)
 	if canLaunch && flags.Watch {
 		return studio.LaunchStudio(ctx, wf), true
 	} else if numDiagnostics > 1 {

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -83,6 +83,9 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 	if source.Ruleset != nil {
 		rulesetToUse = *source.Ruleset
 	}
+	if w.RulesetOverride != "" {
+		rulesetToUse = w.RulesetOverride
+	}
 
 	logger := log.From(ctx)
 	logger.Infof("Running Source %s...", sourceID)

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -34,6 +34,7 @@ type Workflow struct {
 	RepoSubDirs            map[string]string
 	InstallationURLs       map[string]string
 	RegistryTags           []string
+	RulesetOverride        string
 
 	// Internal
 	workflowName       string

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -34,7 +34,11 @@ type Workflow struct {
 	RepoSubDirs            map[string]string
 	InstallationURLs       map[string]string
 	RegistryTags           []string
-	RulesetOverride        string
+
+	// RulesetOverride is used to override the rulesets used for validating
+	// Will take precedence over the ruleset set in the workflow file for the
+	// source being run.
+	RulesetOverride string
 
 	// Internal
 	workflowName       string

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -141,6 +141,18 @@ func WithFrozenWorkflowLock(frozen bool) Opt {
 	}
 }
 
+// If we are in --watch mode (e.g explicitly running the studio), we want to
+// run the recommended ruleset that also includes additional rules such as
+// missing-examples, which are not enabled by default in the generation only
+// ruleset.
+func WithRulesetOverride(watchMode bool) Opt {
+	return func(w *Workflow) {
+		if watchMode {
+			w.RulesetOverride = "speakeasy-recommended"
+		}
+	}
+}
+
 func WithSkipVersioning(skipVersioning bool) Opt {
 	return func(w *Workflow) {
 		w.SkipVersioning = skipVersioning


### PR DESCRIPTION
We'd like to use the `speakeasy-recommended` ruleset for the studio only. This ruleset includes additional lint rules such as `missing-examples` that we'd like to display in the studio.