### PR TITLE
chore(deps): Remove extraneous golang.org/x/exp dependency

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -7,11 +7,11 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy/cmd"
 	"github.com/speakeasy-api/speakeasy/internal/docs"
-	"golang.org/x/exp/slices"
 )
 
 var linkRegex = regexp.MustCompile(`\((.*?\.md)\)`)

--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -3,6 +3,7 @@ package generate
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
@@ -11,8 +12,6 @@ import (
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
-
-	"golang.org/x/exp/slices"
 
 	markdown "github.com/MichaelMure/go-term-markdown"
 	changelog "github.com/speakeasy-api/openapi-generation/v2"

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -3,19 +3,19 @@ package lint
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/arazzo"
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"github.com/speakeasy-api/speakeasy/internal/sdkgen"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"golang.org/x/exp/maps"
-
-	"github.com/speakeasy-api/speakeasy/internal/log"
-	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/validation"
 )
 
@@ -181,7 +181,7 @@ func lintConfig(ctx context.Context, flags lintConfigFlags) error {
 		return err
 	}
 
-	langs := strings.Join(maps.Keys(targetToConfig), ", ")
+	langs := strings.Join(slices.Collect(maps.Keys(targetToConfig)), ", ")
 
 	msg := styles.RenderSuccessMessage(
 		"SDK generation configuration is valid ✓",

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -5,13 +5,14 @@ import (
 	_ "embed"
 	"fmt"
 	"io"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy-core/events"
 	"github.com/speakeasy-api/speakeasy/internal/env"
-	"golang.org/x/exp/maps"
 
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/config"
@@ -421,7 +422,7 @@ func handleMVSChanges(ctx context.Context, wf *workflow.Workflow, outDir string)
 		return
 	}
 
-	source := maps.Values(wf.Sources)[0]
+	source := slices.Collect(maps.Values(wf.Sources))[0]
 
 	anyRemoved := false
 

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -3,16 +3,17 @@ package cmd
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/sdk-gen-config/workflow"
-	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"golang.org/x/exp/maps"
+	"maps"
+	"slices"
 	"strings"
 
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	core "github.com/speakeasy-api/speakeasy-core/auth"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"github.com/speakeasy-api/speakeasy/registry"
 )
 
