### PR TITLE
feat: Initial test command

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -83,6 +83,7 @@ func Init(version, artifactArch string) {
 	mergeInit()
 	addCommand(rootCmd, overlayCmd)
 	addCommand(rootCmd, suggestCmd)
+	addCommand(rootCmd, testCmd)
 	addCommand(rootCmd, defaultCodeSamplesCmd)
 	updateInit(version, artifactArch)
 	proxyInit()

--- a/cmd/testcmd.go
+++ b/cmd/testcmd.go
@@ -1,0 +1,84 @@
+package cmd
+
+import (
+	"context"
+
+	"github.com/speakeasy-api/speakeasy/internal/model"
+	"github.com/speakeasy-api/speakeasy/internal/model/flag"
+	"github.com/speakeasy-api/speakeasy/internal/testcmd"
+)
+
+// testCmd is the command for running target tests.
+var testCmd = &model.ExecutableCommand[testCmdFlags]{
+	Usage:            "test",
+	Short:            "For each workflow target, starts the mock API server and runs testing.",
+	Run:              testCmdRun,
+	RunInteractive:   testCmdRunInteractive,
+	RequiresAuth:     true,
+	UsesWorkflowFile: true,
+	Flags: []flag.Flag{
+		flag.BooleanFlag{
+			Name:        "disable-mockserver",
+			Description: "Skips starting the target testing mock API server before running tests.",
+		},
+		flag.BooleanFlag{
+			Name:        "pinned",
+			Description: "Run using the current CLI version instead of the version specified in the workflow file.",
+			Hidden:      true,
+		},
+		flag.StringFlag{
+			Name:        "target",
+			Shorthand:   "t",
+			Description: "Specify a single workflow target to run testing. Defaults to all targets. Use 'all' to explicitly run all targets.",
+		},
+		flag.BooleanFlag{
+			Name:        "verbose",
+			Description: "Verbose output.",
+		},
+	},
+}
+
+// testCmdFlags stores the testCmd flags values.
+type testCmdFlags struct {
+	DisableMockserver bool   `json:"disable-mockserver"`
+	Pinned            bool   `json:"pinned"`
+	Target            string `json:"target"`
+	Verbose           bool   `json:"verbose"`
+}
+
+// Non-interactive command logic for testCmd.
+func testCmdRun(ctx context.Context, flags testCmdFlags) error {
+	runnerOpts := testCmdRunnerOpts(flags)
+	runner := testcmd.NewRunner(ctx, runnerOpts...)
+
+	return runner.Run(ctx)
+}
+
+// Interactive command logic for testCmd.
+func testCmdRunInteractive(ctx context.Context, flags testCmdFlags) error {
+	runnerOpts := testCmdRunnerOpts(flags)
+	runner := testcmd.NewRunner(ctx, runnerOpts...)
+
+	if flags.Verbose {
+		return runner.Run(ctx)
+	}
+
+	return runner.RunWithVisualization(ctx)
+}
+
+// Returns the test command runner options based on the flags.
+func testCmdRunnerOpts(flags testCmdFlags) []testcmd.RunnerOpt {
+	runnerOpts := []testcmd.RunnerOpt{
+		testcmd.WithWorkflowTarget(flags.Target),
+	}
+
+	if flags.DisableMockserver {
+		runnerOpts = append(runnerOpts, testcmd.WithDisableMockserver())
+	}
+
+	if flags.Verbose {
+		runnerOpts = append(runnerOpts, testcmd.WithVerboseOutput())
+	}
+
+	return runnerOpts
+}

--- a/internal/charm/styles/styles.go
+++ b/internal/charm/styles/styles.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/errors"
+	"github.com/speakeasy-api/speakeasy/internal/env"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"golang.org/x/term"
 )
@@ -189,4 +190,14 @@ func RenderKeymapLegend(keys []string, descriptions []string) string {
 		s += key + " " + Dimmed.Render(descriptions[i]) + "  "
 	}
 	return s
