### PR TITLE
fix: Prevent errant trial expiry in status command

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -149,7 +149,7 @@ func (m statusModel) Print(ctx context.Context) {
 	accountTypeLine.WriteString("Account Type: ")
 	accountTypeLine.WriteString(m.organization.accountType)
 
-	if m.organization.freeTrialExpiry != nil {
+	if m.organization.accountType == string(shared.AccountTypeFree) && m.organization.freeTrialExpiry != nil {
 		expiryDiff := time.Until(*m.organization.freeTrialExpiry)
 		expiryHours := int64(expiryDiff.Hours()) % 24
 		expiryDays := int64(expiryDiff.Hours() / 24)


### PR DESCRIPTION
Previously would return (legit / errant):

```
Account Type: free (Business Trial Expires: 5 days 2 hours)

Account Type: business (Business Trial Expired)
```

Now will see (legit / corrected):

```
Account Type: free (Business Trial Expires: 5 days 2 hours)

Account Type: business
```