@@ -129,7 +130,7 @@ func getRevisions(ctx context.Context, sources, targets []string, wf *workflow.W
 	// Dedup revisions
 	revisions := make(map[string]revision)
 
-	opts := strings.Join(maps.Keys(wf.Sources), ", ")
+	opts := strings.Join(slices.Collect(maps.Keys(wf.Sources)), ", ")
 	for _, source := range sources {
 		if _, ok := wf.Sources[source]; !ok {
 			return nil, fmt.Errorf("source %s not found in workflow.yaml. Options: %s", source, opts)
@@ -144,7 +145,7 @@ func getRevisions(ctx context.Context, sources, targets []string, wf *workflow.W
 		addRevision(ctx, revisions, source, namespace, revisionDigest)
 	}
 
-	opts = strings.Join(maps.Keys(wf.Targets), ", ")
+	opts = strings.Join(slices.Collect(maps.Keys(wf.Targets)), ", ")
 	for _, target := range targets {
 		if _, ok := wf.Targets[target]; !ok {
 			return nil, fmt.Errorf("target %s not found in workflow.yaml. Options: %s", target, opts)
@@ -159,7 +160,7 @@ func getRevisions(ctx context.Context, sources, targets []string, wf *workflow.W
 		addRevision(ctx, revisions, target, namespace, revisionDigest)
 	}
 
-	return maps.Values(revisions), nil
+	return slices.Collect(maps.Values(revisions)), nil
 }
 
 func addRevision(ctx context.Context, revisions map[string]revision, owner, namespace, revisionDigest string) {

--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/spf13/viper v1.19.0
 	github.com/stretchr/testify v1.9.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948
+	golang.org/x/exp v0.0.0-20240823005443-9b4947da3948 // indirect
 	golang.org/x/term v0.25.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -3,13 +3,13 @@ package config
 import (
 	"context"
 	"fmt"
-	core "github.com/speakeasy-api/speakeasy-core/auth"
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"golang.org/x/exp/maps"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
 
+	core "github.com/speakeasy-api/speakeasy-core/auth"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/spf13/viper"
 )
 
@@ -88,7 +88,7 @@ func SetWorkspaceAPIKey(orgSlug, workspaceSlug, key string) error {
 }
 
 func GetAuthenticatedWorkspaces() []string {
-	return maps.Keys(vCfg.GetStringMapString(workspaceKeysKey))
+	return slices.Collect(maps.Keys(vCfg.GetStringMapString(workspaceKeysKey)))
 }
 
 func getWorkspaceKey(orgSlug, workspaceSlug string) string {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"github.com/spf13/cobra"
-	"golang.org/x/exp/slices"
 )
 
 var docSiteRoot = "/docs/speakeasy-cli"

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -3,20 +3,20 @@ package github
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/changes"
-	"github.com/speakeasy-api/versioning-reports/versioning"
 	"os"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
 	"github.com/sethvargo/go-githubactions"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
+	"github.com/speakeasy-api/speakeasy/internal/changes"
 	"github.com/speakeasy-api/speakeasy/internal/env"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/markdown"
+	"github.com/speakeasy-api/versioning-reports/versioning"
 	"go.uber.org/zap"
-	"golang.org/x/exp/slices"
 )
 
 type LintingSummary struct {

--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -2,6 +2,7 @@ package interactivity
 
 import (
 	"fmt"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy/internal/charm"
@@ -10,7 +11,6 @@ import (
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"golang.org/x/exp/slices"
 )
 
 func InteractiveExec(cmd *cobra.Command, args []string, label string) error {

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -3,8 +3,10 @@ package migrate
 import (
 	"context"
 	"fmt"
+	"maps"
 	"os"
 	"regexp"
+	"slices"
 	"strings"
 
 	config "github.com/speakeasy-api/sdk-gen-config"
@@ -13,8 +15,6 @@ import (
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"golang.org/x/exp/maps"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 
@@ -225,7 +225,7 @@ func buildGenerationWorkflowFiles(genWorkflow string) (*workflow.Workflow, *conf
 
 	targets := map[string]workflow.Target{}
 	for lang, output := range langToOutput {
-		name := promptForTargetName(lang, maps.Keys(targets))
+		name := promptForTargetName(lang, slices.Collect(maps.Keys(targets)))
 
 		targets[name] = workflow.Target{
 			Source:     defaultSourceName,

--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -6,23 +6,22 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"maps"
 	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"slices"
 	"syscall"
 	"time"
 
-	"github.com/speakeasy-api/speakeasy/internal/env"
-	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"golang.org/x/exp/maps"
-
 	"github.com/speakeasy-api/speakeasy-core/auth"
-
 	"github.com/speakeasy-api/speakeasy-core/errors"
 	"github.com/speakeasy-api/speakeasy/internal/config"
+	"github.com/speakeasy-api/speakeasy/internal/env"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/internal/run"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"go.uber.org/zap"
 )
 
@@ -33,7 +32,7 @@ func CanLaunch(ctx context.Context, wf *run.Workflow) bool {
 		return false
 	}
 
-	sourceResult := maps.Values(wf.SourceResults)[0]
+	sourceResult := slices.Collect(maps.Values(wf.SourceResults))[0]
 
 	if !utils.IsInteractive() || env.IsGithubAction() {
 		return false

--- a/internal/transform/filterOperations.go
+++ b/internal/transform/filterOperations.go
@@ -4,16 +4,16 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
-	"github.com/speakeasy-api/speakeasy-core/openapi"
-	"github.com/speakeasy-api/speakeasy-core/suggestions"
-	"golang.org/x/exp/maps"
-	"gopkg.in/yaml.v3"
 	"io"
+	"maps"
 	"slices"
 
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/speakeasy-api/openapi-overlay/pkg/overlay"
+	"github.com/speakeasy-api/speakeasy-core/openapi"
+	"github.com/speakeasy-api/speakeasy-core/suggestions"
+	"gopkg.in/yaml.v3"
 )
 
 func FilterOperations(ctx context.Context, schemaPath string, includeOps []string, include bool, yamlOut bool, w io.Writer) error {
@@ -87,7 +87,7 @@ func filterOperations(ctx context.Context, doc libopenapi.Document, model *libop
 }
 
 func BuildRemoveInvalidOperationsOverlay(model *libopenapi.DocumentModel[v3.Document], opToErr map[string]error) overlay.Overlay {
-	return BuildFilterOperationsOverlay(model, false, maps.Keys(opToErr), opToErr)
+	return BuildFilterOperationsOverlay(model, false, slices.Collect(maps.Keys(opToErr)), opToErr)
 }
 
 func BuildFilterOperationsOverlay(model *libopenapi.DocumentModel[v3.Document], include bool, ops []string, opToErr map[string]error) overlay.Overlay {


### PR DESCRIPTION
The `maps.Keys` and `slices.Contains` functionality has moved into the Go standard library.