### PR TITLE
fix: dont sort cmd flags automatically in interactive prompts

### DIFF
--- a/internal/interactivity/interactiveexec.go
+++ b/internal/interactivity/interactiveexec.go
@@ -109,6 +109,8 @@ func RequestFlagValues(commandName string, flags *pflag.FlagSet) ([]*pflag.Flag,
 	var missingRequiredFlags []*pflag.Flag
 	var missingOptionalFlags []*pflag.Flag
 
+	flags.SortFlags = false
+
 	requestValue := func(flag *pflag.Flag) {
 		// If the flag already has a Value, skip it
 		if flag.Changed || flag.Hidden || slices.Contains(utils.FlagsToIgnore, flag.Name) {


### PR DESCRIPTION
Currently the pflag package automatically sorts flags, which results in the interactive prompts displaying flags alphabetically rather than in the order they were defined in code.

This is particularly annoying for the `speakeasy overlay` command, where `before` and `after` are switched around:

![CleanShot 2024-09-30 at 12 38 52@2x](https://github.com/user-attachments/assets/014b3409-e3bb-46ef-b713-a61fc264f588)

I think this change is probably acceptable across the board, as one can assume that flags are already ordered in a logical manner in the code itself. If anyone can think of a case where the default alphabetical sort is important, then let me know.