### PR TITLE
chore: Fix documantation workflow for go.mod lookup

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@0a12ed9d6a96ab950c8f026ed9f722fe0da7ef32 # v5.0.2
         with:
-          go-version-file: "go.mod"
+          go-version-file: "speakeasy/go.mod"
       - name: Generate speakeasy cli docs
         working-directory: speakeasy
         run: |


### PR DESCRIPTION
The repository is checked out into a speakeasy folder instead of root.