### PR TITLE
chore: Use larger runners and disable setup-go caching on Windows for CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,8 @@ permissions:
 jobs:
   release:
     name: Release
-    runs-on: windows-latest-16-cores
+    runs-on:
+      group: windows-latest-large
     steps:
       - name: Setup environment
         run: |-

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,6 +33,8 @@ jobs:
       - uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
+          # Reference: https://github.com/actions/setup-go/issues/495
+          cache: false
       # More assembly might be required: Docker logins, GPG, etc. It all depends
       # on your needs.
       - name: Configure git for private modules

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -2,11 +2,6 @@ name: Validate
 
 on:
   pull_request:
-    types:
-      - opened
-      - reopened
-      - edited
-      - synchronize
 
 jobs:
   build:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -30,7 +30,8 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on:
+      group: "${{ matrix.os }}-large"
 
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
@@ -69,7 +70,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - name: ${{ matrix.test-group }}
-        run: go test -json -v -p 1 ./... | gotestfmt
+      - run: go test -json -v -p 1 ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -36,10 +36,19 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go
+      - name: Set up Go (Linux)
+        if: runner.os == 'Linux'
         uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
         with:
           go-version-file: "go.mod"
+
+      - name: Set up Go (Windows)
+        if: runner.os == 'Windows'
+        uses: actions/setup-go@41dfa10bad2bb2ae585af6ee5bb4d7d973ad74ed # v5.1.0
+        with:
+          go-version-file: "go.mod"
+          # Reference: https://github.com/actions/setup-go/issues/495
+          cache: false
 
       - name: Set up Python
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b # v5.3.0


### PR DESCRIPTION
Reference: https://github.com/actions/setup-go/issues/495

This improves PR testing from >15 minutes to <5 minutes by using larger runners (in runner group so we can tune them without adjusting workflow configuration) and by disabling setup-go caching on Windows. Previously, it could take up to 10 minutes to download and unarchive the setup-go cache on Windows runners due to an acknowledged issue. While this could potentially introduce transient network issues downloading the Go modules from Google's proxies, those issues are generally pretty rare in my experience. We could alternatively change the module cache environment variables on Windows to point at the second hard drive on the runner, but that seemed more likely to break at some point outside our control. Ideally GitHub will fix the setup-go action and we'll just remove the Windows-specific `cache: false` after upgrading.