### PR TITLE
chore: dependencies, and SDK fixes - Clarified `Strategy` field usage…

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi-generation/v2 v2.486.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.486.6
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.29.4
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.18.1

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.5 h1:a3Uy2gCvgrjY4iV79GNVZ6HZjUCFkB6wZPcSYBr27s0=
 github.com/speakeasy-api/openapi v0.1.5/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.486.1 h1:JJJDI8d6tpRb5JKDojbQAE3pcIk+MFyg9OT9az3y6is=
-github.com/speakeasy-api/openapi-generation/v2 v2.486.1/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
+github.com/speakeasy-api/openapi-generation/v2 v2.486.6 h1:u4RyWHJtM3d8bnt2X3lzqGsWTYAqs/Eh84i6zgXOlfc=
+github.com/speakeasy-api/openapi-generation/v2 v2.486.6/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.29.4 h1:db/wcOxguX/OXHp9USNJ56JRTXB4f6WWi92QyGW0pAs=


### PR DESCRIPTION
… in Go SDK Retry Config. - Bumped `phpstan` from 1.x to 2.1.0 with necessary fixes. - Fixed Python SDK deprecation annotations for `TypeAliasType` and resolved conflicts with the `models` package and fields named `bytes`. - Added unit tests for validating enum default values in problematic OpenAPI descriptions.