### PR TITLE
fix: automagically trim spaces from form input

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -162,7 +162,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	}
 
 	if !currentDirectoryEmpty() {
-		_, err = charm.NewForm(huh.NewForm(huh.NewGroup(charm.NewInput().
+		_, err = charm.NewForm(huh.NewForm(huh.NewGroup(charm.NewInput(&promptedDir).
 			Title("What directory should the "+targetType+" files be written to?").
 			Description(description+"\n").
 			Suggestions(charm.DirsInCurrentDir(promptedDir)).
@@ -174,8 +174,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 					}
 				}
 				return nil
-			}).
-			Value(&promptedDir))),
+			}))),
 			charm.WithTitle("Pick an output directory for your newly created files.")).
 			ExecuteForm()
 	} else {

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,8 @@ replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.
 
 replace github.com/daveshanley/vacuum => github.com/speakeasy-api/vacuum v0.0.0-20240926095216-18e2075ffe0f
 
+replace github.com/speakeasy-api/huh => ../huh
+
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4
 	github.com/charmbracelet/bubbles v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -8,8 +8,6 @@ replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.0.
 
 replace github.com/daveshanley/vacuum => github.com/speakeasy-api/vacuum v0.0.0-20240926095216-18e2075ffe0f
 
-replace github.com/speakeasy-api/huh => ../huh
-
 require (
 	github.com/MichaelMure/go-term-markdown v0.1.4
 	github.com/charmbracelet/bubbles v0.18.0

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pb33f/libopenapi v0.18.1
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
-	github.com/speakeasy-api/huh v1.1.1
+	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi-generation/v2 v2.438.3
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.23.6

--- a/go.mod
+++ b/go.mod
@@ -44,6 +44,7 @@ require (
 	github.com/AlekSi/pointer v1.2.0
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/charmbracelet/glamour v0.7.0
+	github.com/charmbracelet/huh v0.5.1
 	github.com/dustin/go-humanize v1.0.1
 	github.com/ericlagergren/decimal v0.0.0-20240411145413-00de7ca16731
 	github.com/inkeep/ai-api-go v0.3.1
@@ -76,7 +77,6 @@ require (
 	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/bytedance/sonic v1.9.1 // indirect
 	github.com/catppuccin/go v0.2.0 // indirect
-	github.com/charmbracelet/huh v0.5.1 // indirect
 	github.com/charmbracelet/x/ansi v0.1.2 // indirect
 	github.com/charmbracelet/x/exp/strings v0.0.0-20240617190524-788ec55faed1 // indirect
 	github.com/charmbracelet/x/input v0.1.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -506,8 +506,6 @@ github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzz
 github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/speakeasy-api/easytemplate v0.11.1 h1:YGEPoldsiXcfhPWN/12B2m78+67RhuFB09HzrVmnX4A=
 github.com/speakeasy-api/easytemplate v0.11.1/go.mod h1:C2px2dvDShpIVSMy6IjKymMNHMHWKv/wngLsf9bLHkA=
-github.com/speakeasy-api/huh v1.1.1 h1:tSBHezk8MRHBwtWqjMB/fepU6HcFWu9esyZxAKw/XAY=
-github.com/speakeasy-api/huh v1.1.1/go.mod h1:iBavR3Ieq/4upEcdq+VXQyeShcoC9cOhsQbhc/cMuLU=
 github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xHR62pM24=
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWUvGEZyMSZW34RHqE85HBsGRYgYP7L7Hh+4FSP4=

--- a/go.sum
+++ b/go.sum
@@ -506,6 +506,8 @@ github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzz
 github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/speakeasy-api/easytemplate v0.11.1 h1:YGEPoldsiXcfhPWN/12B2m78+67RhuFB09HzrVmnX4A=
 github.com/speakeasy-api/easytemplate v0.11.1/go.mod h1:C2px2dvDShpIVSMy6IjKymMNHMHWKv/wngLsf9bLHkA=
+github.com/speakeasy-api/huh v1.1.2 h1:5unC7BZBwq35D45ZUMnNPdiK4c+yFsGFQcnsfNHZ+wA=
+github.com/speakeasy-api/huh v1.1.2/go.mod h1:iBavR3Ieq/4upEcdq+VXQyeShcoC9cOhsQbhc/cMuLU=
 github.com/speakeasy-api/jsonpath v0.1.1 h1:79gtq+zHYPe9dR1urEwl/PPsvP9nMRTGG1xHR62pM24=
 github.com/speakeasy-api/jsonpath v0.1.1/go.mod h1:Py01TnxRUMhC0/FT954KBiaDY2/kaZv3QMc8JxQaVys=
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWUvGEZyMSZW34RHqE85HBsGRYgYP7L7Hh+4FSP4=

--- a/internal/charm/formModel.go
+++ b/internal/charm/formModel.go
@@ -7,7 +7,6 @@ import (
 	"github.com/speakeasy-api/huh"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"slices"
-	"strings"
 )
 
 type Key struct {
@@ -75,24 +74,13 @@ func (m FormModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	form, cmd := m.form.Update(msg)
 
 	if f, ok := form.(*huh.Form); ok {
-		for k, result := range f.Results {
-			resultString, ok := result.(string)
-			if !ok {
-				println("NOT A STRING")
-				continue
-			}
-			println("RESULT: " + resultString)
-			f.Results[k] = strings.TrimSpace(resultString)
-		}
-
 		m.form = f
 		cmds = append(cmds, cmd)
 	}
 
 	// Quit when the form is done.
 	if m.form.State == huh.StateCompleted {
-		return m, tea.Quit
-		//cmds = append(cmds, tea.Quit)
+		cmds = append(cmds, tea.Quit)
 	}
 
 	return m, tea.Batch(cmds...)

--- a/internal/charm/transformAccessor.go
+++ b/internal/charm/transformAccessor.go
@@ -1,0 +1,24 @@
+package charm
+
+import (
+	"github.com/charmbracelet/huh"
+)
+
+type TransformAccessor struct {
+	value     *string
+	transform func(string) string
+}
+
+func (t *TransformAccessor) Get() string {
+	if t.value == nil {
+		return ""
+	}
+	return *t.value
+}
+
+func (t *TransformAccessor) Set(value string) {
+	value = t.transform(value)
+	t.value = &value
+}
+
+var _ huh.Accessor[string] = &TransformAccessor{}

--- a/internal/charm/transformAccessor.go
+++ b/internal/charm/transformAccessor.go
@@ -18,7 +18,7 @@ func (t *TransformAccessor) Get() string {
 
 func (t *TransformAccessor) Set(value string) {
 	value = t.transform(value)
-	t.value = &value
+	*t.value = value
 }
 
 var _ huh.Accessor[string] = &TransformAccessor{}

--- a/internal/charm/utils.go
+++ b/internal/charm/utils.go
@@ -74,10 +74,6 @@ func FormatNewOption(text string) string {
 	return fmt.Sprintf("+ %s", text)
 }
 
-func NewInputNoSpaces() *huh.Input {
-	return huh.NewInput().Prompt("").Inline(true).Accessor(&TransformAccessor{transform: strings.TrimSpace})
-}
-
 // Populates tab complete for schema files in the relative directory
 func SchemaFilesInCurrentDir(relativeDir string, fileExtensions []string) []string {
 	var validFiles []string

--- a/internal/charm/utils.go
+++ b/internal/charm/utils.go
@@ -41,12 +41,29 @@ func FormatCommandDescription(description string) string {
 	return "\n" + descriptionStyle.Render(description)
 }
 
-func NewInlineInput() *huh.Input {
-	return huh.NewInput().Prompt(" ").Inline(true)
+func NewInput(value *string, opts ...InputOpt) *huh.Input {
+	input := huh.NewInput()
+
+	// On windows, enter will get processed as a space, so we need to trim it
+	input = input.Accessor(&TransformAccessor{value: value, transform: strings.TrimSpace})
+
+	// Setting the prompt to empty affects styling
+	input = input.Prompt("")
+
+	for _, opt := range opts {
+		input = opt(input)
+	}
+	return input
 }
 
-func NewInput() *huh.Input {
-	return huh.NewInput().Prompt("")
+func NewInlineInput(value *string) *huh.Input {
+	return NewInput(value, WithInline)
+}
+
+type InputOpt func(*huh.Input) *huh.Input
+
+func WithInline(input *huh.Input) *huh.Input {
+	return input.Prompt(" ").Inline(true)
 }
 
 func FormatEditOption(text string) string {
@@ -55,6 +72,10 @@ func FormatEditOption(text string) string {
 
 func FormatNewOption(text string) string {
 	return fmt.Sprintf("+ %s", text)
+}
+
+func NewInputNoSpaces() *huh.Input {
+	return huh.NewInput().Prompt("").Inline(true).Accessor(&TransformAccessor{transform: strings.TrimSpace})
 }
 
 // Populates tab complete for schema files in the relative directory

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -337,7 +337,9 @@ func getValuesForField(
 }
 
 func addPromptForField(key, defaultValue, validateRegex, validateMessage string, descriptionFn func(v string) string) *huh.Group {
-	input := charm.NewInlineInput().
+	value := defaultValue
+
+	input := charm.NewInlineInput(&value).
 		Key(key).
 		Title(fmt.Sprintf("Choose a %s", key)).
 		Validate(func(s string) error {
@@ -355,9 +357,6 @@ func addPromptForField(key, defaultValue, validateRegex, validateMessage string,
 			}
 			return nil
 		})
-
-	value := defaultValue
-	input = input.Value(&value)
 
 	if descriptionFn != nil {
 		fn := func() string {

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -194,13 +194,11 @@ func executePromptsForPublishing(prompts map[publishingPrompt]*string, target *w
 	for prompt, value := range prompts {
 		var input *huh.Input
 		if prompt.entryType == publishingTypeSecret {
-			input = charm.NewInlineInput().
-				Title(fmt.Sprintf("Provide a name for your %s secret:", prompt.key)).
-				Value(value)
+			input = charm.NewInlineInput(value).
+				Title(fmt.Sprintf("Provide a name for your %s secret:", prompt.key))
 		} else {
-			input = charm.NewInlineInput().
-				Title(fmt.Sprintf("Provide the value of your %s:", prompt.key)).
-				Value(value)
+			input = charm.NewInlineInput(value).
+				Title(fmt.Sprintf("Provide the value of your %s:", prompt.key))
 		}
 		fields = append(fields,
 			input,

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -3,6 +3,7 @@ package prompts
 import (
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/huh"
 	"net/http"
 	"net/url"
 	"os"
@@ -14,7 +15,6 @@ import (
 
 	"github.com/iancoleman/strcase"
 	"github.com/pkg/errors"
-	"github.com/speakeasy-api/huh"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/speakeasy-api/speakeasy-core/auth"
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
@@ -399,6 +399,8 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 		ExecuteForm(); err != nil {
 		return "", nil, err
 	}
+
+	println("FILE LOCATION: " + fileLocation)
 
 	document, err := formatDocument(fileLocation, authHeader, false)
 	if err != nil {

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -33,7 +33,7 @@ func getBaseTargetPrompts(currentWorkflow *workflow.Workflow, sourceName, target
 		}
 
 		targetFields = append(targetFields,
-			charm.NewInlineInput().
+			charm.NewInlineInput(targetName).
 				Title("What is a good name for this target?").
 				Validate(func(s string) error {
 					if s == "" {
@@ -48,8 +48,7 @@ func getBaseTargetPrompts(currentWorkflow *workflow.Workflow, sourceName, target
 						return fmt.Errorf("a target with the name %s already exists", s)
 					}
 					return nil
-				}).
-				Value(targetName),
+				}),
 		)
 	}
 
@@ -59,7 +58,7 @@ func getBaseTargetPrompts(currentWorkflow *workflow.Workflow, sourceName, target
 	}
 	if len(currentWorkflow.Targets) > 0 {
 		groups = append(groups,
-			huh.NewGroup(charm.NewInlineInput().
+			huh.NewGroup(charm.NewInlineInput(outDir).
 				Title("What is a good output directory for your generation target?").
 				Suggestions(charm.DirsInCurrentDir(*outDir)).
 				SetSuggestionCallback(charm.SuggestionCallback(charm.SuggestionCallbackConfig{IsDirectories: true})).
@@ -75,8 +74,7 @@ func getBaseTargetPrompts(currentWorkflow *workflow.Workflow, sourceName, target
 					}
 
 					return nil
-				}).
-				Value(outDir),
+				}),
 			))
 	}
 
@@ -185,11 +183,10 @@ func PromptForOutDirMigration(currentWorkflow *workflow.Workflow, existingTarget
 			originalDir := outDir
 
 			if _, err := charm.NewForm(huh.NewForm(
-				huh.NewGroup(charm.NewInlineInput().
+				huh.NewGroup(charm.NewInlineInput(&outDir).
 					Title(fmt.Sprintf("Optionally provide an output directory to move your existing %s target %s to.", targetType, targetName)).
 					Suggestions(charm.DirsInCurrentDir(outDir)).
-					SetSuggestionCallback(charm.SuggestionCallback(charm.SuggestionCallbackConfig{IsDirectories: true})).
-					Value(&outDir))),
+					SetSuggestionCallback(charm.SuggestionCallback(charm.SuggestionCallbackConfig{IsDirectories: true})))),
 				charm.WithTitle("When setting up multiple targets we recommend you select an output directory not in the root folder.")).ExecuteForm(); err != nil {
 				return err
 			}


### PR DESCRIPTION
On windows, "enter" gets interpreted as a space sometimes. This solves this anywhere we use `cham_internal.NewInput` by using a custom accessor which removes whitespace any time the value is written