### PR TITLE
fix: allow studio to be launched without diagnostics

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -373,12 +373,16 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 }
 
 func shouldLaunchStudio(ctx context.Context, wf *run.Workflow, fromQuickstart bool) bool {
-	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf)
-	if !canLaunch {
+	if !studio.CanLaunch(ctx, wf) {
 		return false
 	}
 
 	offerDeclineOption := !fromQuickstart && config.SeenStudio()
+
+	numDiagnostics := wf.CountDiagnostics()
+	if numDiagnostics == 0 {
+		return false
+	}
 
 	if offerDeclineOption {
 		message := fmt.Sprintf("We've detected %d potential improvements for your SDK. Would you like to launch the studio?", numDiagnostics)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -411,12 +411,11 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 }
 
 func maybeLaunchStudio(ctx context.Context, wf *run.Workflow, flags RunFlags) (error, bool) {
-	canLaunch, numDiagnostics := studio.CanLaunch(ctx, wf)
-	if canLaunch && flags.Watch {
+	if studio.CanLaunch(ctx, wf) && flags.Watch {
 		return studio.LaunchStudio(ctx, wf), true
-	} else if numDiagnostics > 1 {
-		log.From(ctx).PrintfStyled(styles.Info, "\nWe've detected `%d` potential improvements for your SDK.\nGet automatic fixes in the Studio with `speakeasy run --watch`", numDiagnostics)
-	} else if numDiagnostics == 1 {
+	} else if wf.CountDiagnostics() > 1 {
+		log.From(ctx).PrintfStyled(styles.Info, "\nWe've detected `%d` potential improvements for your SDK.\nGet automatic fixes in the Studio with `speakeasy run --watch`", wf.CountDiagnostics())
+	} else if wf.CountDiagnostics() == 1 {
 		log.From(ctx).PrintfStyled(styles.Info, "\nWe've detected `1` potential improvement for your SDK.\nGet automatic fixes in the Studio with `speakeasy run --watch`")
 	}
 

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -261,6 +261,16 @@ func WithRegistryTags(registryTags []string) Opt {
 	}
 }
 
+func (w *Workflow) CountDiagnostics() int {
+	count := 0
+	for _, sourceResult := range w.SourceResults {
+		for _, d := range sourceResult.Diagnosis {
+			count += len(d)
+		}
+	}
+	return count
+}
+
 func (w *Workflow) Clone(ctx context.Context, opts ...Opt) (*Workflow, error) {
 	return NewWorkflow(
 		ctx,

--- a/internal/studio/launchStudio.go
+++ b/internal/studio/launchStudio.go
@@ -13,8 +13,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/samber/lo"
-	"github.com/speakeasy-api/speakeasy-core/suggestions"
 	"github.com/speakeasy-api/speakeasy/internal/env"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"golang.org/x/exp/maps"
@@ -30,29 +28,24 @@ import (
 )
 
 // CanLaunch returns true if the studio can be launched, and the number of diagnostics
-func CanLaunch(ctx context.Context, wf *run.Workflow) (bool, int) {
+func CanLaunch(ctx context.Context, wf *run.Workflow) bool {
 	if len(wf.SourceResults) != 1 {
 		// Only one source at a time is supported in the studio at the moment
-		return false, 0
+		return false
 	}
 
 	sourceResult := maps.Values(wf.SourceResults)[0]
 
 	if !utils.IsInteractive() || env.IsGithubAction() {
-		return false, 0
+		return false
 	}
 
 	if sourceResult.LintResult == nil {
 		// No lint result indicates the spec wasn't even loaded successfully, the studio can't help with that
-		return false, 0
+		return false
 	}
 
-	// TODO: include more relevant diagnostics as we go!
-	numDiagnostics := lo.SumBy(maps.Values(sourceResult.Diagnosis), func(x []suggestions.Diagnostic) int {
-		return len(x)
-	})
-
-	return numDiagnostics > 0, numDiagnostics
+	return true
 }
 
 func LaunchStudio(ctx context.Context, workflow *run.Workflow) error {


### PR DESCRIPTION
Removes the numdiagnostics check from "canLaunch". This is really a _should_ launch concept

The effect of this is that `--watch` will open the studio even if there are no diagnostics, when before it would just do nothing