### PR TITLE
chore(deps): Additional Dependabot configuration for private repository access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,10 @@
 version: 2
+registries:
+  github-private:
+    type: git
+    url: https://github.com
+    username: x-access-token
+    password: ${{secrets.BOT_REPO_TOKEN}}
 updates:
   - package-ecosystem: github-actions
     directory: "/"
@@ -19,15 +25,16 @@ updates:
       gomod-minor-and-patch:
         applies-to: version-updates
         dependency-type: production
+        exclude-patterns:
+          # Does not necessarily follow semver, raise individual PR for ease
+          - "github.com/speakeasy-api/speakeasy-core"
         update-types:
           - minor
           - patch
     ignore:
-      # Ignore private repositories for now. Consider private git "registries"
-      # configuration if we do want to automate these.
-      - dependency-name: "github.com/speakeasy-api/jsonpath"
-      - dependency-name: "github.com/speakeasy-api/speakeasy-core"
       # Updated via ./scripts/upgrade.bash
       - dependency-name: "github.com/speakeasy-api/openapi-generation/v2"
+    registries:
+       - github-private
     schedule:
       interval: weekly


### PR DESCRIPTION
Reference: https://github.com/speakeasy-api/speakeasy/network/updates/891626743

Even with ignored dependencies, transitive private dependencies can cause access issues for Dependabot. This additional configuration runs the Go module updates with a token that has private repository access and is already shared as an organization-wide Dependabot secret.