### PR TITLE
feat: format transform

### DIFF
--- a/cmd/openapi/transform.go
+++ b/cmd/openapi/transform.go
@@ -2,18 +2,19 @@ package openapi
 
 import (
 	"context"
+	"os"
+
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"
 	"github.com/speakeasy-api/speakeasy/internal/transform"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
-	"os"
 )
 
 var transformCmd = &model.CommandGroup{
 	Usage:    "transform",
 	Short:    "Transform an OpenAPI spec using a well-defined function",
-	Commands: []model.Command{removeUnusedCmd, filterOperationsCmd, cleanupCmd},
+	Commands: []model.Command{removeUnusedCmd, filterOperationsCmd, cleanupCmd, formatCmd},
 }
 
 type basicFlagsI struct {
@@ -76,6 +77,13 @@ var cleanupCmd = &model.ExecutableCommand[basicFlagsI]{
 	Flags: basicFlags,
 }
 
+var formatCmd = &model.ExecutableCommand[basicFlagsI]{
+	Usage: "format",
+	Short: "Format a given OpenAPI document",
+	Run:   runFormat,
+	Flags: basicFlags,
+}
+
 func runRemoveUnused(ctx context.Context, flags basicFlagsI) error {
 	out, yamlOut, err := setupOutput(ctx, flags.Out)
 	defer out.Close()
@@ -104,6 +112,16 @@ func runCleanup(ctx context.Context, flags basicFlagsI) error {
 	}
 
 	return transform.CleanupDocument(ctx, flags.Schema, yamlOut, out)
+}
+
+func runFormat(ctx context.Context, flags basicFlagsI) error {
+	out, yamlOut, err := setupOutput(ctx, flags.Out)
+	defer out.Close()
+	if err != nil {
+		return err
+	}
+
+	return transform.FormatDocument(ctx, flags.Schema, yamlOut, out)
 }
 
 func setupOutput(ctx context.Context, out string) (*os.File, bool, error) {

--- a/cmd/openapi/transform.go
+++ b/cmd/openapi/transform.go
@@ -79,7 +79,8 @@ var cleanupCmd = &model.ExecutableCommand[basicFlagsI]{
 
 var formatCmd = &model.ExecutableCommand[basicFlagsI]{
 	Usage: "format",
-	Short: "Format a given OpenAPI document",
+	Short: "Format an OpenAPI document to be more human-readable",
+	Long:  "Format an OpenAPI document to be more human-readable by sorting the keys in a specific order best suited for each level in the OpenAPI specification",
 	Run:   runFormat,
 	Flags: basicFlags,
 }

--- a/integration/resources/formatted.yaml
+++ b/integration/resources/formatted.yaml
@@ -1,0 +1,800 @@
+openapi: 3.0.2
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  version: 1.0.19
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+
+    Some useful links:
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  contact:
+    email: apiteam@swagger.io
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+externalDocs:
+  url: http://swagger.io
+  description: Find out more about Swagger
+servers:
+  - url: "/api/v3"
+tags:
+  - name: pet
+    description: Everything about your Pets
+    externalDocs:
+      url: http://swagger.io
+      description: Find out more
+  - name: store
+    description: Access to Petstore orders
+    externalDocs:
+      url: http://swagger.io
+      description: Find out more about our store
+  - name: user
+    description: Operations about user
+paths:
+  /pet:
+    post:
+      tags:
+        - pet
+      summary: Add a new pet to the store
+      operationId: addPet
+      description: Add a new pet to the store
+      requestBody:
+        description: Create a new pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/Pet"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        405:
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    put:
+      tags:
+        - pet
+      summary: Update an existing pet
+      operationId: updatePet
+      description: Update an existing pet by Id
+      requestBody:
+        description: Update an existent pet in the store
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Pet"
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/Pet"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/Pet"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        400:
+          description: Invalid ID supplied
+        404:
+          description: Pet not found
+        405:
+          description: Validation exception
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/findByStatus:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by status
+      operationId: findPetsByStatus
+      description: Multiple status values can be provided with comma separated strings
+      parameters:
+        - name: status
+          description: Status values that need to be considered for filter
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: string
+            enum:
+              - available
+              - pending
+              - sold
+            default: available
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        400:
+          description: Invalid status value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/findByTags:
+    get:
+      tags:
+        - pet
+      summary: Finds Pets by tags
+      operationId: findPetsByTags
+      description: Multiple tags can be provided with comma separated strings. Use tag1, tag2, tag3 for testing.
+      parameters:
+        - name: tags
+          description: Tags to filter by
+          in: query
+          required: false
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/Pet"
+        400:
+          description: Invalid tag value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/{petId}:
+    get:
+      tags:
+        - pet
+      summary: Find pet by ID
+      operationId: getPetById
+      description: Returns a single pet
+      parameters:
+        - name: petId
+          description: ID of pet to return
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Pet"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        400:
+          description: Invalid ID supplied
+        404:
+          description: Pet not found
+      security:
+        - api_key: []
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    post:
+      tags:
+        - pet
+      summary: Updates a pet in the store with form data
+      operationId: updatePetWithForm
+      description: ''
+      parameters:
+        - name: petId
+          description: ID of pet that needs to be updated
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: name
+          description: Name of pet that needs to be updated
+          in: query
+          schema:
+            type: string
+        - name: status
+          description: Status of pet that needs to be updated
+          in: query
+          schema:
+            type: string
+      responses:
+        405:
+          description: Invalid input
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+    delete:
+      tags:
+        - pet
+      summary: Deletes a pet
+      operationId: deletePet
+      description: ''
+      parameters:
+        - name: api_key
+          description: ''
+          in: header
+          required: false
+          schema:
+            type: string
+        - name: petId
+          description: Pet id to delete
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        400:
+          description: Invalid pet value
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /pet/{petId}/uploadImage:
+    post:
+      tags:
+        - pet
+      summary: uploads an image
+      operationId: uploadFile
+      description: ''
+      parameters:
+        - name: petId
+          description: ID of pet to update
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+        - name: additionalMetadata
+          description: Additional Metadata
+          in: query
+          required: false
+          schema:
+            type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ApiResponse"
+      security:
+        - petstore_auth:
+            - write:pets
+            - read:pets
+  /store/inventory:
+    get:
+      tags:
+        - store
+      summary: Returns pet inventories by status
+      operationId: getInventory
+      description: Returns a map of status codes to quantities
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+        - api_key: []
+  /store/order:
+    post:
+      tags:
+        - store
+      summary: Place an order for a pet
+      operationId: placeOrder
+      description: Place a new order in the store
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Order"
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/Order"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/Order"
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        405:
+          description: Invalid input
+  /store/order/{orderId}:
+    get:
+      tags:
+        - store
+      summary: Find purchase order by ID
+      operationId: getOrderById
+      description: For valid response try integer IDs with value <= 5 or > 10. Other values will generate exceptions.
+      parameters:
+        - name: orderId
+          description: ID of order that needs to be fetched
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/Order"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Order"
+        400:
+          description: Invalid ID supplied
+        404:
+          description: Order not found
+    delete:
+      tags:
+        - store
+      summary: Delete purchase order by ID
+      operationId: deleteOrder
+      description: For valid response try integer IDs with value < 1000. Anything above 1000 or nonintegers will generate API errors
+      parameters:
+        - name: orderId
+          description: ID of the order that needs to be deleted
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        400:
+          description: Invalid ID supplied
+        404:
+          description: Order not found
+  /user:
+    post:
+      tags:
+        - user
+      summary: Create user
+      operationId: createUser
+      description: This can only be done by the logged in user.
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/User"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/User"
+      responses:
+        default:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+  /user/createWithList:
+    post:
+      tags:
+        - user
+      summary: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      description: Creates list of users with given input array
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                $ref: "#/components/schemas/User"
+      responses:
+        200:
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        default:
+          description: successful operation
+  /user/login:
+    get:
+      tags:
+        - user
+      summary: Logs user into the system
+      operationId: loginUser
+      description: ''
+      parameters:
+        - name: username
+          description: The user name for login
+          in: query
+          required: false
+          schema:
+            type: string
+        - name: password
+          description: The password for login in clear text
+          in: query
+          required: false
+          schema:
+            type: string
+      responses:
+        200:
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        400:
+          description: Invalid username/password supplied
+  /user/logout:
+    get:
+      tags:
+        - user
+      summary: Logs out current logged in user session
+      operationId: logoutUser
+      description: ''
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  /user/{username}:
+    get:
+      tags:
+        - user
+      summary: Get user by user name
+      operationId: getUserByName
+      description: ''
+      parameters:
+        - name: username
+          description: 'The name that needs to be fetched. Use user1 for testing. '
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        200:
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/User"
+            application/json:
+              schema:
+                $ref: "#/components/schemas/User"
+        400:
+          description: Invalid username supplied
+        404:
+          description: User not found
+    put:
+      tags:
+        - user
+      summary: Update user
+      operationId: updateUser
+      description: This can only be done by the logged in user.
+      parameters:
+        - name: username
+          description: name that needs to be updated
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/User"
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/User"
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: "#/components/schemas/User"
+      responses:
+        default:
+          description: successful operation
+    delete:
+      tags:
+        - user
+      summary: Delete user
+      operationId: deleteUser
+      description: This can only be done by the logged in user.
+      parameters:
+        - name: username
+          description: The name that needs to be deleted
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        400:
+          description: Invalid username supplied
+        404:
+          description: User not found
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          enum:
+            - placed
+            - approved
+            - delivered
+          example: approved
+        complete:
+          type: boolean
+      xml:
+        name: order
+    Customer:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          items:
+            $ref: "#/components/schemas/Address"
+          xml:
+            name: addresses
+            wrapped: true
+      xml:
+        name: customer
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: '94301'
+      xml:
+        name: address
+    Category:
+      type: object
+      properties:
+        name:
+          type: string
+          example: Dogs
+        id:
+          type: integer
+          format: int64
+          example: 1
+      xml:
+        name: category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+      xml:
+        name: user
+    Tag:
+      type: object
+      properties:
+        name:
+          type: string
+        id:
+          type: integer
+          format: int64
+      xml:
+        name: tag
+    Pet:
+      type: object
+      required:
+        - name
+        - photoUrls
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: "#/components/schemas/Tag"
+          xml:
+            wrapped: true
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          $ref: "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          items:
+            type: string
+            xml:
+              name: photoUrl
+          xml:
+            wrapped: true
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+            - available
+            - pending
+            - sold
+      xml:
+        name: pet
+    ApiResponse:
+      type: object
+      properties:
+        type:
+          type: string
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+      xml:
+        name: "##default"
+  requestBodies:
+    Pet:
+      description: Pet object that needs to be added to the store
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            $ref: "#/components/schemas/Pet"
+    UserArray:
+      description: List of user object
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              $ref: "#/components/schemas/User"
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore3.swagger.io/oauth/authorize
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      name: api_key
+      type: apiKey
+      in: header

--- a/integration/resources/unformatted.yaml
+++ b/integration/resources/unformatted.yaml
@@ -1,0 +1,803 @@
+info:
+  title: Swagger Petstore - OpenAPI 3.0
+  description: |-
+    This is a sample Pet Store Server based on the OpenAPI 3.0 specification.  You can find out more about
+    Swagger at [http://swagger.io](http://swagger.io). In the third iteration of the pet store, we've switched to the design first approach!
+    You can now help us improve the API whether it's by making changes to the definition itself or to the code.
+    That way, with time, we can improve the API in general, and expose some of the new features in OAS3.
+
+    Some useful links:
+    - [The Pet Store repository](https://github.com/swagger-api/swagger-petstore)
+    - [The source API definition for the Pet Store](https://github.com/swagger-api/swagger-petstore/blob/master/src/main/resources/openapi.yaml)
+  termsOfService: http://swagger.io/terms/
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
+  contact:
+    email: apiteam@swagger.io
+  version: 1.0.19
+openapi: 3.0.2
+externalDocs:
+  description: Find out more about Swagger
+  url: http://swagger.io
+servers:
+- url: "/api/v3"
+tags:
+- name: pet
+  externalDocs:
+    description: Find out more
+    url: http://swagger.io
+  description: Everything about your Pets
+- name: store
+  description: Access to Petstore orders
+  externalDocs:
+    description: Find out more about our store
+    url: http://swagger.io
+- name: user
+  description: Operations about user
+paths:
+  "/pet":
+    post:
+      tags:
+      - pet
+      summary: Add a new pet to the store
+      description: Add a new pet to the store
+      operationId: addPet
+      requestBody:
+        description: Create a new pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          application/xml:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          application/x-www-form-urlencoded:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '405':
+          description: Invalid input
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    put:
+      tags:
+      - pet
+      summary: Update an existing pet
+      description: Update an existing pet by Id
+      operationId: updatePet
+      requestBody:
+        description: Update an existent pet in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          application/xml:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+          application/x-www-form-urlencoded:
+            schema:
+              "$ref": "#/components/schemas/Pet"
+        required: true
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+        '405':
+          description: Validation exception
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  "/pet/findByStatus":
+    get:
+      tags:
+      - pet
+      summary: Finds Pets by status
+      description: Multiple status values can be provided with comma separated strings
+      operationId: findPetsByStatus
+      parameters:
+      - name: status
+        description: Status values that need to be considered for filter
+        required: false
+        explode: true
+        in: query
+        schema:
+          default: available
+          type: string
+          enum:
+          - available
+          - pending
+          - sold
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid status value
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  "/pet/findByTags":
+    get:
+      tags:
+      - pet
+      operationId: findPetsByTags
+      description: Multiple tags can be provided with comma separated strings. Use
+        tag1, tag2, tag3 for testing.
+      summary: Finds Pets by tags
+      parameters:
+      - name: tags
+        in: query
+        description: Tags to filter by
+        required: false
+        explode: true
+        schema:
+          type: array
+          items:
+            type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                type: array
+                items:
+                  "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid tag value
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  "/pet/{petId}":
+    get:
+      summary: Find pet by ID
+      tags:
+      - pet
+      operationId: getPetById
+      description: Returns a single pet
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to return
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Pet"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Pet not found
+      security:
+      - api_key: []
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    post:
+      tags:
+      - pet
+      summary: Updates a pet in the store with form data
+      description: ''
+      operationId: updatePetWithForm
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet that needs to be updated
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: name
+        in: query
+        description: Name of pet that needs to be updated
+        schema:
+          type: string
+      - name: status
+        in: query
+        description: Status of pet that needs to be updated
+        schema:
+          type: string
+      responses:
+        '405':
+          description: Invalid input
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+    delete:
+      tags:
+      - pet
+      summary: Deletes a pet
+      description: ''
+      operationId: deletePet
+      parameters:
+      - name: api_key
+        in: header
+        description: ''
+        required: false
+        schema:
+          type: string
+      - name: petId
+        in: path
+        description: Pet id to delete
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '400':
+          description: Invalid pet value
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  "/pet/{petId}/uploadImage":
+    post:
+      tags:
+      - pet
+      summary: uploads an image
+      description: ''
+      operationId: uploadFile
+      parameters:
+      - name: petId
+        in: path
+        description: ID of pet to update
+        required: true
+        schema:
+          type: integer
+          format: int64
+      - name: additionalMetadata
+        in: query
+        description: Additional Metadata
+        required: false
+        schema:
+          type: string
+      requestBody:
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/ApiResponse"
+      security:
+      - petstore_auth:
+        - write:pets
+        - read:pets
+  "/store/inventory":
+    get:
+      tags:
+      - store
+      summary: Returns pet inventories by status
+      description: Returns a map of status codes to quantities
+      operationId: getInventory
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+                  format: int32
+      security:
+      - api_key: []
+  "/store/order":
+    post:
+      tags:
+      - store
+      summary: Place an order for a pet
+      description: Place a new order in the store
+      operationId: placeOrder
+      requestBody:
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/Order"
+          application/xml:
+            schema:
+              "$ref": "#/components/schemas/Order"
+          application/x-www-form-urlencoded:
+            schema:
+              "$ref": "#/components/schemas/Order"
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '405':
+          description: Invalid input
+  "/store/order/{orderId}":
+    get:
+      tags:
+      - store
+      summary: Find purchase order by ID
+      description: For valid response try integer IDs with value <= 5 or > 10. Other
+        values will generate exceptions.
+      operationId: getOrderById
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of order that needs to be fetched
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/Order"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/Order"
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+    delete:
+      tags:
+      - store
+      summary: Delete purchase order by ID
+      description: For valid response try integer IDs with value < 1000. Anything
+        above 1000 or nonintegers will generate API errors
+      operationId: deleteOrder
+      parameters:
+      - name: orderId
+        in: path
+        description: ID of the order that needs to be deleted
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '400':
+          description: Invalid ID supplied
+        '404':
+          description: Order not found
+  "/user":
+    post:
+      tags:
+      - user
+      summary: Create user
+      description: This can only be done by the logged in user.
+      operationId: createUser
+      requestBody:
+        description: Created user object
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+          application/xml:
+            schema:
+              "$ref": "#/components/schemas/User"
+          application/x-www-form-urlencoded:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        default:
+          description: successful operation
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/User"
+  "/user/createWithList":
+    post:
+      tags:
+      - user
+      summary: Creates list of users with given input array
+      description: Creates list of users with given input array
+      operationId: createUsersWithListInput
+      requestBody:
+        content:
+          application/json:
+            schema:
+              type: array
+              items:
+                "$ref": "#/components/schemas/User"
+      responses:
+        '200':
+          description: Successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/User"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        default:
+          description: successful operation
+  "/user/login":
+    get:
+      tags:
+      - user
+      summary: Logs user into the system
+      description: ''
+      operationId: loginUser
+      parameters:
+      - name: username
+        in: query
+        description: The user name for login
+        required: false
+        schema:
+          type: string
+      - name: password
+        in: query
+        description: The password for login in clear text
+        required: false
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          headers:
+            X-Rate-Limit:
+              description: calls per hour allowed by the user
+              schema:
+                type: integer
+                format: int32
+            X-Expires-After:
+              description: date in UTC when token expires
+              schema:
+                type: string
+                format: date-time
+          content:
+            application/xml:
+              schema:
+                type: string
+            application/json:
+              schema:
+                type: string
+        '400':
+          description: Invalid username/password supplied
+  "/user/logout":
+    get:
+      tags:
+      - user
+      summary: Logs out current logged in user session
+      description: ''
+      operationId: logoutUser
+      parameters: []
+      responses:
+        default:
+          description: successful operation
+  "/user/{username}":
+    get:
+      tags:
+      - user
+      summary: Get user by user name
+      description: ''
+      operationId: getUserByName
+      parameters:
+      - name: username
+        in: path
+        description: 'The name that needs to be fetched. Use user1 for testing. '
+        required: true
+        schema:
+          type: string
+      responses:
+        '200':
+          description: successful operation
+          content:
+            application/xml:
+              schema:
+                "$ref": "#/components/schemas/User"
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/User"
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+    put:
+      tags:
+      - user
+      summary: Update user
+      description: This can only be done by the logged in user.
+      operationId: updateUser
+      parameters:
+      - name: username
+        in: path
+        description: name that needs to be updated
+        required: true
+        schema:
+          type: string
+      requestBody:
+        description: Update an existent user in the store
+        content:
+          application/json:
+            schema:
+              "$ref": "#/components/schemas/User"
+          application/xml:
+            schema:
+              "$ref": "#/components/schemas/User"
+          application/x-www-form-urlencoded:
+            schema:
+              "$ref": "#/components/schemas/User"
+      responses:
+        default:
+          description: successful operation
+    delete:
+      tags:
+      - user
+      summary: Delete user
+      description: This can only be done by the logged in user.
+      operationId: deleteUser
+      parameters:
+      - name: username
+        in: path
+        description: The name that needs to be deleted
+        required: true
+        schema:
+          type: string
+      responses:
+        '400':
+          description: Invalid username supplied
+        '404':
+          description: User not found
+components:
+  schemas:
+    Order:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        petId:
+          type: integer
+          format: int64
+          example: 198772
+        quantity:
+          type: integer
+          format: int32
+          example: 7
+        shipDate:
+          type: string
+          format: date-time
+        status:
+          type: string
+          description: Order Status
+          example: approved
+          enum:
+          - placed
+          - approved
+          - delivered
+        complete:
+          type: boolean
+      xml:
+        name: order
+    Customer:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 100000
+        username:
+          type: string
+          example: fehguy
+        address:
+          type: array
+          xml:
+            name: addresses
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Address"
+      xml:
+        name: customer
+    Address:
+      type: object
+      properties:
+        street:
+          type: string
+          example: 437 Lytton
+        city:
+          type: string
+          example: Palo Alto
+        state:
+          type: string
+          example: CA
+        zip:
+          type: string
+          example: '94301'
+      xml:
+        name: address
+    Category:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 1
+        name:
+          type: string
+          example: Dogs
+      xml:
+        name: category
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        username:
+          type: string
+          example: theUser
+        firstName:
+          type: string
+          example: John
+        lastName:
+          type: string
+          example: James
+        email:
+          type: string
+          example: john@email.com
+        password:
+          type: string
+          example: '12345'
+        phone:
+          type: string
+          example: '12345'
+        userStatus:
+          type: integer
+          description: User Status
+          format: int32
+          example: 1
+      xml:
+        name: user
+    Tag:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+      xml:
+        name: tag
+    Pet:
+      required:
+      - name
+      - photoUrls
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          example: 10
+        name:
+          type: string
+          example: doggie
+        category:
+          "$ref": "#/components/schemas/Category"
+        photoUrls:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            type: string
+            xml:
+              name: photoUrl
+        tags:
+          type: array
+          xml:
+            wrapped: true
+          items:
+            "$ref": "#/components/schemas/Tag"
+        status:
+          type: string
+          description: pet status in the store
+          enum:
+          - available
+          - pending
+          - sold
+      xml:
+        name: pet
+    ApiResponse:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        type:
+          type: string
+        message:
+          type: string
+      xml:
+        name: "##default"
+  requestBodies:
+    Pet:
+      description: Pet object that needs to be added to the store
+      content:
+        application/json:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+        application/xml:
+          schema:
+            "$ref": "#/components/schemas/Pet"
+    UserArray:
+      description: List of user object
+      content:
+        application/json:
+          schema:
+            type: array
+            items:
+              "$ref": "#/components/schemas/User"
+  securitySchemes:
+    petstore_auth:
+      type: oauth2
+      flows:
+        implicit:
+          authorizationUrl: https://petstore3.swagger.io/oauth/authorize
+          scopes:
+            write:pets: modify pets in your account
+            read:pets: read your pets
+    api_key:
+      type: apiKey
+      name: api_key
+      in: header

--- a/internal/transform/format.go
+++ b/internal/transform/format.go
@@ -4,12 +4,343 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"slices"
 
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/speakeasy-api/speakeasy-core/openapi"
 	"gopkg.in/yaml.v3"
 )
+
+// NodeType represents the type of YAML node structure we're dealing with
+type NodeType int
+
+const (
+	RootNode NodeType = iota
+	ComponentsNode
+	PathNode
+	InfoNode
+	OperationNode
+	SchemaNode
+	ResponseNode
+	SecurityNode
+	UrlNode
+	TagNode
+	UnknownNode
+)
+
+func (n NodeType) String() string {
+	return [...]string{
+		"RootNode",
+		"ComponentsNode",
+		"PathNode",
+		"InfoNode",
+		"OperationNode",
+		"SchemaNode",
+		"ResponseNode",
+		"SecurityNode",
+		"UrlNode",
+		"TagNode",
+		"UnknownNode",
+	}[n]
+}
+
+// Define the desired order of keys for different levels
+var rootOrder = []string{
+	"openapi",
+	"info",
+	"externalDocs",
+	"security",
+	"servers",
+	"tags",
+	"paths",
+	"components",
+}
+
+var infoOrder = []string{
+	"title",
+	"version",
+	"summary",
+	"description",
+	"termsOfService",
+	"contact",
+	"license",
+}
+
+var contactOrder = []string{
+	"name",
+	"url",
+	"email",
+}
+
+var componentsOrder = []string{
+	"schemas",
+	"responses",
+	"parameters",
+	"examples",
+	"requestBodies",
+	"headers",
+	"securitySchemes",
+	"links",
+	"callbacks",
+}
+
+var pathOrder = []string{
+	"summary",
+	"description",
+	"servers",
+	"parameters",
+	"get",
+	"post",
+	"put",
+	"delete",
+	"patch",
+	"head",
+	"options",
+	"trace",
+}
+
+var operationOrder = []string{
+	"tags",
+	"summary",
+	"operationId",
+	"description",
+	"externalDocs",
+	"parameters",
+	"requestBody",
+	"responses",
+	"callbacks",
+	"deprecated",
+	"security",
+	"servers",
+}
+
+var schemaOrder = []string{
+	"name",
+	"type",
+	"title",
+	"summary",
+	"description",
+	"in",
+	"$ref",
+	"format",
+	"enum",
+	"default",
+	"multipleOf",
+	"maximum",
+	"exclusiveMaximum",
+	"minimum",
+	"exclusiveMinimum",
+	"maxLength",
+	"minLength",
+	"pattern",
+	"maxItems",
+	"minItems",
+	"uniqueItems",
+	"maxProperties",
+	"minProperties",
+	"required",
+	"properties",
+	"items",
+	"anyOf",
+	"oneOf",
+	"allOf",
+	"not",
+	"additionalProperties",
+	"example",
+	"examples",
+	"deprecated",
+}
+
+var responseOrder = []string{
+	"description",
+	"headers",
+	"content",
+	"links",
+}
+
+var securityOrder = []string{
+	"type",
+	"description",
+	"name",
+	"in",
+	"scheme",
+	"bearerFormat",
+	"flows",
+	"openIdConnectUrl",
+}
+
+var parameterOrder = []string{
+	"name",
+	"in",
+	"description",
+	"required",
+	"deprecated",
+	"allowEmptyValue",
+	"style",
+	"explode",
+	"allowReserved",
+	"schema",
+	"example",
+	"examples",
+	"content",
+}
+
+var requestBodyOrder = []string{
+	"description",
+	"content",
+	"required",
+}
+
+var headerOrder = []string{
+	"description",
+	"required",
+	"deprecated",
+	"allowEmptyValue",
+	"style",
+	"explode",
+	"schema",
+	"example",
+	"examples",
+	"content",
+}
+
+var tagOrder = []string{
+	"name",
+	"description",
+	"externalDocs",
+}
+
+var urlOrder = []string{
+	"name",
+	"identifier",
+	"url",
+	"description",
+	"variables",
+	"email",
+}
+
+var unknownOrder = []string{}
+
+// Orders contains the order of keys for each node type
+type Orders struct {
+	rootOrder        []string
+	infoOrder        []string
+	contactOrder     []string
+	componentsOrder  []string
+	pathOrder        []string
+	operationOrder   []string
+	schemaOrder      []string
+	responseOrder    []string
+	securityOrder    []string
+	parameterOrder   []string
+	requestBodyOrder []string
+	headerOrder      []string
+	tagOrder         []string
+	urlOrder         []string
+	unknownOrder     []string
+}
+
+var orders = Orders{
+	rootOrder:        rootOrder,
+	infoOrder:        infoOrder,
+	contactOrder:     contactOrder,
+	componentsOrder:  componentsOrder,
+	pathOrder:        pathOrder,
+	operationOrder:   operationOrder,
+	schemaOrder:      schemaOrder,
+	responseOrder:    responseOrder,
+	securityOrder:    securityOrder,
+	parameterOrder:   parameterOrder,
+	requestBodyOrder: requestBodyOrder,
+	headerOrder:      headerOrder,
+	tagOrder:         tagOrder,
+	urlOrder:         urlOrder,
+	unknownOrder:     unknownOrder,
+}
+
+// NodeTypeIdentifier contains sets of keys that identify different node types
+var NodeTypeIdentifier = struct {
+	httpMethods         []string
+	tagKeys             []string
+	schemaKeys          []string
+	operationKeys       []string
+	securityKeys        []string
+	uniqueSecurityKeys  []string
+	componentKeys       []string
+	uniqueComponentKeys []string
+	responseKeys        []string
+}{
+	httpMethods:         []string{"get", "put", "post", "delete", "options", "head", "patch", "trace"},
+	tagKeys:             []string{"name", "description", "externalDocs"},
+	schemaKeys:          []string{"$ref", "type", "properties", "items", "required", "additionalProperties"},
+	operationKeys:       []string{"operationId", "requestBody", "responses", "parameters", "tags"},
+	securityKeys:        []string{"type", "scheme", "flows", "bearerFormat", "openIdConnectUrl"},
+	uniqueSecurityKeys:  []string{"flows", "bearerFormat", "openIdConnectUrl"},
+	componentKeys:       []string{"schemas", "responses", "parameters", "examples", "requestBodies", "headers", "securitySchemes", "links", "callbacks"},
+	uniqueComponentKeys: []string{"schemas", "securitySchemes", "pathItems"},
+	responseKeys:        []string{"content", "headers"},
+}
+
+// determineNodeType returns the appropriate NodeType based on the keys present
+func determineNodeType(keys []string) NodeType {
+	switch {
+	// Root level identifiers
+	case slices.Contains(keys, "openapi"):
+		return RootNode
+
+	// Operation objects
+	case containsAny(keys, NodeTypeIdentifier.operationKeys) && !containsAny(keys, NodeTypeIdentifier.uniqueComponentKeys):
+		return OperationNode
+
+	// Components section
+	case containsAny(keys, NodeTypeIdentifier.componentKeys):
+		return ComponentsNode
+
+	// URL-based nodes (servers, externalDocs, and license)
+	case (slices.Contains(keys, "url")):
+		return UrlNode
+
+	// Path operations
+	case containsAny(keys, NodeTypeIdentifier.httpMethods):
+		return PathNode
+
+	// Schema definitions
+	case containsAny(keys, NodeTypeIdentifier.schemaKeys) && !containsAny(keys, NodeTypeIdentifier.uniqueSecurityKeys):
+		return SchemaNode
+
+	// Info objects
+	case (slices.Contains(keys, "version") || slices.Contains(keys, "title")) &&
+		!containsAny(keys, NodeTypeIdentifier.httpMethods):
+		return InfoNode
+
+	// Response objects
+	case slices.Contains(keys, "description") &&
+		containsAny(keys, NodeTypeIdentifier.responseKeys):
+		return ResponseNode
+
+	// Security objects
+	case containsAny(keys, NodeTypeIdentifier.securityKeys):
+		return SecurityNode
+
+	// Tag objects
+	case containsAny(keys, NodeTypeIdentifier.tagKeys):
+		return TagNode
+
+	default:
+		return UnknownNode
+	}
+}
+
+// containsAny returns true if slice contains any of the target values
+func containsAny(slice, targets []string) bool {
+	for _, target := range targets {
+		if slices.Contains(slice, target) {
+			return true
+		}
+	}
+	return false
+}
 
 func FormatDocument(ctx context.Context, schemaPath string, yamlOut bool, w io.Writer) error {
 	return transformer[interface{}]{
@@ -33,33 +364,10 @@ func FormatFromReader(ctx context.Context, schema io.Reader, schemaPath string, 
 func Format(ctx context.Context, doc libopenapi.Document, model *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
 	root := model.Index.GetRootNode()
 
-	// Define the desired order of keys for different levels
-	rootOrder := []string{
-		"openapi",
-		"info",
-		"security",
-		"servers",
-		"paths",
-		"components",
-		"tags",
+	if err := walkAndReorderNodes(ctx, root); err != nil {
+		return doc, model, fmt.Errorf("failed to reorder nodes: %w", err)
 	}
 
-	componentsOrder := []string{
-		"securitySchemes",
-		"schemas",
-		"responses",
-		"requestBodies",
-		"parameters",
-		"examples",
-		"headers",
-		"links",
-		"callbacks",
-	}
-
-	// Walk through and reorder all mapping nodes
-	walkAndReorderNodes(ctx, root, rootOrder, componentsOrder)
-
-	// Render and reload the document to ensure that the changes are reflected in the model
 	updatedDoc, err := yaml.Marshal(root)
 	if err != nil {
 		return doc, model, fmt.Errorf("failed to marshal document: %w", err)
@@ -73,44 +381,86 @@ func Format(ctx context.Context, doc libopenapi.Document, model *libopenapi.Docu
 	return *docNew, model, nil
 }
 
-func walkAndReorderNodes(ctx context.Context, node *yaml.Node, rootOrder, componentsOrder []string) {
-	if node == nil {
-		return
+func walkAndReorderNodes(ctx context.Context, node *yaml.Node) error {
+	if node == nil || ctx.Err() != nil {
+		return ctx.Err()
 	}
 
-	if node.Kind == yaml.MappingNode {
-		// Determine which order to use based on the context
-		orderToUse := rootOrder
-		if len(node.Content) > 0 {
-			// Check if this is the components section
-			if node.Content[0].Value == "components" {
-				orderToUse = componentsOrder
+	// Handle document nodes by processing their content
+	if node.Kind == yaml.DocumentNode {
+		for _, child := range node.Content {
+			if err := walkAndReorderNodes(ctx, child); err != nil {
+				return err
 			}
 		}
-
-		reorderYAMLNode(node, orderToUse)
+		return nil
 	}
 
-	// Recursively process all child nodes
+	// Only attempt to reorder mapping nodes
+	if node.Kind == yaml.MappingNode {
+		// Extract original keys
+		originalKeys := make([]string, 0, len(node.Content)/2)
+		for i := 0; i < len(node.Content); i += 2 {
+			originalKeys = append(originalKeys, node.Content[i].Value)
+		}
+
+		// Determine order and reorder node
+		nodeType := determineNodeType(originalKeys)
+		orderToUse := getOrderForType(nodeType, orders)
+		if err := reorderYAMLNode(node, originalKeys, orderToUse); err != nil {
+			return fmt.Errorf("failed to reorder node: %w", err)
+		}
+	}
+
+	// Recursively process children for all node types
 	for _, child := range node.Content {
-		walkAndReorderNodes(ctx, child, rootOrder, componentsOrder)
+		if err := walkAndReorderNodes(ctx, child); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func getOrderForType(nodeType NodeType, orders Orders) []string {
+	switch nodeType {
+	case RootNode:
+		return orders.rootOrder
+	case ComponentsNode:
+		return orders.componentsOrder
+	case PathNode:
+		return orders.pathOrder
+	case InfoNode:
+		return orders.infoOrder
+	case OperationNode:
+		return orders.operationOrder
+	case SchemaNode:
+		return orders.schemaOrder
+	case ResponseNode:
+		return orders.responseOrder
+	case SecurityNode:
+		return orders.securityOrder
+	case UrlNode:
+		return orders.urlOrder
+	case TagNode:
+		return orders.tagOrder
+	default:
+		return orders.rootOrder
 	}
 }
 
-func reorderYAMLNode(node *yaml.Node, order []string) error {
+func reorderYAMLNode(node *yaml.Node, originalKeys []string, order []string) error {
 	if node.Kind != yaml.MappingNode {
 		return fmt.Errorf("node is not a map")
 	}
 
 	// Create a map to hold key-value pairs by key
 	kvMap := make(map[string]*yaml.Node)
-	// Keep track of original keys to handle unknown ones
-	originalKeys := make([]string, 0)
+
 	for i := 0; i < len(node.Content); i += 2 {
 		keyNode := node.Content[i]
 		valueNode := node.Content[i+1]
 		kvMap[keyNode.Value] = valueNode
-		originalKeys = append(originalKeys, keyNode.Value)
 	}
 
 	// Clear the current Content slice

--- a/internal/transform/format.go
+++ b/internal/transform/format.go
@@ -13,36 +13,49 @@ import (
 )
 
 // NodeType represents the type of YAML node structure we're dealing with
-type NodeType int
+type NodeType string
 
 const (
-	RootNode NodeType = iota
-	ComponentsNode
-	PathNode
-	InfoNode
-	OperationNode
-	SchemaNode
-	ResponseNode
-	SecurityNode
-	UrlNode
-	TagNode
-	UnknownNode
+	RootNode       NodeType = "RootNode"
+	ComponentsNode NodeType = "ComponentsNode"
+	PathNode       NodeType = "PathNode"
+	InfoNode       NodeType = "InfoNode"
+	OperationNode  NodeType = "OperationNode"
+	SchemaNode     NodeType = "SchemaNode"
+	ResponseNode   NodeType = "ResponseNode"
+	SecurityNode   NodeType = "SecurityNode"
+	UrlNode        NodeType = "UrlNode"
+	TagNode        NodeType = "TagNode"
+	UnknownNode    NodeType = "UnknownNode"
 )
 
 func (n NodeType) String() string {
-	return [...]string{
-		"RootNode",
-		"ComponentsNode",
-		"PathNode",
-		"InfoNode",
-		"OperationNode",
-		"SchemaNode",
-		"ResponseNode",
-		"SecurityNode",
-		"UrlNode",
-		"TagNode",
-		"UnknownNode",
-	}[n]
+	switch n {
+	case RootNode:
+		return "RootNode"
+	case ComponentsNode:
+		return "ComponentsNode"
+	case PathNode:
+		return "PathNode"
+	case InfoNode:
+		return "InfoNode"
+	case OperationNode:
+		return "OperationNode"
+	case SchemaNode:
+		return "SchemaNode"
+	case ResponseNode:
+		return "ResponseNode"
+	case SecurityNode:
+		return "SecurityNode"
+	case UrlNode:
+		return "UrlNode"
+	case TagNode:
+		return "TagNode"
+	case UnknownNode:
+		return "UnknownNode"
+	default:
+		return "UnknownNode"
+	}
 }
 
 // Define the desired order of keys for different levels

--- a/internal/transform/format.go
+++ b/internal/transform/format.go
@@ -1,0 +1,142 @@
+package transform
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/pb33f/libopenapi"
+	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
+	"github.com/speakeasy-api/speakeasy-core/openapi"
+	"gopkg.in/yaml.v3"
+)
+
+func FormatDocument(ctx context.Context, schemaPath string, yamlOut bool, w io.Writer) error {
+	return transformer[interface{}]{
+		schemaPath:  schemaPath,
+		transformFn: Format,
+		w:           w,
+		jsonOut:     !yamlOut,
+	}.Do(ctx)
+}
+
+func FormatFromReader(ctx context.Context, schema io.Reader, schemaPath string, w io.Writer, yamlOut bool) error {
+	return transformer[interface{}]{
+		r:           schema,
+		schemaPath:  schemaPath,
+		transformFn: Format,
+		w:           w,
+		jsonOut:     !yamlOut,
+	}.Do(ctx)
+}
+
+func Format(ctx context.Context, doc libopenapi.Document, model *libopenapi.DocumentModel[v3.Document], _ interface{}) (libopenapi.Document, *libopenapi.DocumentModel[v3.Document], error) {
+	root := model.Index.GetRootNode()
+
+	// Define the desired order of keys for different levels
+	rootOrder := []string{
+		"openapi",
+		"info",
+		"security",
+		"servers",
+		"paths",
+		"components",
+		"tags",
+	}
+
+	componentsOrder := []string{
+		"securitySchemes",
+		"schemas",
+		"responses",
+		"requestBodies",
+		"parameters",
+		"examples",
+		"headers",
+		"links",
+		"callbacks",
+	}
+
+	// Walk through and reorder all mapping nodes
+	walkAndReorderNodes(ctx, root, rootOrder, componentsOrder)
+
+	// Render and reload the document to ensure that the changes are reflected in the model
+	updatedDoc, err := yaml.Marshal(root)
+	if err != nil {
+		return doc, model, fmt.Errorf("failed to marshal document: %w", err)
+	}
+
+	docNew, model, err := openapi.Load(updatedDoc, doc.GetConfiguration().BasePath)
+	if err != nil {
+		return doc, model, fmt.Errorf("failed to reload document: %w", err)
+	}
+
+	return *docNew, model, nil
+}
+
+func walkAndReorderNodes(ctx context.Context, node *yaml.Node, rootOrder, componentsOrder []string) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.MappingNode {
+		// Determine which order to use based on the context
+		orderToUse := rootOrder
+		if len(node.Content) > 0 {
+			// Check if this is the components section
+			if node.Content[0].Value == "components" {
+				orderToUse = componentsOrder
+			}
+		}
+
+		reorderYAMLNode(node, orderToUse)
+	}
+
+	// Recursively process all child nodes
+	for _, child := range node.Content {
+		walkAndReorderNodes(ctx, child, rootOrder, componentsOrder)
+	}
+}
+
+func reorderYAMLNode(node *yaml.Node, order []string) error {
+	if node.Kind != yaml.MappingNode {
+		return fmt.Errorf("node is not a map")
+	}
+
+	// Create a map to hold key-value pairs by key
+	kvMap := make(map[string]*yaml.Node)
+	// Keep track of original keys to handle unknown ones
+	originalKeys := make([]string, 0)
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		valueNode := node.Content[i+1]
+		kvMap[keyNode.Value] = valueNode
+		originalKeys = append(originalKeys, keyNode.Value)
+	}
+
+	// Clear the current Content slice
+	node.Content = []*yaml.Node{}
+
+	// First, append key-value pairs in the specified order
+	for _, key := range order {
+		if valueNode, ok := kvMap[key]; ok {
+			node.Content = append(node.Content, &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: key,
+			}, valueNode)
+			// Remove from kvMap to track what's been processed
+			delete(kvMap, key)
+		}
+	}
+
+	// Then append any remaining keys that weren't in the order slice
+	for _, key := range originalKeys {
+		if valueNode, ok := kvMap[key]; ok {
+			node.Content = append(node.Content, &yaml.Node{
+				Kind:  yaml.ScalarNode,
+				Value: key,
+			}, valueNode)
+		}
+	}
+
+	return nil
+}

--- a/internal/transform/format_test.go
+++ b/internal/transform/format_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pb33f/libopenapi"
 	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
 )
 
 func TestFormat(t *testing.T) {
@@ -38,6 +39,15 @@ func TestFormat(t *testing.T) {
 	testOutput.ReadFrom(reader)
 	require.NoError(t, err)
 
+	var actual yaml.Node
+	var expected yaml.Node
+
+	err = yaml.Unmarshal(testInput.Bytes(), &actual)
+	require.NoError(t, err)
+
+	err = yaml.Unmarshal(testOutput.Bytes(), &expected)
+	require.NoError(t, err)
+
 	// Require the pre-formatted spec matches the expected spec
-	require.Equal(t, string(testOutput.String()), string(testInput.String()))
+	require.Equal(t, expected, actual)
 }

--- a/internal/transform/format_test.go
+++ b/internal/transform/format_test.go
@@ -1,0 +1,43 @@
+package transform
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"os"
+	"testing"
+
+	"github.com/pb33f/libopenapi"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFormat(t *testing.T) {
+	// Create a buffer to store the formatted spec
+	var testInput bytes.Buffer
+	var testOutput bytes.Buffer
+
+	// Call FormatDocument to format the spec
+	err := FormatDocument(context.Background(), "../../integration/resources/unformatted.yaml", true, &testInput)
+	require.NoError(t, err)
+
+	// Parse the formatted spec
+	formattedDoc, err := libopenapi.NewDocument(testInput.Bytes())
+	require.NoError(t, err)
+
+	// Check that the formatted spec is valid
+	_, errors := formattedDoc.BuildV3Model()
+	require.Empty(t, errors)
+
+	// Open the spec we expect to see to compare
+	file, err := os.Open("../../integration/resources/formatted.yaml")
+	require.NoError(t, err)
+	defer file.Close()
+
+	// Read the expected spec into a buffer
+	reader := bufio.NewReader(file)
+	testOutput.ReadFrom(reader)
+	require.NoError(t, err)
+
+	// Require the pre-formatted spec matches the expected spec
+	require.Equal(t, string(testOutput.String()), string(testInput.String()))
+}


### PR DESCRIPTION
This pull request introduces a new command to format OpenAPI documents and includes corresponding tests. The most important changes include adding the `formatCmd` command, implementing the `runFormat` function, and creating tests to ensure the formatting works correctly.

### New command for formatting OpenAPI documents:

* [`cmd/openapi/transform.go`](diffhunk://#diff-f618debf6dbd5b8b72bdb3a3772aff1757bd578d0810643b6821fb87c7c6f864R5-R17): Added the `formatCmd` command to the `transformCmd` command group, which formats an OpenAPI document to be more human-readable. [[1]](diffhunk://#diff-f618debf6dbd5b8b72bdb3a3772aff1757bd578d0810643b6821fb87c7c6f864R5-R17) [[2]](diffhunk://#diff-f618debf6dbd5b8b72bdb3a3772aff1757bd578d0810643b6821fb87c7c6f864R80-R87)
* [`cmd/openapi/transform.go`](diffhunk://#diff-f618debf6dbd5b8b72bdb3a3772aff1757bd578d0810643b6821fb87c7c6f864R118-R127): Implemented the `runFormat` function to handle the logic for the new `formatCmd` command.

### Tests for the new format command:

* [`internal/transform/format_test.go`](diffhunk://#diff-9511b86f9ed3a81e745007649f568b02e25a674c9c43e729263a857331b45352R1-R53): Added tests to verify the behavior of the new `formatCmd` command, ensuring that the formatted OpenAPI document matches the expected output.