### PR TITLE
chore: upgrade speakeasy-core

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.23.7
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.11
-	github.com/speakeasy-api/speakeasy-core v0.15.12
+	github.com/speakeasy-api/speakeasy-core v0.16.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -512,8 +512,8 @@ github.com/speakeasy-api/sdk-gen-config v1.23.7 h1:H1wKo3FMjtgTy5Hik523I8VPDg5Fp
 github.com/speakeasy-api/sdk-gen-config v1.23.7/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.11 h1:3lVkbqhH5Q8NBXyPH2yt7ilEQ7Mmy3WLdd+A5OB7Km8=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.14.11/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.15.12 h1:k6QfXTNY8GQu17mXM0kAApC9msU6YHVFa96+0DCzjzk=
-github.com/speakeasy-api/speakeasy-core v0.15.12/go.mod h1:0U4gDvmCjWVzteXXPhdKcktzTwggyHBSU8EvBpgTA7I=
+github.com/speakeasy-api/speakeasy-core v0.16.0 h1:UpMEUFQ76rQyTFQ9JTv8EsX9V5DEr1ePJbdvw9+nJ68=
+github.com/speakeasy-api/speakeasy-core v0.16.0/go.mod h1:0U4gDvmCjWVzteXXPhdKcktzTwggyHBSU8EvBpgTA7I=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=


### PR DESCRIPTION
bump speakeasy-core (no public interface changes, just an extra private method for use in our generator)