### PR TITLE
fix: better additive method name suggestions

### DIFF
--- a/internal/studio/modifications/overlay.go
+++ b/internal/studio/modifications/overlay.go
@@ -149,6 +149,28 @@ func MergeActions(actions []overlay.Action) []overlay.Action {
 	return deduped
 }
 
+func GetModifiedTargets(dir, modificationType string) ([]string, error) {
+	overlayLocation, err := GetOverlayPath(dir)
+	if err != nil {
+		return nil, err
+	}
+	overlay, err := loader.LoadOverlay(overlayLocation)
+	if err != nil {
+		return nil, err
+	}
+
+	var targets []string
+	for _, action := range overlay.Actions {
+		if mod := suggestions.GetModificationExtension(action); mod != nil {
+			if modificationType == mod.Type {
+				targets = append(targets, action.Target)
+			}
+		}
+	}
+
+	return targets, nil
+}
+
 // Return new suggestions that are not already in the list of suggestions
 func RemoveAlreadySuggested(alreadySuggested []overlay.Action, newSuggestions []overlay.Action) []overlay.Action {
 	getKey := func(x overlay.Action, index int) string {
@@ -162,7 +184,7 @@ func RemoveAlreadySuggested(alreadySuggested []overlay.Action, newSuggestions []
 
 	return lo.Filter(newSuggestions, func(x overlay.Action, index int) bool {
 		key := getKey(x, index)
-		return slices.Contains(alreadySuggestedKeys, key)
+		return !slices.Contains(alreadySuggestedKeys, key)
 	})
 }
 

--- a/internal/studio/studioHandlers.go
+++ b/internal/studio/studioHandlers.go
@@ -290,6 +290,7 @@ func (h *StudioHandlers) suggestMethodNames(ctx context.Context, w http.Response
 		if err != nil {
 			log.From(ctx).Warnf("error loading existing overlay: %s", err.Error())
 		} else {
+			// Theoretically this shouldn't be necessary anymore because suggestions are filtered by suggest.SuggestOperationIDs
 			suggestOverlay.Actions = modifications.RemoveAlreadySuggested(existingOverlay.Actions, suggestOverlay.Actions)
 		}
 	}


### PR DESCRIPTION
https://linear.app/speakeasy/issue/SPE-4404/bug-studio-not-suggesting-additional-fixes-for-newly-added-operations

The actual issue was just a missing `not` in a filter expression. But I took the opportunity to improve how we get suggestions more broadly by pre-filtering operations for which we have suggestions. This speeds up the roundtrip to the LLM (before, we were getting all suggestions then filtering afterwards)