### PR TITLE
feat: base quickstart on remote existing target

### DIFF
--- a/internal/charm/utils.go
+++ b/internal/charm/utils.go
@@ -15,11 +15,12 @@ const AutoCompleteAnnotation = "autocomplete_extensions"
 
 var OpenAPIFileExtensions = []string{".yaml", ".yml", ".json"}
 
-func NewBranchPrompt(title string, output *bool) *huh.Group {
+func NewBranchPrompt(title, description string, output *bool) *huh.Group {
 	return huh.NewGroup(huh.NewConfirm().
 		Title(title).
 		Affirmative("Yes.").
 		Negative("No.").
+		Description(description).
 		Value(output))
 }
 

--- a/internal/interactivity/simpleConfirm.go
+++ b/internal/interactivity/simpleConfirm.go
@@ -9,7 +9,7 @@ func SimpleConfirm(message string, defaultValue bool) bool {
 	confirm := defaultValue
 
 	if _, err := charm_internal.NewForm(
-		huh.NewForm(charm_internal.NewBranchPrompt(message, &confirm)),
+		huh.NewForm(charm_internal.NewBranchPrompt(message, "", &confirm)),
 	).
 		ExecuteForm(); err != nil {
 		return false

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -3,6 +3,7 @@ package remote
 import (
 	"context"
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/samber/lo"
@@ -68,6 +69,11 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 	seenUniqueNamespaces := make(map[string]bool)
 
 	var generations []RecentGeneration
+
+	// sort by most recent
+	sort.Slice(res.TargetSDKList, func(i, j int) bool {
+		return res.TargetSDKList[i].LastEventCreatedAt.After(res.TargetSDKList[j].LastEventCreatedAt)
+	})
 
 	for _, target := range res.TargetSDKList {
 		// Filter out cli events that aren't generation based, or lack the required

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -36,7 +36,7 @@ type RecentGeneration struct {
 const (
 	// The event stream contains multiple events for the same namespace, so we want to
 	// break execution once we've seen a minimum, arbitrary number of unique namespaces.
-	minimumRecentGenerationsToShow int = 5
+	recentGenerationsToShow int = 5
 )
 
 // GetRecentWorkspaceGenerations returns the most recent generations of targets in a workspace
@@ -96,7 +96,7 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 			Success:              event.Success,
 		})
 
-		if len(seenUniqueNamespaces) >= minimumRecentGenerationsToShow {
+		if len(seenUniqueNamespaces) >= recentGenerationsToShow {
 			break
 		}
 	}

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -26,8 +26,8 @@ type RecentGeneration struct {
 	Published            bool
 
 	// May not be set
-	GitRepoOrg string
-	GitRepo    string
+	GitRepoOrg *string
+	GitRepo    *string
 
 	// gen.yaml
 	GenerateConfig *string
@@ -88,8 +88,8 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 			CreatedAt:            event.CreatedAt,
 			TargetName:           *event.GenerateTargetName,
 			Target:               *event.GenerateTarget,
-			GitRepoOrg:           *event.GitRemoteDefaultOwner,
-			GitRepo:              *event.GitRemoteDefaultRepo,
+			GitRepoOrg:           event.GitRemoteDefaultOwner,
+			GitRepo:              event.GitRemoteDefaultRepo,
 			SourceNamespace:      *event.SourceNamespaceName,
 			SourceRevisionDigest: *event.SourceRevisionDigest,
 			GenerateConfig:       event.GenerateConfigPreRaw,

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -29,7 +29,7 @@ type RecentGeneration struct {
 	GitRepoOrg string
 	GitRepo    string
 
-	// gen.yaml - uses GenerateConfigPostRaw (e.g state of the config post-last-generation)
+	// gen.yaml
 	GenerateConfig *string
 }
 
@@ -92,7 +92,7 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 			GitRepo:              *event.GitRemoteDefaultRepo,
 			SourceNamespace:      *event.SourceNamespaceName,
 			SourceRevisionDigest: *event.SourceRevisionDigest,
-			GenerateConfig:       event.GenerateConfigPostRaw,
+			GenerateConfig:       event.GenerateConfigPreRaw,
 			Success:              event.Success,
 		})
 

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -1,0 +1,87 @@
+package remote
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	core "github.com/speakeasy-api/speakeasy-core/auth"
+
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/operations"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+	"github.com/speakeasy-api/speakeasy/internal/sdk"
+)
+
+// FindRecentRemoteSources returns a list of recent remote sources
+// based on events in the workspace.
+func FindRecentRemoteNamespaces(ctx context.Context, limit int) ([]shared.Namespace, error) {
+	speakeasyClient, err := sdk.InitSDK()
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := speakeasyClient.Artifacts.GetNamespaces(ctx)
+
+	if err != nil {
+		return nil, err
+	}
+
+	items := res.GetNamespacesResponse.Items
+
+	sort.Slice(items, func(i, j int) bool {
+		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	})
+
+	var namespaces []shared.Namespace
+
+	for i, item := range items {
+		if i >= limit {
+			break
+		}
+		namespaces = append(namespaces, item)
+	}
+
+	return namespaces, nil
+}
+
+func FetchRevisions(ctx context.Context, namespace string) ([]shared.Revision, error) {
+	speakeasyClient, err := sdk.InitSDK()
+
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := speakeasyClient.Artifacts.GetRevisions(ctx, operations.GetRevisionsRequest{
+		NamespaceName: namespace,
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	if res.GetRevisionsResponse == nil {
+		return nil, fmt.Errorf("no revisions found for namespace %s", namespace)
+	}
+
+	return res.GetRevisionsResponse.Items, nil
+}
+
+func GetRegistryUriForRevision(ctx context.Context, revision shared.Revision) (string, error) {
+	orgSlug := core.GetOrgSlugFromContext(ctx)
+	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
+
+	if orgSlug == "" || workspaceSlug == "" {
+		return "", fmt.Errorf("could not generate registry uri: missing organization or workspace slug")
+	}
+
+	hasTags := len(revision.Tags) > 0
+
+	// TODO: base should be configurable
+	// TODO: should we be using new domain?
+	// TODO: prefer latest?
+	if hasTags {
+		return fmt.Sprintf("registry.speakeasyapi.dev/%s/%s/%s:%s", orgSlug, workspaceSlug, revision.NamespaceName, revision.Tags[0]), nil
+	}
+	return fmt.Sprintf("registry.speakeasyapi.dev/%s/%s/%s@%s", orgSlug, workspaceSlug, revision.NamespaceName, revision.Digest), nil
+}

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -23,9 +23,14 @@ type RecentGeneration struct {
 	SourceNamespace      string
 	SourceRevisionDigest string
 	Success              bool
+	Published            bool
 
 	// May not be set
-	GitRepo *string
+	GitRepoOrg string
+	GitRepo    string
+
+	// gen.yaml - uses GenerateConfigPostRaw (e.g state of the config post-last-generation)
+	GenerateConfig *string
 }
 
 const (
@@ -71,6 +76,7 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 		if !isRelevantGenerationEvent(event) {
 			continue
 		}
+
 		if seenUniqueNamespaces[*event.SourceNamespaceName] {
 			continue
 		}
@@ -82,9 +88,11 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 			CreatedAt:            event.CreatedAt,
 			TargetName:           *event.GenerateTargetName,
 			Target:               *event.GenerateTarget,
-			GitRepo:              event.GenerateRepoURL,
+			GitRepoOrg:           *event.GitRemoteDefaultOwner,
+			GitRepo:              *event.GitRemoteDefaultRepo,
 			SourceNamespace:      *event.SourceNamespaceName,
 			SourceRevisionDigest: *event.SourceRevisionDigest,
+			GenerateConfig:       event.GenerateConfigPostRaw,
 			Success:              event.Success,
 		})
 

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -47,6 +47,7 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 		return nil, err
 	}
 
+	// The event stream is limited to the most recent 250 events
 	res, err := speakeasyClient.Events.SearchWorkspaceEvents(ctx, operations.SearchWorkspaceEventsRequest{
 		WorkspaceID:     &workspaceId,
 		InteractionType: shared.InteractionTypeTargetGenerate.ToPointer(),
@@ -56,7 +57,7 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 		return nil, err
 	}
 
-	if res.GetCliEventBatch() == nil {
+	if len(res.CliEventBatch) == 0 {
 		return nil, fmt.Errorf("no events found for workspace %s", workspaceId)
 	}
 

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -29,9 +29,13 @@ type RecentGeneration struct {
 }
 
 const (
+	// The event stream contains multiple events for the same namespace, so we want to
+	// break execution once we've seen a minimum, arbitrary number of unique namespaces.
 	minimumRecentGenerationsToShow int = 5
 )
 
+// GetRecentWorkspaceGenerations returns the most recent generations of targets in a workspace
+// This is based on the CLi event stream, which is updated on every CLI interaction.
 func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, error) {
 	workspaceId, err := core.GetWorkspaceIDFromContext(ctx)
 	if err != nil {
@@ -61,6 +65,8 @@ func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, err
 	var generations []RecentGeneration
 
 	for _, event := range res.CliEventBatch {
+		// Filter out cli events that aren't generation based, or lack the required
+		// fields.
 		if !isRelevantGenerationEvent(event) {
 			continue
 		}

--- a/internal/remote/sources.go
+++ b/internal/remote/sources.go
@@ -3,71 +3,110 @@ package remote
 import (
 	"context"
 	"fmt"
-	"sort"
+	"time"
 
 	core "github.com/speakeasy-api/speakeasy-core/auth"
+	"github.com/speakeasy-api/speakeasy/internal/sdk"
 
 	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/operations"
 	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
-	"github.com/speakeasy-api/speakeasy/internal/sdk"
 )
 
-// FindRecentRemoteSources returns a list of recent remote sources
-// based on events in the workspace.
-func FindRecentRemoteNamespaces(ctx context.Context, limit int) ([]shared.Namespace, error) {
+// RecentGeneration represents a recent generation of a target in the workspace.
+// The source of this data is our CLI event stream, which is updated every time
+// a target is generated.
+type RecentGeneration struct {
+	CreatedAt            time.Time
+	ID                   string
+	TargetName           string
+	Target               string
+	SourceNamespace      string
+	SourceRevisionDigest string
+	Success              bool
+
+	// May not be set
+	GitRepo *string
+}
+
+const (
+	minimumRecentGenerationsToShow int = 5
+)
+
+func GetRecentWorkspaceGenerations(ctx context.Context) ([]RecentGeneration, error) {
+	workspaceId, err := core.GetWorkspaceIDFromContext(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	speakeasyClient, err := sdk.InitSDK()
-
 	if err != nil {
 		return nil, err
 	}
 
-	res, err := speakeasyClient.Artifacts.GetNamespaces(ctx)
-
-	if err != nil {
-		return nil, err
-	}
-
-	items := res.GetNamespacesResponse.Items
-
-	sort.Slice(items, func(i, j int) bool {
-		return items[i].UpdatedAt.After(items[j].UpdatedAt)
+	res, err := speakeasyClient.Events.SearchWorkspaceEvents(ctx, operations.SearchWorkspaceEventsRequest{
+		WorkspaceID:     &workspaceId,
+		InteractionType: shared.InteractionTypeTargetGenerate.ToPointer(),
 	})
 
-	var namespaces []shared.Namespace
+	if err != nil {
+		return nil, err
+	}
 
-	for i, item := range items {
-		if i >= limit {
+	if res.GetCliEventBatch() == nil {
+		return nil, fmt.Errorf("no events found for workspace %s", workspaceId)
+	}
+
+	seenUniqueNamespaces := make(map[string]bool)
+
+	var generations []RecentGeneration
+
+	for _, event := range res.CliEventBatch {
+		if !isRelevantGenerationEvent(event) {
+			continue
+		}
+		if seenUniqueNamespaces[*event.SourceNamespaceName] {
+			continue
+		}
+
+		seenUniqueNamespaces[*event.SourceNamespaceName] = true
+
+		generations = append(generations, RecentGeneration{
+			ID:                   event.ID,
+			CreatedAt:            event.CreatedAt,
+			TargetName:           *event.GenerateTargetName,
+			Target:               *event.GenerateTarget,
+			GitRepo:              event.GenerateRepoURL,
+			SourceNamespace:      *event.SourceNamespaceName,
+			SourceRevisionDigest: *event.SourceRevisionDigest,
+			Success:              event.Success,
+		})
+
+		if len(seenUniqueNamespaces) >= minimumRecentGenerationsToShow {
 			break
 		}
-		namespaces = append(namespaces, item)
 	}
 
-	return namespaces, nil
+	return generations, nil
 }
 
-func FetchRevisions(ctx context.Context, namespace string) ([]shared.Revision, error) {
-	speakeasyClient, err := sdk.InitSDK()
-
-	if err != nil {
-		return nil, err
+func isRelevantGenerationEvent(event shared.CliEvent) bool {
+	if event.SourceRevisionDigest == nil {
+		return false
+	}
+	if event.GenerateTarget == nil {
+		return false
+	}
+	if event.GenerateTargetName == nil {
+		return false
+	}
+	if event.SourceNamespaceName == nil {
+		return false
 	}
 
-	res, err := speakeasyClient.Artifacts.GetRevisions(ctx, operations.GetRevisionsRequest{
-		NamespaceName: namespace,
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	if res.GetRevisionsResponse == nil {
-		return nil, fmt.Errorf("no revisions found for namespace %s", namespace)
-	}
-
-	return res.GetRevisionsResponse.Items, nil
+	return true
 }
 
-func GetRegistryUriForRevision(ctx context.Context, revision shared.Revision) (string, error) {
+func GetRegistryUriForSource(ctx context.Context, sourceNamespace, sourceRevisionDigest string) (string, error) {
 	orgSlug := core.GetOrgSlugFromContext(ctx)
 	workspaceSlug := core.GetWorkspaceSlugFromContext(ctx)
 
@@ -75,13 +114,5 @@ func GetRegistryUriForRevision(ctx context.Context, revision shared.Revision) (s
 		return "", fmt.Errorf("could not generate registry uri: missing organization or workspace slug")
 	}
 
-	hasTags := len(revision.Tags) > 0
-
-	// TODO: base should be configurable
-	// TODO: should we be using new domain?
-	// TODO: prefer latest?
-	if hasTags {
-		return fmt.Sprintf("registry.speakeasyapi.dev/%s/%s/%s:%s", orgSlug, workspaceSlug, revision.NamespaceName, revision.Tags[0]), nil
-	}
-	return fmt.Sprintf("registry.speakeasyapi.dev/%s/%s/%s@%s", orgSlug, workspaceSlug, revision.NamespaceName, revision.Digest), nil
+	return fmt.Sprintf("registry.speakeasyapi.dev/%s/%s/%s@%s", orgSlug, workspaceSlug, sourceNamespace, sourceRevisionDigest), nil
 }

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -3,16 +3,21 @@ package prompts
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/huh"
-	"github.com/speakeasy-api/speakeasy-core/openapi"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
+	"github.com/speakeasy-api/huh"
+	"github.com/speakeasy-api/speakeasy-core/openapi"
+
 	humanize "github.com/dustin/go-humanize/english"
+	"github.com/samber/lo"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/remote"
 
 	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
@@ -164,18 +169,58 @@ func getOverlayPrompts(promptForOverlay *bool, overlayLocation, authHeader *stri
 	return groups
 }
 
-func quickstartBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartState, error) {
+const (
+	recentNamespacesLimit int = 5
+)
+
+func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartState, error) {
 	source := &workflow.Source{}
 	var sourceName, fileLocation, authHeader string
 
+	// Retrieve recent namespaces and check if there are any available.
+	recentNamespaces, err := remote.FindRecentRemoteNamespaces(ctx, recentNamespacesLimit)
+	hasRecentRemoteNamespaces := err == nil && len(recentNamespaces) > 0
+
+	// Determine if we should use a remote source. Defaults to true before the user
+	// has interacted with the form.
+	useRemoteSource := hasRecentRemoteNamespaces
+
+	if hasRecentRemoteNamespaces {
+		prompt := charm_internal.NewBranchPrompt(
+			"Do you want to base your SDK on an existing remote source?",
+			"Selecting 'Yes' will allow you to pick from the most recently used sources in your workspace",
+			&useRemoteSource,
+		)
+		if _, err := charm_internal.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
+			useRemoteSource = false
+		}
+	}
+
+	selectedRegistryUri := ""
+	if useRemoteSource {
+		namespaceId, err := selectNamespace(ctx, recentNamespaces)
+		if err == nil && namespaceId != "" {
+			selectedRegistryUri, err = fetchRegistryUri(ctx, namespaceId)
+
+			if err != nil {
+				useRemoteSource = false
+			}
+		}
+	}
+
+	// Determine the file location based on existing values or user input.
 	if quickstart.Defaults.SchemaPath != nil {
 		fileLocation = *quickstart.Defaults.SchemaPath
+	} else if useRemoteSource && selectedRegistryUri != "" {
+		// The workflow file will be updated with a registry based input like:
+		// inputs:
+		// - location: registry.speakeasyapi.dev/speakeasy-self/speakeasy-self/petstore-oas@latest
+		fileLocation = selectedRegistryUri
 	} else {
 		if err := getOASLocation(&fileLocation, &authHeader, true); err != nil {
 			return nil, err
 		}
 	}
-
 
 	var summary *openapi.Summary
 	if authHeader == "" {
@@ -183,19 +228,10 @@ func quickstartBaseForm(ctx context.Context, quickstart *Quickstart) (*Quickstar
 		summary, _ = openapi.GetOASSummary(contents, fileLocation)
 	}
 
-
 	orgSlug := auth.GetOrgSlugFromContext(ctx)
-
 	isUsingSampleSpec := strings.TrimSpace(fileLocation) == ""
-
 	if isUsingSampleSpec {
-		quickstart.IsUsingSampleOpenAPISpec = true
-		// Other parts of the code make assumptions that the workflow has a valid source
-		// This is a hack to satisfy those assumptions, we will overwrite this with a proper
-		// file location when we have written the sample spec to disk when we know the SDK output directory
-		fileLocation = "https://example.com/OVERWRITE_WHEN_SAMPLE_SPEC_IS_WRITTEN"
-		sourceName = "petstore-oas"
-		quickstart.SDKName = "Petstore"
+		configureSampleSpec(quickstart, &fileLocation, &sourceName)
 	} else {
 		// No need to prompt for SDK name if we are using a sample spec
 		if err := getSDKName(&quickstart.SDKName, strcase.ToCamel(orgSlug)); err != nil {
@@ -208,29 +244,27 @@ func quickstartBaseForm(ctx context.Context, quickstart *Quickstart) (*Quickstar
 		}
 	}
 
+	// Prepare the source with the provided document.
 	document, err := formatDocument(fileLocation, authHeader, false)
 	if err != nil {
 		return nil, err
 	}
-
 	source.Inputs = append(source.Inputs, *document)
 
+	// If registry is enabled, create a registry entry.
 	if registry.IsRegistryEnabled(ctx) && orgSlug != "" && auth.GetWorkspaceSlugFromContext(ctx) != "" {
-		registryEntry := &workflow.SourceRegistry{}
-		if err := registryEntry.SetNamespace(fmt.Sprintf("%s/%s/%s", orgSlug, auth.GetWorkspaceSlugFromContext(ctx), strcase.ToKebab(sourceName))); err != nil {
+		if err := configureRegistry(source, orgSlug, auth.GetWorkspaceSlugFromContext(ctx), sourceName); err != nil {
 			return nil, err
 		}
-		source.Registry = registryEntry
 	}
 
+	// Validate the source and set it to the quickstart.
 	if err := source.Validate(); err != nil {
 		return nil, errors.Wrap(err, "failed to validate source")
 	}
-
 	quickstart.WorkflowFile.Sources[sourceName] = *source
 
 	nextState := TargetBase
-
 	return &nextState, nil
 }
 
@@ -297,7 +331,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 			huh.NewGroup(oasLocationPrompt(&fileLocation, false)),
 		}
 		groups = append(groups, getRemoteAuthenticationPrompts(&fileLocation, &authHeader)...)
-		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another openapi file to this source?", &addOpenAPIFile))
+		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another openapi file to this source?", "", &addOpenAPIFile))
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
 			charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
@@ -314,7 +348,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 
 	addOverlayFile := false
 	if _, err := charm_internal.NewForm(huh.NewForm(
-		charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", &addOverlayFile)),
+		charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", "", &addOverlayFile)),
 		charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
 		ExecuteForm(); err != nil {
 		return nil, err
@@ -325,7 +359,7 @@ func AddToSource(name string, currentSource *workflow.Source) (*workflow.Source,
 		var fileLocation, authHeader string
 		trueVal := true
 		groups := getOverlayPrompts(&trueVal, &fileLocation, &authHeader)
-		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another overlay file to this source?", &addOverlayFile))
+		groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add another overlay file to this source?", "", &addOverlayFile))
 		if _, err := charm_internal.NewForm(huh.NewForm(
 			groups...),
 			charm_internal.WithTitle(fmt.Sprintf("Let's add to the source %s", name))).
@@ -390,7 +424,7 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	var groups []*huh.Group
 	var promptForOverlay bool
-	groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", &promptForOverlay))
+	groups = append(groups, charm_internal.NewBranchPrompt("Would you like to add an overlay file to this source?", "", &promptForOverlay))
 	groups = append(groups, getOverlayPrompts(&promptForOverlay, &overlayFileLocation, &overlayAuthHeader)...)
 	groups = append(groups, huh.NewGroup(
 		charm_internal.NewInlineInput(&outputLocation).
@@ -541,4 +575,60 @@ func validateOpenApiFileLocation(s string, allowEmpty bool) error {
 	}
 
 	return validateDocumentLocation(s, charm_internal.OpenAPIFileExtensions)
+}
+
+// selectNamespace handles the user interaction for selecting a namespace.
+func selectNamespace(ctx context.Context, namespaces []shared.Namespace) (string, error) {
+	nsOpts := make([]huh.Option[string], len(namespaces))
+	for i, ns := range namespaces {
+		nsOpts[i] = huh.NewOption(ns.Name, ns.Name)
+	}
+
+	namespaceId := ""
+	selectPrompt := charm_internal.NewSelectPrompt(
+		"Select a recent remote source",
+		"These are the most recently updated remote sources in your workspace.",
+		nsOpts,
+		&namespaceId,
+	)
+	_, err := charm_internal.NewForm(huh.NewForm(selectPrompt)).ExecuteForm()
+	return namespaceId, err
+}
+
+// fetchRegistryUri fetches the registry URI for a given namespace ID.
+func fetchRegistryUri(ctx context.Context, namespaceId string) (string, error) {
+	revisions, err := remote.FetchRevisions(ctx, namespaceId)
+	if err != nil || len(revisions) == 0 {
+		return "", err
+	}
+
+	// Prefer revision with the 'latest' tag or fallback to the first revision.
+	revision := lo.FindOrElse(revisions, revisions[0], func(rev shared.Revision) bool {
+		return slices.Contains(rev.Tags, "latest")
+	})
+
+	return remote.GetRegistryUriForRevision(ctx, revision)
+}
+
+// configureSampleSpec sets up the sample spec configuration for the quickstart.
+func configureSampleSpec(quickstart *Quickstart, fileLocation, sourceName *string) {
+	quickstart.IsUsingSampleOpenAPISpec = true
+
+	// Other parts of the code make assumptions that the workflow has a valid source
+	// This is a hack to satisfy those assumptions, we will overwrite this with a proper
+	// file location when we have written the sample spec to disk when we know the SDK output directory
+	*fileLocation = "https://example.com/OVERWRITE_WHEN_SAMPLE_SPEC_IS_WRITTEN"
+	*sourceName = "petstore-oas"
+	quickstart.SDKName = "Petstore"
+}
+
+// configureRegistry sets up the registry entry for the source.
+func configureRegistry(source *workflow.Source, orgSlug, workspaceSlug, sourceName string) error {
+	registryEntry := &workflow.SourceRegistry{}
+	namespace := fmt.Sprintf("%s/%s/%s", orgSlug, workspaceSlug, strcase.ToKebab(sourceName))
+	if err := registryEntry.SetNamespace(namespace); err != nil {
+		return err
+	}
+	source.Registry = registryEntry
+	return nil
 }

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -180,8 +180,8 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 
 	if hasRecentGenerations {
 		prompt := charm_internal.NewBranchPrompt(
-			"Do you want to base your SDK on an existing remote source?",
-			"Selecting 'Yes' will allow you to pick from the most recently used sources in your workspace",
+			"Do you want to base your SDK on an existing SDK?",
+			"Selecting 'Yes' will allow you to pick from the most recently used SDKs in your workspace",
 			&useRemoteSource,
 		)
 		if _, err := charm_internal.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
@@ -581,8 +581,8 @@ func selectRecentGeneration(ctx context.Context, generations []remote.RecentGene
 	for i, generation := range generations {
 		label := fmt.Sprintf("%s (%s)", generation.TargetName, generation.Target)
 
-		if generation.GitRepo != "" && generation.GitRepoOrg != "" {
-			label += fmt.Sprintf(" %s/%s", generation.GitRepoOrg, generation.GitRepo)
+		if generation.GitRepo != nil && generation.GitRepoOrg != nil {
+			label += fmt.Sprintf(" %s/%s", *generation.GitRepoOrg, *generation.GitRepo)
 		}
 
 		opts[i] = huh.NewOption(label, generation.ID)
@@ -593,8 +593,8 @@ func selectRecentGeneration(ctx context.Context, generations []remote.RecentGene
 	// TODO: replace with updated Select API with custom option rendering when/if upstream is
 	// merged: https://github.com/charmbracelet/huh/pull/424
 	selectPrompt := charm_internal.NewSelectPrompt(
-		"Select a recent remote source",
-		"These are the most recently updated remote sources in your workspace.",
+		"Select a recent SDK",
+		"These are the most recently updated SDKs in your workspace.",
 		opts,
 		&evtId,
 	)

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -206,7 +206,6 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 		}
 	}
 
-	// Determine the file location based on existing values or user input.
 	if quickstart.Defaults.SchemaPath != nil {
 		fileLocation = *quickstart.Defaults.SchemaPath
 	} else if useRemoteSource && selectedRegistryUri != "" {
@@ -244,21 +243,18 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 		}
 	}
 
-	// Prepare the source with the provided document.
 	document, err := formatDocument(fileLocation, authHeader, false)
 	if err != nil {
 		return nil, err
 	}
 	source.Inputs = append(source.Inputs, *document)
 
-	// If registry is enabled, create a registry entry.
 	if registry.IsRegistryEnabled(ctx) && orgSlug != "" && auth.GetWorkspaceSlugFromContext(ctx) != "" {
 		if err := configureRegistry(source, orgSlug, auth.GetWorkspaceSlugFromContext(ctx), sourceName); err != nil {
 			return nil, err
 		}
 	}
 
-	// Validate the source and set it to the quickstart.
 	if err := source.Validate(); err != nil {
 		return nil, errors.Wrap(err, "failed to validate source")
 	}

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -585,8 +585,8 @@ func selectRecentGeneration(ctx context.Context, generations []remote.RecentGene
 	for i, generation := range generations {
 		label := fmt.Sprintf("%s (%s)", generation.TargetName, generation.Target)
 
-		if generation.GitRepo != nil {
-			label += fmt.Sprintf(" %s", *generation.GitRepo)
+		if generation.GitRepo != "" && generation.GitRepoOrg != "" {
+			label += fmt.Sprintf(" %s/%s", generation.GitRepoOrg, generation.GitRepo)
 		}
 
 		opts[i] = huh.NewOption(label, generation.ID)

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -144,7 +144,6 @@ func getSDKName(sdkName *string, placeholder string) error {
 	}
 
 	return nil
-
 }
 
 func getOverlayPrompts(promptForOverlay *bool, overlayLocation, authHeader *string) []*huh.Group {

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -35,7 +35,7 @@ const (
 
 // TODO: Add Github Configuration Next
 var StateMapping map[QuickstartState]formFunction = map[QuickstartState]formFunction{
-	SourceBase: quickstartBaseForm,
+	SourceBase: sourceBaseForm,
 	TargetBase: targetBaseForm,
 	ConfigBase: configBaseForm,
 }


### PR DESCRIPTION
This PR adds the ability to bootstrap a new target using a pre-existing specification hosted on Speakeasy's registry. The CLI will now show the most recent 5 targets that have been interacted with (based on the CLI event stream).

If there are any recent target candidates in the workspace, then the user will be presented with the option to choose from an existing SDK or create from scratch at the beginning of Quickstart. If there are no previous generations in a workspace, then the existing "new user" flow will be shown where the user can enter a filepath to a spec:

![CleanShot 2024-10-07 at 13 46 20@2x](https://github.com/user-attachments/assets/8cc576bc-e0bf-4a56-8ad6-5d5308fb8cae)

Then selecting from the list of recent SDKs:

![CleanShot 2024-10-07 at 13 46 32@2x](https://github.com/user-attachments/assets/6d2b44d3-f93c-4c15-b41f-5e70fb954bea)

(n.b the look and feel of the select list in the 2nd screenshot will change / look much better once the corresponding https://github.com/charmbracelet/huh/pull/424 pr has been merged)

The end result is that a new workflow file is created that references the existing Registry URI for the spec from the previous target

## Next steps

- Try and re-use as much of the prior target's `gen.yaml`