### PR TITLE
chore: Update GitHub Actions setup-go to use go-version-file

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ^1.21
+          go-version-file: "go.mod"
       - name: Generate speakeasy cli docs
         working-directory: speakeasy
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,8 +31,7 @@ jobs:
           preset: conventionalcommits
       - uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ">=1.21.0"
-          cache: true
+          go-version-file: "go.mod"
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - name: Configure git for private modules

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version: ">=1.20.0"
+          go-version-file: "go.mod"
 
       - name: Set up Python
         uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
@@ -65,17 +65,6 @@ jobs:
         env:
           GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
         run: git config --global url."https://speakeasybot:${env:GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
-
-      - uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
-        with:
-          path: |
-            ~/go/pkg/mod
-            ~/.cache/go-build
-            ~/Library/Caches/go-build
-            ~\AppData\Local\go-build
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
 
       - name: Build
         run: go build ./...


### PR DESCRIPTION
Reference: https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file

Prevent the need to manually update versions in CI files or otherwise have CI error on Go module version updates.

This change also removes the manual cache: true and actions/cache usage, as its automatic in actions/setup-go:

> The action has a built-in functionality for caching and restoring go modules and build outputs. It uses toolkit/cache under the hood but requires less configuration settings. The cache input is optional, and caching is turned on by default.