+}
+
+// Renders the support@speakeasy.com email address with emphasis for interactive
+// output and as a normal string in GitHub Actions.
+func RenderSupportEmail() string {
+	if env.IsGithubAction() {
+		return "support@speakeasy.com"
+	}
+
+	return Emphasized.Render("support@speakeasy.com")
 }

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -28,3 +28,9 @@ func GoArch() string {
 func IsLocalDev() bool {
 	return os.Getenv("SPEAKEASY_ENVIRONMENT") == "local"
 }
+
+// Returns the SPEAKEASY_RUN_LOCATION environment variable value. For example,
+// this is set by Speakeasy maintained GitHub Actions to "action".
+func SpeakeasyRunLocation() string {
+	return os.Getenv("SPEAKEASY_RUN_LOCATION")
+}

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -18,6 +18,7 @@ import (
 	"github.com/speakeasy-api/speakeasy-core/access"
 	"github.com/speakeasy-api/speakeasy-core/events"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/env"
 
 	changelog "github.com/speakeasy-api/openapi-generation/v2"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -106,7 +107,7 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 		}, fmt.Errorf("failed to get schema contents: %w", err)
 	}
 
-	runLocation := os.Getenv("SPEAKEASY_RUN_LOCATION")
+	runLocation := env.SpeakeasyRunLocation()
 	if runLocation == "" {
 		runLocation = "cli"
 	}

