### PR TITLE
chore: Ignore additional private repos in Dependabot for now

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,10 @@ updates:
           - minor
           - patch
     ignore:
+      # Ignore private repositories for now. Consider private git "registries"
+      # configuration if we do want to automate these.
+      - dependency-name: "github.com/speakeasy-api/jsonpath"
+      - dependency-name: "github.com/speakeasy-api/speakeasy-core"
       # Updated via ./scripts/upgrade.bash
       - dependency-name: "github.com/speakeasy-api/openapi-generation/v2"
     schedule:


### PR DESCRIPTION
Reference: https://docs.github.com/en/free-pro-team@latest/github/setting-up-and-managing-organizations-and-teams/managing-security-and-analysis-settings-for-your-organization#allowing-dependabot-to-access-private-repositories

We can add this instead if we do want to automate them (or if these ignores don't do the trick):

```yaml
registries:
  github-private:
    type: git
    url: https://github.com
    username: x-access-token
    password: ${{secrets.BOT_REPO_TOKEN}}
# ...
updates:
# ...
  - package-ecosystem: gomod
    registries:
       - github-private
```