### PR TITLE
fix: bump sdk-gen-config for updated workflow transform validation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -25,7 +25,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi-generation/v2 v2.483.1
 	github.com/speakeasy-api/openapi-overlay v0.9.0
-	github.com/speakeasy-api/sdk-gen-config v1.29.1
+	github.com/speakeasy-api/sdk-gen-config v1.29.2
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.18.1
 	github.com/speakeasy-api/speakeasy-core v0.17.6
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/speakeasy-api/openapi-generation/v2 v2.483.1 h1:+p5ohBYJNg8PPoh162CJW
 github.com/speakeasy-api/openapi-generation/v2 v2.483.1/go.mod h1:tLJiel73xdMx/1tbfWYip4QB5YpeNFpqAdXOQHVVeEg=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
-github.com/speakeasy-api/sdk-gen-config v1.29.1 h1:oi//Zx9cIdL2KClrySYgNVU/ta4oYt8okies5bcQ+wI=
-github.com/speakeasy-api/sdk-gen-config v1.29.1/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
+github.com/speakeasy-api/sdk-gen-config v1.29.2 h1:oHAwd16CblHLrD8a0surblvyVLgk+DZZbjW68OfVzZU=
+github.com/speakeasy-api/sdk-gen-config v1.29.2/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.18.1 h1:6yMA7JQmBrkjsZbP9yEPCKq2xZfieHS47nKCI9DgWVo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.18.1/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
 github.com/speakeasy-api/speakeasy-core v0.17.6 h1:+BglRNsWuwvdWkcuUCsa9k2UrqRXdbUAheZLvSJmLDE=


### PR DESCRIPTION
This pull request includes a minor update to the `go.mod` file to bump the version of the `sdk-gen-config` dependency.

Dependency update:

* [`go.mod`](diffhunk://#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L28-R28): Updated `github.com/speakeasy-api/sdk-gen-config` from version `v1.29.1` to `v1.29.2`.