### PR TITLE
feat(nix): Add Nix package configuration to goreleaser.yaml

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -74,6 +74,7 @@ chocolateys:
     release_notes: "https://github.com/speakeasy-api/speakeasy/releases/tag/v{{ .Version }}"
     api_key: "{{ .Env.CHOCOLATEY_API_KEY }}"
     source_repo: "https://push.chocolatey.org/"
+
 winget:
   - name: speakeasy
     publisher: Speakeasy
@@ -108,3 +109,13 @@ winget:
           owner: microsoft
           name: winget-pkgs
           branch: master
+
+nix:
+  - name: speakeasy
+    homepage: https://www.speakeasy.com
+    description: The Speakeasy CLI for interacting with the Speakeasy Platform
+    path: pkgs/speakeasy/default.nix
+    license: Apache-2.0
+    repository:
+      owner: speakeasy-api
+      name: nur


### PR DESCRIPTION
This update introduces a new Nix configuration for the Speakeasy CLI, allowing distribution via Nix package manager. It includes metadata like homepage, description, license, and repository details to ensure proper packaging.

And your "nur" repository: https://github.com/flemzord/nur/tree/master 
