### PR TITLE
chore: Update documentation generation for website changes

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -29,7 +29,7 @@ func main() {
 
 	exclusionList := []string{
 		filepath.Join(*outDir, "getting-started.mdx"),
-		filepath.Join(*outDir, "_meta.json"),
+		filepath.Join(*outDir, "_meta.tsx"),
 	}
 
 	if _, err := removeDocs(*outDir, exclusionList); err != nil {

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -12,7 +12,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var docSiteRoot = "/docs/speakeasy-cli"
+var docSiteRoot = "/docs/speakeasy-reference/cli"
 
 func GenerateDocs(cmd *cobra.Command, outDir string, docSiteLinks bool) error {
 	docosaurusPositioning := map[string]int{}
@@ -178,7 +178,7 @@ func getDocSiteLink(cmd *cobra.Command) string {
 	fullPath := strings.TrimPrefix(strings.TrimPrefix(cmd.CommandPath(), cmd.Root().Name()), " ")
 
 	if strings.TrimSpace(fullPath) == "" {
-		return docSiteRoot
+		return docSiteRoot + "/getting-started"
 	}
 
 	return fmt.Sprintf("%s/%s", docSiteRoot, strings.ReplaceAll(fullPath, " ", "/"))


### PR DESCRIPTION
Reference: https://github.com/speakeasy-api/speakeasy-registry/pull/3360

The current script would make now-unexpected changes to the website given upstream changes. Verified these updates by running locally with the same command given to the website PR generation and reviewing the difference.