### PR TITLE
feat: we should no longer populate speakeasy version in new actions

### DIFF
--- a/prompts/github.go
+++ b/prompts/github.go
@@ -530,9 +530,8 @@ func defaultGenerationFile() *config.GenerateWorkflow {
 			Generate: config.Job{
 				Uses: "speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15",
 				With: map[string]any{
-					"speakeasy_version": "latest",
-					"force":             "${{ github.event.inputs.force }}",
-					config.Mode:         "pr",
+					"force":     "${{ github.event.inputs.force }}",
+					config.Mode: "pr",
 				},
 				Secrets: secrets,
 			},


### PR DESCRIPTION
Populating this is redundant and irrelevant, workflow.yaml determines what versions are used.