### PR TITLE
fix: don't block on codesample push failure

### DIFF
--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -185,44 +185,20 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 
 	if t.CodeSamples != nil {
 		codeSamplesStep := rootStep.NewSubstep("Generating Code Samples")
-		configPath := "."
-		outputPath := t.CodeSamples.Output
-		if t.Output != nil {
-			configPath = *t.Output
-			outputPath = filepath.Join(*t.Output, outputPath)
-		}
+		namespaceName, digest, err := w.runCodeSamples(ctx, codeSamplesStep, *t.CodeSamples, t.Target, sourcePath, t.Output)
 
-		// Err if set to blocking, log a warn if not
-		blockingError := func(err error) bool {
-			if err == nil {
-				return false
-			}
+		if err != nil {
 			// Block by default. Only warn if explicitly set to non-blocking
 			if t.CodeSamples.Blocking == nil || *t.CodeSamples.Blocking {
-				return true
+				return sourceRes, nil, err
 			} else {
 				log.From(ctx).Warnf("failed to generate code samples: %s", err.Error())
 				codeSamplesStep.Skip("failed, but step set to non-blocking")
 			}
-			return false
 		}
 
-		overlayString, err := codesamples.GenerateOverlay(ctx, sourcePath, "", "", configPath, outputPath, []string{t.Target}, true, *t.CodeSamples)
-		if blockingError(err) {
-			return sourceRes, nil, err
-		}
-
-		if !w.FrozenWorkflowLock && err == nil {
-			namespaceName, digest, err := w.snapshotCodeSamples(ctx, codeSamplesStep, overlayString, *t.CodeSamples)
-			if err != nil {
-				if blockingError(err) {
-					return sourceRes, nil, err
-				}
-			} else {
-				targetLock.CodeSamplesNamespace = namespaceName
-				targetLock.CodeSamplesRevisionDigest = digest
-			}
-		}
+		targetLock.CodeSamplesNamespace = namespaceName
+		targetLock.CodeSamplesRevisionDigest = digest
 	}
 
 	rootStep.SucceedWorkflow()
@@ -243,6 +219,27 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 	w.lockfile.Targets[target] = targetLock
 
 	return sourceRes, &targetResult, nil
+}
+
+// Returns codeSamples namespace name and digest
+func (w *Workflow) runCodeSamples(ctx context.Context, codeSamplesStep *workflowTracking.WorkflowStep, codeSamples workflow.CodeSamples, target, sourcePath string, baseOutputPath *string) (string, string, error) {
+	configPath := "."
+	outputPath := codeSamples.Output
+	if baseOutputPath != nil {
+		configPath = *baseOutputPath
+		outputPath = filepath.Join(*baseOutputPath, outputPath)
+	}
+
+	overlayString, err := codesamples.GenerateOverlay(ctx, sourcePath, "", "", configPath, outputPath, []string{target}, true, codeSamples)
+	if err != nil {
+		return "", "", err
+	}
+
+	if !w.FrozenWorkflowLock {
+		return w.snapshotCodeSamples(ctx, codeSamplesStep, overlayString, codeSamples)
+	}
+
+	return "", "", nil
 }
 
 func (w *Workflow) snapshotCodeSamples(ctx context.Context, parentStep *workflowTracking.WorkflowStep, overlayString string, codeSampleConfig workflow.CodeSamples) (namespaceName string, digest string, err error) {


### PR DESCRIPTION
Captures all codesamples logic behind the "blocking/non-blocking" logic instead of just the actual generation part