### PR TITLE
fix: Prevent invalid cross-device link update errors on Linux

### DIFF
--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -5,17 +5,19 @@ import (
 	"archive/zip"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/cache"
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"github.com/speakeasy-api/speakeasy/internal/env"
-	"github.com/speakeasy-api/speakeasy/internal/log"
 	"io"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/speakeasy-api/speakeasy/internal/cache"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/env"
+	"github.com/speakeasy-api/speakeasy/internal/log"
 
 	"github.com/google/go-github/v58/github"
 	"github.com/hashicorp/go-version"
@@ -191,8 +193,73 @@ func install(artifactArch, downloadURL, installLocation string, timeout int) err
 		return err
 	}
 
-	if err := os.Rename(filepath.Join(tmpLocation, binaryName), installLocation); err != nil {
-		return fmt.Errorf("failed to replace binary: %w", err)
+	tmpBinaryLocation := filepath.Join(tmpLocation, binaryName)
+
+	if err := os.Rename(tmpBinaryLocation, installLocation); err != nil {
+		// os.Rename can have issues on Linux when the temporary and install
+		// directories are on separate filesystem mounts. In this case, try to
+		// catch the "invalid cross-device link" error and fallback to manual
+		// file copy and removal.
+		// Reference: https://github.com/golang/go/issues/41487
+		var linkErr *os.LinkError
+
+		if !errors.As(err, &linkErr) || !strings.Contains(linkErr.Err.Error(), "invalid cross-device link") {
+			return fmt.Errorf("failed to replace binary: %w", err)
+		}
+
+		tmpBinaryFile, err := os.Open(tmpBinaryLocation)
+
+		if err != nil {
+			return fmt.Errorf("failed to replace binary: unable to open source file: %w", err)
+		}
+
+		defer tmpBinaryFile.Close()
+
+		// To prevent ETXTBSY errors, write the new executable in the original
+		// location with a .new suffix, rename the running executable as .old,
+		// rename the new executable to the original location (now on same
+		// mount), and remove the old executable.
+		installLocationOld := installLocation + ".old"
+		installLocationNew := installLocation + ".new"
+
+		installFileNew, err := os.Create(installLocationNew)
+
+		if err != nil {
+			return fmt.Errorf("failed to replace binary: unable to create destination file: %w", err)
+		}
+
+		if _, err := io.Copy(installFileNew, tmpBinaryFile); err != nil {
+			_ = installFileNew.Close()
+
+			return fmt.Errorf("failed to replace binary: unable to copy file: %w", err)
+		}
+
+		_ = installFileNew.Close()
+
+		if err := os.Rename(installLocation, installLocationOld); err != nil {
+			_ = os.Remove(installLocationNew)
+
+			return fmt.Errorf("failed to replace binary: unable to rename running executable: %w", err)
+		}
+
+		if err := os.Rename(installLocationNew, installLocation); err != nil {
+			_ = os.Remove(installLocationNew)
+
+			// Ensure original executable path remains valid.
+			_ = os.Rename(installLocationOld, installLocation)
+
+			return fmt.Errorf("failed to replace binary: unable to rename new executable: %w", err)
+		}
+
+		if err := os.Remove(installLocationOld); err != nil {
+			return fmt.Errorf("failed to replace binary: unable to remove old running executable: %w", err)
+		}
+
+		// TODO: Determine if this should be called after os.MkdirTemp instead:
+		//    defer os.RemoveAll(dirName)
+		if err := os.Remove(tmpBinaryLocation); err != nil {
+			return fmt.Errorf("failed to replace binary: unable to remove source file: %w", err)
+		}
 	}
 
 	// Ensure the install is executable


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/SPE-4208/bug-cli-update-fails-on-linux-with-differing-filesystems-for-tmp-and
Reference: https://github.com/golang/go/issues/41487

When the CLI is running on Linux, the Linux system has different mounts for home and temporary directories, and the `update` command is called (or the same functionality automatically invoked with other commands), then the CLI can return an `invalid cross-device link` error without updating the executable when using the Go standard library `os.Rename()` function. This change introduces fallback logic to catch that error and manually overwrite the executable while accounting for `ETXTBSY` errors on the running executable.

Reproduction (macOS host):

```console
$ docker run -i -t --privileged --rm ubuntu:24.04
```

Reproduction (Docker container, manual install to not need `sudo`):

```console
$ apt-get update && apt-get install -y wget unzip
$ cd /tmp
$ wget https://github.com/speakeasy-api/speakeasy/releases/download/v1.404.4/speakeasy_linux_arm64.zip
$ unzip speakeasy_linux_arm64.zip
$ chmod a+x speakeasy
$ cp speakeasy /usr/bin/speakeasy
$ echo "none    /mnt/ramfs    ramfs    noauto,user,size=1024M,mode=1777    0    0" >> /etc/fstab
$ mkdir /mnt/ramfs
$ mount /mnt/ramfs
$ export TMPDIR=/mnt/ramfs
$ speakeasy update
failed to replace binary: rename /mnt/ramfs/speakeasy1609184771/extracted/speakeasy /usr/bin/speakeasy: invalid cross-device link
```

Verification (macOS host, these changes):

```console
$ GOOS=linux go build .
$ docker run -i -t --privileged --rm -v /Users/bflad/src/github.com/speakeasy-api/speakeasy/speakeasy:/tmp/speakeasy ubuntu:24.04
```

Verification (Docker container):

```console
$ cp /tmp/speakeasy /usr/bin/speakeasy
$ speakeasy --version
speakeasy version 0.0.1
linux_amd64
$ apt-get update && apt-get install -y ca-certificates
$ echo "none    /mnt/ramfs    ramfs    noauto,user,size=1024M,mode=1777    0    0" >> /etc/fstab
$ mkdir /mnt/ramfs
$ mount /mnt/ramfs
$ export TMPDIR=/mnt/ramfs
$ speakeasy update
Updated to version v1.404.5
$ speakeasy --version
speakeasy version 1.404.5
linux_amd64
```