### PR TITLE
chore: do not store sourcemaps, always include openapi info.version as a tag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -28,7 +28,7 @@ require (
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.28.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.6
-	github.com/speakeasy-api/speakeasy-core v0.16.2
+	github.com/speakeasy-api/speakeasy-core v0.17.0
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -513,8 +513,8 @@ github.com/speakeasy-api/sdk-gen-config v1.28.0 h1:Gm3WqJCxs7ExEJcRVhMsUq2mC7S23
 github.com/speakeasy-api/sdk-gen-config v1.28.0/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.6 h1:Z+4cE9tYJzS7It5r8nFEomk3x39xm0JKwjBFhEFqmrY=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.15.6/go.mod h1:b4fiZ1Wid0JHwwiYqhaPifDwjmC15uiN7A8Cmid+9kw=
-github.com/speakeasy-api/speakeasy-core v0.16.2 h1:rkiNmq1TBZPUUrK16loqmlkF//f2W5QBbfRJdAeZj7c=
-github.com/speakeasy-api/speakeasy-core v0.16.2/go.mod h1:0U4gDvmCjWVzteXXPhdKcktzTwggyHBSU8EvBpgTA7I=
+github.com/speakeasy-api/speakeasy-core v0.17.0 h1:D1XndpDX5nhS0RndAw5o2oqlgIkr0sTScUahmy6jjj8=
+github.com/speakeasy-api/speakeasy-core v0.17.0/go.mod h1:0U4gDvmCjWVzteXXPhdKcktzTwggyHBSU8EvBpgTA7I=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1/go.mod h1:XbzaM0sMjj8bGooz/uEtNkOh1FQiJK7RFuNG3LPBSAU=
 github.com/speakeasy-api/speakeasy-proxy v0.0.2 h1:u4rQ8lXvuYRCSxiLQGb5JxkZRwNIDlyh+pMFYD6OGjA=

--- a/internal/run/sourceTracking.go
+++ b/internal/run/sourceTracking.go
@@ -206,6 +206,8 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 	}
 	annotations.Revision = revision
 	annotations.BundleRoot = strings.TrimPrefix(rootDocumentPath, string(os.PathSeparator))
+	// Always add the openapi document version as a tag
+	tags = append(tags, annotations.Version)
 
 	err = pl.BuildOCIImage(ctx, bundler.NewReadWriteFS(memfs, memfs), &bundler.OCIBuildOptions{
 		Tags:         tags,


### PR DESCRIPTION
1. Should result in less (no?) duplicates in the registry, as those duplicates emerged from the sourcemap and some random strings in filenames, alongside representing full (abs) filenames. If we have a use-case for this we'll re-add it in a different form.
2. info.version (i.e. the openapi document version) should now be always uploaded into the registry as a tag. This makes public URLs more meaningful