### PR TITLE
fix: remove ruleset overriding for studio

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -316,7 +316,6 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
-		run.WithRulesetOverride(flags.Watch),
 		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 
@@ -374,7 +373,6 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithRegistryTags(flags.RegistryTags),
 		run.WithSetVersion(flags.SetVersion),
 		run.WithFrozenWorkflowLock(flags.FrozenWorkflowLock),
-		run.WithRulesetOverride(flags.Watch),
 		run.WithSkipCleanup(), // The studio won't work if we clean up before it launches
 	}
 

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -83,9 +83,6 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 	if source.Ruleset != nil {
 		rulesetToUse = *source.Ruleset
 	}
-	if w.RulesetOverride != "" {
-		rulesetToUse = w.RulesetOverride
-	}
 
 	logger := log.From(ctx)
 	logger.Infof("Running Source %s...", sourceID)

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -141,18 +141,6 @@ func WithFrozenWorkflowLock(frozen bool) Opt {
 	}
 }
 
-// If we are in --watch mode (e.g explicitly running the studio), we want to
-// run the recommended ruleset that also includes additional rules such as
-// missing-examples, which are not enabled by default in the generation only
-// ruleset.
-func WithRulesetOverride(watchMode bool) Opt {
-	return func(w *Workflow) {
-		if watchMode {
-			w.RulesetOverride = "speakeasy-recommended"
-		}
-	}
-}
-
 func WithSkipVersioning(skipVersioning bool) Opt {
 	return func(w *Workflow) {
 		w.SkipVersioning = skipVersioning

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -35,11 +35,6 @@ type Workflow struct {
 	InstallationURLs       map[string]string
 	RegistryTags           []string
 
-	// RulesetOverride is used to override the rulesets used for validating
-	// Will take precedence over the ruleset set in the workflow file for the
-	// source being run.
-	RulesetOverride string
-
 	// Internal
 	workflowName       string
 	SDKOverviewURLs    map[string]string

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -132,7 +132,6 @@ func (h *StudioHandlers) reRun(ctx context.Context, w http.ResponseWriter, r *ht
 		run.WithSkipGenerateLintReport(),
 		run.WithSkipSnapshot(true),
 		run.WithSkipChangeReport(true),
-		run.WithRulesetOverride(true),
 	)
 	if err != nil {
 		return fmt.Errorf("error cloning workflow runner: %w", err)


### PR DESCRIPTION
Removes specific overriding of rulesets from the CLI code in the case where watch flag is provided 

https://speakeasyapi.slack.com/archives/C0698C9K4NL/p1729078919662769