### PR TITLE
fix: support specs with no responses section for error-codes suggest

### DIFF
--- a/internal/suggest/errorCodes/errorCodes.go
+++ b/internal/suggest/errorCodes/errorCodes.go
@@ -109,21 +109,41 @@ func (b *builder) Build() overlay.Overlay {
 	}
 
 	if len(missingSchemaNodes) > 0 {
-		actions = append(actions, overlay.Action{
-			Target: "$.components.schemas",
-			Update: *builder.NewMappingNode(
-				missingSchemaNodes...,
-			),
-		})
+		schemasNode := *builder.NewMappingNode(missingSchemaNodes...)
+
+		// If components.schemas doesn't already exist, appending will fail silently
+		// If components.schemas does exist, we don't want to overwrite it
+		missingSchemasComponents := b.document.Components == nil || b.document.Components.Schemas == nil || b.document.Components.Schemas.IsZero()
+		if missingSchemasComponents {
+			actions = append(actions, overlay.Action{
+				Target: "$.components",
+				Update: *builder.NewNode("schemas", &schemasNode),
+			})
+		} else {
+			actions = append(actions, overlay.Action{
+				Target: "$.components.schemas",
+				Update: schemasNode,
+			})
+		}
 	}
 
 	if len(missingComponentNodes) > 0 {
-		actions = append(actions, overlay.Action{
-			Target: "$.components.responses",
-			Update: *builder.NewMappingNode(
-				missingComponentNodes...,
-			),
-		})
+		responsesNode := *builder.NewMappingNode(missingComponentNodes...)
+
+		// If components.responses doesn't already exist, appending will fail silently
+		// If components.responses does exist, we don't want to overwrite it
+		missingResponseComponents := b.document.Components == nil || b.document.Components.Responses == nil || b.document.Components.Responses.IsZero()
+		if missingResponseComponents {
+			actions = append(actions, overlay.Action{
+				Target: "$.components",
+				Update: *builder.NewNode("responses", &responsesNode),
+			})
+		} else {
+			actions = append(actions, overlay.Action{
+				Target: "$.components.responses",
+				Update: responsesNode,
+			})
+		}
 	}
 
 	return overlay.Overlay{

--- a/internal/suggest/errorCodes/errorCodes_test.go
+++ b/internal/suggest/errorCodes/errorCodes_test.go
@@ -16,6 +16,7 @@ func TestBuildErrorCodesOverlay(t *testing.T) {
 		name, in, out string
 	}
 	toTest := []args{
+		{"Simple petstore", "testData/petstore.yaml", "testData/petstore_expected.yaml"},
 		{"Reuse 4XX code", "testData/reuse4xx.yaml", "testData/reuse4xx_expected.yaml"},
 		{"Simple case -- add all missing", "testData/simple.yaml", "testData/simple_expected.yaml"},
 		{"Name conflict in added schema", "testData/nameConflict.yaml", "testData/nameConflict_expected.yaml"},
@@ -26,8 +27,6 @@ func TestBuildErrorCodesOverlay(t *testing.T) {
 			ctx := context.Background()
 
 			overlay, err := errorCodes.BuildErrorCodesOverlay(ctx, tt.in)
-
-			overlay.Format(os.Stdout)
 
 			_, _, model, err := schemas.LoadDocument(ctx, tt.in)
 			require.NoError(t, err)
@@ -42,6 +41,8 @@ func TestBuildErrorCodesOverlay(t *testing.T) {
 			// Convert root to YAML
 			actualBytes, err := yaml.Marshal(root)
 			require.NoError(t, err)
+
+			println(string(actualBytes))
 
 			// Compare the actual and expected YAML
 			require.YAMLEq(t, string(expectedBytes), string(actualBytes))

--- a/internal/suggest/errorCodes/testData/petstore.yaml
+++ b/internal/suggest/errorCodes/testData/petstore.yaml
@@ -1,0 +1,114 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+        - names
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string

--- a/internal/suggest/errorCodes/testData/petstore_expected.yaml
+++ b/internal/suggest/errorCodes/testData/petstore_expected.yaml
@@ -1,0 +1,301 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      parameters:
+        - name: limit
+          in: query
+          description: How many items to return at one time (max 100)
+          required: false
+          schema:
+            type: integer
+            maximum: 100
+            format: int32
+      responses:
+        '200':
+          description: A paged array of pets
+          headers:
+            x-next:
+              description: A link to the next page of responses
+              schema:
+                type: string
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pets"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        400:
+          $ref: '#/components/responses/BadRequest'
+        413:
+          $ref: '#/components/responses/BadRequest'
+        414:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/BadRequest'
+        422:
+          $ref: '#/components/responses/BadRequest'
+        431:
+          $ref: '#/components/responses/BadRequest'
+        510:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        407:
+          $ref: '#/components/responses/Unauthorized'
+        511:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        501:
+          $ref: '#/components/responses/NotFound'
+        505:
+          $ref: '#/components/responses/NotFound'
+        429:
+          $ref: '#/components/responses/RateLimited'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        502:
+          $ref: '#/components/responses/InternalServerError'
+        503:
+          $ref: '#/components/responses/InternalServerError'
+        506:
+          $ref: '#/components/responses/InternalServerError'
+        507:
+          $ref: '#/components/responses/InternalServerError'
+        508:
+          $ref: '#/components/responses/InternalServerError'
+        408:
+          $ref: '#/components/responses/Timeout'
+        504:
+          $ref: '#/components/responses/Timeout'
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      responses:
+        '201':
+          description: Null response
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        400:
+          $ref: '#/components/responses/BadRequest'
+        413:
+          $ref: '#/components/responses/BadRequest'
+        414:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/BadRequest'
+        422:
+          $ref: '#/components/responses/BadRequest'
+        431:
+          $ref: '#/components/responses/BadRequest'
+        510:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        407:
+          $ref: '#/components/responses/Unauthorized'
+        511:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        501:
+          $ref: '#/components/responses/NotFound'
+        505:
+          $ref: '#/components/responses/NotFound'
+        429:
+          $ref: '#/components/responses/RateLimited'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        502:
+          $ref: '#/components/responses/InternalServerError'
+        503:
+          $ref: '#/components/responses/InternalServerError'
+        506:
+          $ref: '#/components/responses/InternalServerError'
+        507:
+          $ref: '#/components/responses/InternalServerError'
+        508:
+          $ref: '#/components/responses/InternalServerError'
+        408:
+          $ref: '#/components/responses/Timeout'
+        504:
+          $ref: '#/components/responses/Timeout'
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
+        400:
+          $ref: '#/components/responses/BadRequest'
+        413:
+          $ref: '#/components/responses/BadRequest'
+        414:
+          $ref: '#/components/responses/BadRequest'
+        415:
+          $ref: '#/components/responses/BadRequest'
+        422:
+          $ref: '#/components/responses/BadRequest'
+        431:
+          $ref: '#/components/responses/BadRequest'
+        510:
+          $ref: '#/components/responses/BadRequest'
+        401:
+          $ref: '#/components/responses/Unauthorized'
+        403:
+          $ref: '#/components/responses/Unauthorized'
+        407:
+          $ref: '#/components/responses/Unauthorized'
+        511:
+          $ref: '#/components/responses/Unauthorized'
+        404:
+          $ref: '#/components/responses/NotFound'
+        501:
+          $ref: '#/components/responses/NotFound'
+        505:
+          $ref: '#/components/responses/NotFound'
+        429:
+          $ref: '#/components/responses/RateLimited'
+        500:
+          $ref: '#/components/responses/InternalServerError'
+        502:
+          $ref: '#/components/responses/InternalServerError'
+        503:
+          $ref: '#/components/responses/InternalServerError'
+        506:
+          $ref: '#/components/responses/InternalServerError'
+        507:
+          $ref: '#/components/responses/InternalServerError'
+        508:
+          $ref: '#/components/responses/InternalServerError'
+        408:
+          $ref: '#/components/responses/Timeout'
+        504:
+          $ref: '#/components/responses/Timeout'
+components:
+  schemas:
+    Pet:
+      type: object
+      required:
+        - id
+        - name
+        - names
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        tag:
+          type: string
+    Pets:
+      type: array
+      maxItems: 100
+      items:
+        $ref: "#/components/schemas/Pet"
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    BadRequestError:
+      type: string
+    UnauthorizedError:
+      type: string
+    NotFoundError:
+      type: string
+    RateLimitedError:
+      type: string
+    InternalServerError:
+      type: string
+    TimeoutError:
+      type: string
+  responses:
+    BadRequest:
+      description: A collection of codes that generally means the end user got something wrong in making the request
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/BadRequestError'
+    Unauthorized:
+      description: A collection of codes that generally means the client was not authenticated correctly for the request they want to make
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/UnauthorizedError'
+    NotFound:
+      description: Status codes relating to the resource/entity they are requesting not being found or endpoints/routes not existing
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/NotFoundError'
+    RateLimited:
+      description: Status codes relating to the client being rate limited by the server
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/RateLimitedError'
+    InternalServerError:
+      description: A collection of status codes that generally mean the server failed in an unexpected way
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/InternalServerError'
+    Timeout:
+      description: Timeouts occurred with the request
+      content:
+        '*/*':
+          schema:
+            $ref: '#/components/schemas/TimeoutError'


### PR DESCRIPTION
Error-codes suggest doesn't work properly for specs that don't already have a `components.responses` or `components.schemas` section