### PR TITLE
feat: reset gen lock version retries

### DIFF
--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -305,6 +305,14 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 			_ = log.SendToLogProxy(ctx, log.LogProxyLevelError, msg, nil)
 			logger.PrintfStyled(styles.DimmedItalic, msg)
 			if env.IsGithubAction() {
+				gitCmd := exec.Command("git", "checkout", "--", ".speakeasy/gen.lock")
+				gitCmd.Stdin = os.Stdin
+				gitCmd.Stdout = os.Stdout
+				gitCmd.Stderr = os.Stderr
+
+				if err = gitCmd.Run(); err != nil {
+					logger.PrintfStyled(styles.DimmedItalic, "failed resetting gen.lock to previous state")
+				}
 				githubactions.AddStepSummary("# Speakeasy Version upgrade failure\n" + msg)
 			}
 


### PR DESCRIPTION
Optimistically reset gen.lock when we are retrying a generation with previous version in github actions