--- a/internal/testcmd/runner.go
+++ b/internal/testcmd/runner.go
@@ -1,0 +1,242 @@
+package testcmd
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+	"github.com/speakeasy-api/speakeasy-core/auth"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/env"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/utils"
+	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
+)
+
+// Runner is a struct that contains the options and internal state for the test
+// command.
+type Runner struct {
+	// When enabled, skips starting the target testing mock API server before
+	// running tests.
+	disableMockserver bool
+
+	// Directory of the discovered workflow configuration project directory.
+	// This directory will be joined with workflow target output directory
+	// in the workflow configuration, if set.
+	projectDir string
+
+	// When enabled, outputs verbose output from the generator.
+	verboseOutput bool
+
+	// Discovered workflow configuration.
+	workflow *workflow.Workflow
+
+	// Name of the workflow target to run testing against. Defaults to all
+	// targets when an empty string.
+	workflowTarget string
+
+	// Enhanced CLI visualization tracker for the workflow.
+	workflowTracker *workflowTracking.WorkflowStep
+}
+
+// NewRunner creates a new Runner with the given options.
+func NewRunner(ctx context.Context, opts ...RunnerOpt) *Runner {
+	// Defaults
+	r := &Runner{
+		workflowTracker: workflowTracking.NewWorkflowStep("Workflow Testing", log.From(ctx), nil),
+	}
+
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	return r
+}
+
+// Run loads the workflow, loads the generator, and runs target testing.
+func (r *Runner) Run(ctx context.Context) error {
+	if err := r.checkAccountType(ctx); err != nil {
+		return err
+	}
+
+	if err := r.loadWorkflow(); err != nil {
+		return err
+	}
+
+	if err := r.runWorkflowTargetTesting(ctx); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// RunWithVisualization calls Run with enhanced CLI visualizations. The full
+// logs are captured and only displayed if there is an error.
+func (r *Runner) RunWithVisualization(ctx context.Context) error {
+	logger := log.From(ctx)
+
+	// Swallow but retain the logs to be displayed later, upon failure
+	logCaptureBuffer := new(bytes.Buffer)
+	logCapture := logger.WithWriter(logCaptureBuffer)
+	updatesChannel := make(chan workflowTracking.UpdateMsg)
+
+	r.workflowTracker = workflowTracking.NewWorkflowStep("Workflow Testing", logCapture, updatesChannel)
+
+	var runErr error
+
+	runFnCli := func() error {
+		runCtx := log.With(ctx, logCapture)
+		runErr = r.Run(runCtx)
+
+		r.workflowTracker.Finalize(runErr == nil)
+
+		return runErr
+	}
+
+	err := r.workflowTracker.RunWithVisualization(runFnCli, updatesChannel)
+
+	if err != nil {
+		logger.Errorf("Workflow testing failed: %s", err)
+	}
+
+	// Display error logs if the workflow failed
+	if runErr != nil {
+		logger.Errorf("Workflow testing failed: %s\n", runErr)
+
+		output := strings.TrimSpace(logCaptureBuffer.String())
+
+		logger.PrintlnUnstyled(styles.MakeSection("Workflow testing run logs", output, styles.Colors.Grey))
+	}
+
+	return errors.Join(err, runErr)
+}
+
+// Checks the account type to ensure testing is enabled.
+func (r *Runner) checkAccountType(ctx context.Context) error {
+	accountType := auth.GetAccountTypeFromContext(ctx)
+
+	if accountType == nil {
+		return fmt.Errorf("Account type not found. Ensure you are logged in via the `speakeasy auth login` command or SPEAKEASY_API_KEY environment variable.")
+	}
+
+	if *accountType != shared.AccountTypeEnterprise {
+		return fmt.Errorf("Testing is not supported on the %s account tier. Contact support@speakeasy.com for more information.", *accountType)
+	}
+
+	return nil
+}
+
+// Discovers the workflow configuration to set the runner project directory and
+// workflow.
+func (r *Runner) loadWorkflow() error {
+	wf, projectDir, err := utils.GetWorkflowAndDir()
+
+	if err != nil || wf == nil {
+		return fmt.Errorf("Unable to load workflow configuration (workflow.yaml): %w", err)
+	}
+
+	r.projectDir = projectDir
+	r.workflow = wf
+
+	return nil
+}
+
+// Prepares and returns the generator instance.
+func (r *Runner) prepareGenerator(ctx context.Context) (*generate.Generator, error) {
+	logger := log.From(ctx)
+	runLocation := env.SpeakeasyRunLocation()
+
+	if runLocation == "" {
+		runLocation = "cli"
+	}
+
+	generatorOpts := []generate.GeneratorOptions{
+		generate.WithDontWrite(),
+		generate.WithLogger(logger.WithFormatter(log.PrefixedFormatter)),
+		generate.WithRunLocation(runLocation),
+	}
+
+	// The generator verbose output option, regardless of given value, also
+	// resets the logger in the generator, so only set when enabled. Otherwise,
+	// output can interleave/format incorrectly.
+	if r.verboseOutput {
+		generatorOpts = append(generatorOpts, generate.WithVerboseOutput(true))
+	}
+
+	generator, err := generate.New(generatorOpts...)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to prepare testing instance: %w", err)
+	}
+
+	return generator, nil
+}
+
+// Runs testing for all given workflow targets.
+func (r *Runner) runWorkflowTargetTesting(ctx context.Context) error {
+	if r.workflowTarget == "" {
+		return r.runAllWorkflowTargetsTesting(ctx)
+	}
+
+	workflowTarget, ok := r.workflow.Targets[r.workflowTarget]
+
+	if !ok {
+		return fmt.Errorf("Workflow target %s not found in configuration.", r.workflowTarget)
+	}
+
+	return r.runSingleWorkflowTargetTesting(ctx, r.workflowTarget, workflowTarget)
+}
+
+// Runs testing for all workflow targets.
+func (r *Runner) runAllWorkflowTargetsTesting(ctx context.Context) error {
+	for workflowTargetName, workflowTarget := range r.workflow.Targets {
+		if err := r.runSingleWorkflowTargetTesting(ctx, workflowTargetName, workflowTarget); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Runs testing for a single workflow target. The output directory is set to
+// the project directory or joined with the target output directory, if set in
+// the workflow configuration.
+func (r *Runner) runSingleWorkflowTargetTesting(ctx context.Context, workflowTargetName string, workflowTarget workflow.Target) error {
+	logger := log.From(ctx)
+	outputDir := r.projectDir
+
+	if workflowTarget.Output != nil && *workflowTarget.Output != "" {
+		outputDir = filepath.Join(r.projectDir, *workflowTarget.Output)
+	}
+
+	targetTracker := r.workflowTracker.NewSubstep(fmt.Sprintf("Target: %s", workflowTargetName))
+
+	logger.Infof("Running target %s (%s) testing...\n", workflowTargetName, workflowTarget.Target)
+
+	logListener := make(chan log.Msg)
+	testingTracker := targetTracker.NewSubstep(fmt.Sprintf("Testing %s Target", utils.CapitalizeFirst(workflowTarget.Target)))
+	go testingTracker.ListenForSubsteps(logListener)
+
+	testingLogger := logger.WithListener(logListener)
+	testingCtx := log.With(ctx, testingLogger)
+
+	generator, err := r.prepareGenerator(testingCtx)
+
+	if err != nil {
+		return err
+	}
+
+	if err := generator.RunTargetTesting(testingCtx, workflowTarget.Target, outputDir); err != nil {
+		return fmt.Errorf("error running workflow target %s (%s) testing: %w", workflowTargetName, workflowTarget.Target, err)
+	}
+
+	targetTracker.SucceedWorkflow()
+
+	return nil
+}

--- a/internal/testcmd/runner.go
+++ b/internal/testcmd/runner.go
@@ -126,7 +126,7 @@ func (r *Runner) checkAccountType(ctx context.Context) error {
 	}
 
 	if *accountType != shared.AccountTypeEnterprise {
-		return fmt.Errorf("Testing is not supported on the %s account tier. Contact support@speakeasy.com for more information.", *accountType)
+		return fmt.Errorf("Testing is not supported on the %s account tier. Contact %s for more information.", *accountType, styles.RenderSupportEmail())
 	}
 
 	return nil

--- a/internal/testcmd/runner_opt.go
+++ b/internal/testcmd/runner_opt.go
@@ -1,0 +1,31 @@
+package testcmd
+
+// RunnerOpt is a function that modifies a Runner.
+type RunnerOpt func(*Runner)
+
+// WithDisableMockserver is an option that skips starting the target testing
+// mock API server.
+func WithDisableMockserver() RunnerOpt {
+	return func(r *Runner) {
+		r.disableMockserver = true
+	}
+}
+
+// WithVerboseOutput is an option that enables verbose output.
+func WithVerboseOutput() RunnerOpt {
+	return func(r *Runner) {
+		r.verboseOutput = true
+	}
+}
+
+// WithWorkflowTarget is an option that specifies a single workflow target to
+// run testing against. If passed "all", all targets will be run.
+func WithWorkflowTarget(workflowTarget string) RunnerOpt {
+	if workflowTarget == "all" {
+		workflowTarget = ""
+	}
+
+	return func(r *Runner) {
+		r.workflowTarget = workflowTarget
+	}
+}


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-778/feature-speakeasy-test-cli-command

This change introduces an initial `speakeasy test` CLI command, which runs workflow target testing such as `go test` for Go and `vitest` for TypeScript. Its output is similar to the `speakeasy run` CLI command including both an interactive mode with enhanced CLI visualization (unless passing the `--verbose` flag) and non-interactive mode. It will return an error status code if the workflow configuration cannot be discovered, if there are test failures as determined by the target testing, or any other process handling errors. The command should support running in GitHub Actions with appropriate CLI version selection, outputs, and error handling.

Future generator enhancements will enable the command to automatically start and stop the mock API server.

```console
$ ~/go/bin/speakeasy test --help
For each workflow target, starts the mock API server and runs testing.

Usage:
  speakeasy test [flags]

Flags:
      --disable-mockserver   Skips starting the target testing mock API server before running tests.
  -h, --help                 help for test
  -t, --target string        Specify a single workflow target to run testing. Defaults to all targets. Use 'all' to explicitly run all targets.
      --verbose              Verbose output.

Global Flags:
      --logLevel string   the log level (available options: [info, warn, error]) (default "info")
```

![CleanShot 2024-11-22 at 01 10 20](https://github.com/user-attachments/assets/80dcdc56-bd77-4378-be55-ffe9769b38dd)
