### PR TITLE
fix: readme logos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@
   ![ezgif com-video-to-gif (1)](https://github.com/speakeasy-api/speakeasy/assets/90289500/ff6972c4-4e8a-4a5c-a976-75e97cc42f5a)
 </div>
 <br />
-
+<br />
 ## What is Speakeasy?
 
 [Speakeasy](https://www.speakeasy.com/) gives your users the developer experience that makes API integrations easy.

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
   <picture>
     <img src="https://github.com/speakeasy-api/speakeasy/assets/68016351/159f0565-0cfa-468a-8fcd-7c3590eea355">
   </picture>
+  <br />
 
   ![ezgif com-video-to-gif (1)](https://github.com/speakeasy-api/speakeasy/assets/90289500/ff6972c4-4e8a-4a5c-a976-75e97cc42f5a)
 </div>

--- a/README.md
+++ b/README.md
@@ -17,10 +17,10 @@
     <img src="https://github.com/speakeasy-api/speakeasy/assets/68016351/159f0565-0cfa-468a-8fcd-7c3590eea355">
   </picture>
   <br />
+  <br />
 
   ![ezgif com-video-to-gif (1)](https://github.com/speakeasy-api/speakeasy/assets/90289500/ff6972c4-4e8a-4a5c-a976-75e97cc42f5a)
 </div>
-<br />
 <br />
 ## What is Speakeasy?
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,9 @@
    <a href="https://speakeasy.com/docs/create-client-sdks/"><img src="https://img.shields.io/static/v1?label=Docs&message=Quickstart&color=000&style=for-the-badge" /></a>
    <a href="https://join.slack.com/t/speakeasy-dev/shared_invite/zt-1cwb3flxz-lS5SyZxAsF_3NOq5xc8Cjw"><img src="https://img.shields.io/static/v1?label=Slack&message=Join&color=7289da&style=for-the-badge" /></a>
 
-  ![Group 26](https://github.com/speakeasy-api/speakeasy/assets/68016351/159f0565-0cfa-468a-8fcd-7c3590eea355)
+  <picture>
+    <img src="https://github.com/speakeasy-api/speakeasy/assets/68016351/159f0565-0cfa-468a-8fcd-7c3590eea355">
+  </picture>
 
   ![ezgif com-video-to-gif (1)](https://github.com/speakeasy-api/speakeasy/assets/90289500/ff6972c4-4e8a-4a5c-a976-75e97cc42f5a)
 </div>

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@
   ![ezgif com-video-to-gif (1)](https://github.com/speakeasy-api/speakeasy/assets/90289500/ff6972c4-4e8a-4a5c-a976-75e97cc42f5a)
 </div>
 <br />
+
 ## What is Speakeasy?
 
 [Speakeasy](https://www.speakeasy.com/) gives your users the developer experience that makes API integrations easy.


### PR DESCRIPTION
Stops GitHub from autolinking the target logos which doesn't go anywhere anyway :) 