### PR TITLE
fix: check error severity during MVS

### DIFF
--- a/internal/run/minimumViableSpec.go
+++ b/internal/run/minimumViableSpec.go
@@ -19,8 +19,10 @@ func (w *Workflow) retryWithMinimumViableSpec(ctx context.Context, parentStep *w
 	invalidOperationToErr := make(map[string]error)
 	for _, err := range vErrs {
 		vErr := errors.GetValidationErr(err)
-		for _, op := range vErr.AffectedOperationIDs {
-			invalidOperationToErr[op] = err // TODO: support multiple errors per operation?
+		if vErr.Severity == errors.SeverityError {
+			for _, op := range vErr.AffectedOperationIDs {
+				invalidOperationToErr[op] = err // TODO: support multiple errors per operation?
+			}
 		}
 	}
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/SPE-4429/operations-not-showing-up-in-generated-sdk