### PR TITLE
chore: validate custom linting rulesets sooner

### DIFF
--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -266,12 +266,12 @@ func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schem
 	}
 
 	if defaultRuleset != "" {
-		lintConfig, _, err := lint.Load([]string{"."})
-		if err != nil {
-			return nil, fmt.Errorf("failed to load .speakeasy/lint.yaml: %w", err)
-		}
-
 		if !slices.Contains(validSpeakeasyRulesets, defaultRuleset) {
+			lintConfig, _, err := lint.Load([]string{"."})
+			if err != nil {
+				return nil, fmt.Errorf("failed to load .speakeasy/lint.yaml: %w", err)
+			}
+
 			if _, ok := lintConfig.Rulesets[defaultRuleset]; !ok {
 				return nil, fmt.Errorf("specified ruleset %s not found in .speakeasy/lint.yaml", defaultRuleset)
 			}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -3,7 +3,9 @@ package validation
 import (
 	"context"
 	"fmt"
+	"github.com/speakeasy-api/sdk-gen-config/lint"
 	"io"
+	"slices"
 	"strings"
 
 	"github.com/speakeasy-api/speakeasy-core/openapi"
@@ -41,6 +43,8 @@ type ValidationResult struct {
 	InvalidOperations []string
 	Report            *reports.ReportResult
 }
+
+var validSpeakeasyRulesets = []string{"speakeasy-recommended", "speakeasy-generation", "speakeasy-openapi", "vacuum", "owasp"}
 
 func ValidateWithInteractivity(ctx context.Context, schemaPath, header, token string, limits *OutputLimits, defaultRuleset, workingDir string, skipGenerateReport bool) (*ValidationResult, error) {
 	logger := log.From(ctx)
@@ -262,6 +266,17 @@ func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schem
 	}
 
 	if defaultRuleset != "" {
+		lintConfig, _, err := lint.Load([]string{"."})
+		if err != nil {
+			return nil, fmt.Errorf("failed to load .speakeasy/lint.yaml: %w", err)
+		}
+
+		if !slices.Contains(validSpeakeasyRulesets, defaultRuleset) {
+			if _, ok := lintConfig.Rulesets[defaultRuleset]; !ok {
+				return nil, fmt.Errorf("specified ruleset %s not found in .speakeasy/lint.yaml", defaultRuleset)
+			}
+		}
+
 		opts = append(opts, generate.WithValidationRuleset(defaultRuleset))
 	}
 


### PR DESCRIPTION
Fixes two issues:
- Before, we would panic when given a ruleset that's missing from `lint.yaml`. We now check earlier for the ruleset and return a nicer error
- There was a longstanding visual issue with `run` output where we would double print every error. This fixes that

![CleanShot 2024-12-18 at 15 20 21@2x](https://github.com/user-attachments/assets/636f4841-725b-439f-9927-b7e3c5f23bbf)
![CleanShot 2024-12-18 at 15 20 34@2x](https://github.com/user-attachments/assets/d4ae6a5a-b7e1-48cf-ad62-425913c84e1f)
