### PR TITLE
feat: Enable testing in workflows via speakeasy run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -30,6 +30,7 @@ type RunFlags struct {
 	RepoSubdir         string            `json:"repo-subdir"`
 	RepoSubdirs        map[string]string `json:"repo-subdirs"`
 	SkipCompile        bool              `json:"skip-compile"`
+	SkipTesting        bool              `json:"skip-testing"`
 	SkipVersioning     bool              `json:"skip-versioning"`
 	FrozenWorkflowLock bool              `json:"frozen-workflow-lockfile"`
 	Force              bool              `json:"force"`
@@ -107,6 +108,10 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 		flag.BooleanFlag{
 			Name:        "skip-compile",
 			Description: "skip compilation when generating the SDK",
+		},
+		flag.BooleanFlag{
+			Name:        "skip-testing",
+			Description: "skip testing after generating the SDK, if testing is configured in the workflow",
 		},
 		flag.BooleanFlag{
 			Name:         "skip-versioning",
@@ -297,6 +302,7 @@ func askForSource(sources []string) (string, error) {
 var minimalOpts = []run.Opt{
 	run.WithSkipChangeReport(true),
 	run.WithSkipSnapshot(true),
+	run.WithSkipTesting(true),
 	run.WithSkipGenerateLintReport(),
 }
 
@@ -313,6 +319,7 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		run.WithInstallationURLs(flags.InstallationURLs),
 		run.WithDebug(flags.Debug),
 		run.WithShouldCompile(!flags.SkipCompile),
+		run.WithSkipTesting(flags.SkipTesting),
 		run.WithSkipVersioning(flags.SkipVersioning),
 		run.WithVerbose(flags.Verbose),
 		run.WithRegistryTags(flags.RegistryTags),
@@ -367,6 +374,7 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 	opts := []run.Opt{
 		run.WithTarget(flags.Target),
 		run.WithSource(flags.Source),
+		run.WithSkipTesting(flags.SkipTesting),
 		run.WithSkipVersioning(flags.SkipVersioning),
 		run.WithRepo(flags.Repo),
 		run.WithRepoSubDirs(flags.RepoSubdirs),

--- a/internal/run/target.go
+++ b/internal/run/target.go
@@ -201,6 +201,16 @@ func (w *Workflow) runTarget(ctx context.Context, target string) (*SourceResult,
 		targetLock.CodeSamplesRevisionDigest = digest
 	}
 
+	if targetEnablesTesting(t) {
+		testingStep := rootStep.NewSubstep(fmt.Sprintf("Running %s Testing", utils.CapitalizeFirst(t.Target)))
+
+		if w.SkipTesting {
+			testingStep.Skip("explicitly disabled")
+		} else if err := w.runTesting(ctx, target, t, testingStep, outDir); err != nil {
+			return sourceRes, nil, err
+		}
+	}
+
 	rootStep.SucceedWorkflow()
 
 	if sourceLock, ok := w.lockfile.Sources[t.Source]; ok {

--- a/internal/run/testing.go
+++ b/internal/run/testing.go
@@ -1,0 +1,79 @@
+package run
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/speakeasy/internal/env"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/workflowTracking"
+)
+
+// Prepares and returns the target testing generator instance.
+func (w Workflow) prepareTestingGenerator(ctx context.Context) (*generate.Generator, error) {
+	logger := log.From(ctx)
+	runLocation := env.SpeakeasyRunLocation()
+
+	if runLocation == "" {
+		runLocation = "cli"
+	}
+
+	generatorOpts := []generate.GeneratorOptions{
+		generate.WithDontWrite(),
+		generate.WithLogger(logger.WithFormatter(log.PrefixedFormatter)),
+		generate.WithRunLocation(runLocation),
+	}
+
+	// The generator verbose output option, regardless of given value, also
+	// resets the logger in the generator, so only set when enabled. Otherwise,
+	// output can interleave/format incorrectly.
+	if w.Verbose {
+		generatorOpts = append(generatorOpts, generate.WithVerboseOutput(true))
+	}
+
+	generator, err := generate.New(generatorOpts...)
+
+	if err != nil {
+		return nil, fmt.Errorf("Unable to prepare testing instance: %w", err)
+	}
+
+	return generator, nil
+}
+
+// Runs target testing for the given target. Returns an error if the generator
+// setup or testing commands failed.
+func (w Workflow) runTesting(ctx context.Context, workflowTargetName string, target workflow.Target, testingStep *workflowTracking.WorkflowStep, outputDir string) error {
+	logger := log.From(ctx)
+	logListener := make(chan log.Msg)
+
+	go testingStep.ListenForSubsteps(logListener)
+
+	testingLogger := logger.WithListener(logListener)
+	testingCtx := log.With(ctx, testingLogger)
+
+	generator, err := w.prepareTestingGenerator(testingCtx)
+
+	if err != nil {
+		return err
+	}
+
+	if err := generator.RunTargetTesting(testingCtx, target.Target, outputDir); err != nil {
+		return fmt.Errorf("error running workflow target %s (%s) testing: %w", workflowTargetName, target.Target, err)
+	}
+
+	testingStep.SucceedWorkflow()
+
+	return nil
+}
+
+// Returns true if target configuration enables testing.
+func targetEnablesTesting(target workflow.Target) bool {
+	// Testing should only run if the target explicitly has testing enabled.
+	if target.Testing == nil || target.Testing.Enabled == nil {
+		return false
+	}
+
+	return *target.Testing.Enabled
+}

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -3,8 +3,9 @@ package run
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/registry"
 	"time"
+
+	"github.com/speakeasy-api/speakeasy/registry"
 
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
 	"github.com/speakeasy-api/speakeasy-core/events"
@@ -35,6 +36,10 @@ type Workflow struct {
 	RepoSubDirs            map[string]string
 	InstallationURLs       map[string]string
 	RegistryTags           []string
+
+	// Enable if target testing should be explicitly disabled, regardless of the
+	// workflow configuration enabling testing.
+	SkipTesting bool
 
 	// Internal
 	workflowName       string
@@ -215,6 +220,14 @@ func WithSkipCleanup() Opt {
 	}
 }
 
+// Prevents target testing from running even if the workflow configuration
+// enables it.
+func WithSkipTesting(skipTesting bool) Opt {
+	return func(w *Workflow) {
+		w.SkipTesting = skipTesting
+	}
+}
+
 func WithFromQuickstart(fromQuickstart bool) Opt {
 	return func(w *Workflow) {
 		w.FromQuickstart = fromQuickstart
@@ -263,6 +276,7 @@ func (w *Workflow) Clone(ctx context.Context, opts ...Opt) (*Workflow, error) {
 				WithSkipLinting(),
 				WithSkipChangeReport(w.SkipChangeReport),
 				WithSkipSnapshot(w.SkipSnapshot),
+				WithSkipTesting(w.SkipTesting),
 				WithFromQuickstart(w.FromQuickstart),
 				WithRepo(w.Repo),
 				WithRepoSubDirs(w.RepoSubDirs),


### PR DESCRIPTION
Reference: https://linear.app/speakeasy/issue/GEN-779/feature-speakeasy-run-cli-command-support-for-target-testing
Reference: https://www.speakeasy.com/docs/workflow-file-reference#targets

If a workflow configuration (`.speakeasy/workflow.yaml`) target enables testing, e.g.

```yaml
targets:
  TARGET:
    testing:
      enabled: true
```

Then the `speakeasy run` command will now run target testing unless explicitly disabled with the `--skip-testing` flag. Verified the following:

* No/disabled `targets.TARGET.testing.enabled` does not show or run target testing steps
* Test success generates output like the following:

```
│ Workflow - success
│ └─Target: petstore-sdk - success
│   └─Source: sample-source - success
...
│   └─Validating gen.yaml - success
│   └─Generating Go SDK - success
...
│   └─Generating Code Samples - success
...
│   └─Running Go Testing - success
│     └─Setup Environment - success
│     └─Run Target Testing - success
```

* Explicitly disabled testing (`--minimal` / `--skip-testing`)

```
│ Workflow - success
│ └─Target: petstore-sdk - success
...
│   └─Running Go Testing - skipped (explicitly disabled)
```

* Test failures (in this case, test generation not enabled) generates output like the following:

```
│ Workflow - failed
│ └─Target: petstore-sdk - failed
│   └─Source: sample-source - success
...
│   └─Validating gen.yaml - success
│   └─Generating Go SDK - success
...
│   └─Generating Code Samples - success
...
│   └─Running Go Testing - failed
│     └─Setup Environment - success
│     └─Run Target Testing - failed
...

» Running Go Testing...

» Setup Environment...

INFO    Found config file	{"path":"/Users/bflad/src/github.com/bflad/petstore-sdk-go/.speakeasy/gen.yaml"}

» Run Target Testing...

INFO    Running command: go test -count=1 ./tests	{"path":"/Users/bflad/src/github.com/bflad/petstore-sdk-go"}
WARN    failed running commands:

no Go files in /Users/bflad/src/github.com/bflad/petstore-sdk-go/tests
```