### PR TITLE
fix: properly output json in run when requested

### DIFF
--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -3,7 +3,9 @@ package integration_tests
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -400,6 +402,23 @@ func TestSpecWorkflows(t *testing.T) {
 				"/pet/findByStatus",
 			},
 		},
+		{
+			name:      "test simple json conversion",
+			inputDocs: []string{"part1.yaml"},
+			out:       "output.json",
+			expectedPaths: []string{
+				"/pet/findByTags",
+			},
+		},
+		{
+			name:      "test json conversion with overlay",
+			inputDocs: []string{"part1.yaml"},
+			overlays:  []string{"renameOperationOverlay.yaml"},
+			out:       "output.json",
+			expectedPaths: []string{
+				"/pet/findByTags",
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -480,6 +499,10 @@ func TestSpecWorkflows(t *testing.T) {
 						t.Errorf("Unexpected path %s found in output document", path)
 					}
 				}
+			}
+
+			if !utils.HasYAMLExt(tt.out) {
+				require.True(t, json.Valid(content))
 			}
 		})
 	}


### PR DESCRIPTION
Now we will properly convert to json during `run` if `output: ` has a `.json` extension

https://linear.app/speakeasy/issue/SPE-4451/request-output-in-json-format-instead-of-yaml