### PR TITLE
fix: add ruleset override to rerun

### DIFF
--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -132,6 +132,7 @@ func (h *StudioHandlers) reRun(ctx context.Context, w http.ResponseWriter, r *ht
 		run.WithSkipGenerateLintReport(),
 		run.WithSkipSnapshot(true),
 		run.WithSkipChangeReport(true),
+		run.WithRulesetOverride(true),
 	)
 	if err != nil {
 		return fmt.Errorf("error cloning workflow runner: %w", err)


### PR DESCRIPTION
The missing-examples diagnostic would disappear if a regeneration is triggered (via reRun). This is because for subsequent re-runs we haven't been using the ruleset override mechanism I added, which means that the default ruleset that explicitly excludes `missing-examples` was being used.