### PR TITLE
feat: add billing activate-webhooks command

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      - uses: webiny/action-conventional-commits@8bc41ff4e7d423d56fa4905f6ff79209a78776c7 # v1.3.0
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build:
-    name: Conventional Commits
+    name: Conventional pull request names
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -25,7 +25,6 @@ var activateWebhooksCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		logger := log.From(cmd.Context())
 
-		// Show warning and confirmation prompt
 		logger.Println(styles.RenderWarningMessage(
 			"Webhooks are a paid feature",
 			"Activating webhooks will enable billing for this feature",
@@ -50,7 +49,6 @@ var activateWebhooksCmd = &cobra.Command{
 			return nil
 		}
 
-		// Load the SDK generation config
 		workingDir, err := os.Getwd()
 		if err != nil {
 			return fmt.Errorf("failed to get working directory: %w", err)
@@ -60,17 +58,13 @@ var activateWebhooksCmd = &cobra.Command{
 			return fmt.Errorf("failed to load SDK generation config: %w", err)
 		}
 
-		// Track if we found any languages to update
 		updated := false
 
-		// Enable webhooks for each configured language
 		for _, lang := range cfg.Config.Languages {
-			// Create webhooks config if it doesn't exist
 			if lang.Cfg["webhooks"] == nil {
 				lang.Cfg["webhooks"] = map[string]any{}
 			}
 
-			// Enable webhooks
 			lang.Cfg["webhooks"].(map[string]any)["enabled"] = true
 			updated = true
 		}
@@ -79,7 +73,6 @@ var activateWebhooksCmd = &cobra.Command{
 			return fmt.Errorf("no supported language configuration found in gen.yaml")
 		}
 
-		// Save the updated config
 		if err := sdkGenConfig.SaveConfig(workingDir, cfg.Config); err != nil {
 			return fmt.Errorf("failed to save SDK generation config: %w", err)
 		}

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -49,7 +49,7 @@ func activateWebhooksExec(ctx context.Context, flags ActivateWebhooksFlags) erro
 	)
 
 	logger.Println("For more information, see:")
-	logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+	logger.Println("https://www.speakeasy.com/docs/customize/webhooks")
 
 	if _, err := charm.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
 		return fmt.Errorf("failed to get user confirmation: %w", err)
@@ -89,7 +89,5 @@ func activateWebhooksExec(ctx context.Context, flags ActivateWebhooksFlags) erro
 	}
 
 	logger.Println("Successfully upgraded - webhooks are now enabled")
-	logger.Println("For more information, see:")
-	logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
 	return nil
 }

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"os"
 
@@ -9,82 +10,86 @@ import (
 	"github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
 	"github.com/speakeasy-api/speakeasy/internal/log"
-	"github.com/spf13/cobra"
+	"github.com/speakeasy-api/speakeasy/internal/model"
 )
 
-var billingCmd = &cobra.Command{
-	Use:   "billing",
-	Short: "Manage billing related operations",
-	Long:  `Commands for managing billing related operations in Speakeasy.`,
+type BillingFlags struct{}
+
+type ActivateWebhooksFlags struct{}
+
+var billingCmd = &model.CommandGroup{
+	Usage:          "billing",
+	Short:          "Manage billing related operations",
+	Long:           `Commands for managing billing related operations in Speakeasy.`,
+	InteractiveMsg: "What do you want to do?",
+	Commands:       []model.Command{activateWebhooksCmd},
 }
 
-var activateWebhooksCmd = &cobra.Command{
-	Use:   "activate-webhooks",
-	Short: "Activate webhooks in the SDK generation configuration",
-	Long:  `Search for and update the SDK generation configuration file to activate webhooks for the configured language.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		logger := log.From(cmd.Context())
+var activateWebhooksCmd = &model.ExecutableCommand[ActivateWebhooksFlags]{
+	Usage:        "activate-webhooks",
+	Short:        "Activate webhooks in the SDK generation configuration",
+	Long:         `Search for and update the SDK generation configuration file to activate webhooks for the configured language.`,
+	Run:          activateWebhooksExec,
+	RequiresAuth: true,
+}
 
-		logger.Println(styles.RenderWarningMessage(
-			"Webhooks are a paid feature",
-			"Activating webhooks will enable billing for this feature",
-		))
+func activateWebhooksExec(ctx context.Context, flags ActivateWebhooksFlags) error {
+	logger := log.From(ctx)
 
-		confirm := false
-		prompt := charm.NewBranchPrompt(
-			"Would you like to proceed with activating webhooks?",
-			"This will enable billing for the webhooks feature",
-			&confirm,
-		)
+	logger.Println(styles.RenderWarningMessage(
+		"Webhooks are a paid feature",
+		"Activating webhooks will enable billing for this feature",
+	))
 
-		logger.Println("For more information, see:")
-		logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+	confirm := false
+	prompt := charm.NewBranchPrompt(
+		"Would you like to proceed with activating webhooks?",
+		"This will enable billing for the webhooks feature",
+		&confirm,
+	)
 
-		if _, err := charm.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
-			return fmt.Errorf("failed to get user confirmation: %w", err)
-		}
+	logger.Println("For more information, see:")
+	logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
 
-		if !confirm {
-			logger.Println("Webhook activation cancelled")
-			return nil
-		}
+	if _, err := charm.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
+		return fmt.Errorf("failed to get user confirmation: %w", err)
+	}
 
-		workingDir, err := os.Getwd()
-		if err != nil {
-			return fmt.Errorf("failed to get working directory: %w", err)
-		}
-		cfg, err := sdkGenConfig.Load(workingDir)
-		if err != nil {
-			return fmt.Errorf("failed to load SDK generation config: %w", err)
-		}
-
-		updated := false
-
-		for _, lang := range cfg.Config.Languages {
-			if lang.Cfg["webhooks"] == nil {
-				lang.Cfg["webhooks"] = map[string]any{}
-			}
-
-			lang.Cfg["webhooks"].(map[string]any)["enabled"] = true
-			updated = true
-		}
-
-		if !updated {
-			return fmt.Errorf("no supported language configuration found in gen.yaml")
-		}
-
-		if err := sdkGenConfig.SaveConfig(workingDir, cfg.Config); err != nil {
-			return fmt.Errorf("failed to save SDK generation config: %w", err)
-		}
-
-		logger.Println("Successfully upgraded - webhooks are now enabled")
-		logger.Println("For more information, see:")
-		logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+	if !confirm {
+		logger.Println("Webhook activation cancelled")
 		return nil
-	},
-}
+	}
 
-func init() {
-	billingCmd.AddCommand(activateWebhooksCmd)
-	rootCmd.AddCommand(billingCmd)
+	workingDir, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("failed to get working directory: %w", err)
+	}
+	cfg, err := sdkGenConfig.Load(workingDir)
+	if err != nil {
+		return fmt.Errorf("failed to load SDK generation config: %w", err)
+	}
+
+	updated := false
+
+	for _, lang := range cfg.Config.Languages {
+		if lang.Cfg["webhooks"] == nil {
+			lang.Cfg["webhooks"] = map[string]any{}
+		}
+
+		lang.Cfg["webhooks"].(map[string]any)["enabled"] = true
+		updated = true
+	}
+
+	if !updated {
+		return fmt.Errorf("no supported language configuration found in gen.yaml")
+	}
+
+	if err := sdkGenConfig.SaveConfig(workingDir, cfg.Config); err != nil {
+		return fmt.Errorf("failed to save SDK generation config: %w", err)
+	}
+
+	logger.Println("Successfully upgraded - webhooks are now enabled")
+	logger.Println("For more information, see:")
+	logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+	return nil
 }

--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/speakeasy-api/huh"
+	sdkGenConfig "github.com/speakeasy-api/sdk-gen-config"
+	"github.com/speakeasy-api/speakeasy/internal/charm"
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/spf13/cobra"
+)
+
+var billingCmd = &cobra.Command{
+	Use:   "billing",
+	Short: "Manage billing related operations",
+	Long:  `Commands for managing billing related operations in Speakeasy.`,
+}
+
+var activateWebhooksCmd = &cobra.Command{
+	Use:   "activate-webhooks",
+	Short: "Activate webhooks in the SDK generation configuration",
+	Long:  `Search for and update the SDK generation configuration file to activate webhooks for the configured language.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		logger := log.From(cmd.Context())
+
+		// Show warning and confirmation prompt
+		logger.Println(styles.RenderWarningMessage(
+			"Webhooks are a paid feature",
+			"Activating webhooks will enable billing for this feature",
+		))
+
+		confirm := false
+		prompt := charm.NewBranchPrompt(
+			"Would you like to proceed with activating webhooks?",
+			"This will enable billing for the webhooks feature",
+			&confirm,
+		)
+
+		logger.Println("For more information, see:")
+		logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+
+		if _, err := charm.NewForm(huh.NewForm(prompt)).ExecuteForm(); err != nil {
+			return fmt.Errorf("failed to get user confirmation: %w", err)
+		}
+
+		if !confirm {
+			logger.Println("Webhook activation cancelled")
+			return nil
+		}
+
+		// Load the SDK generation config
+		workingDir, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("failed to get working directory: %w", err)
+		}
+		cfg, err := sdkGenConfig.Load(workingDir)
+		if err != nil {
+			return fmt.Errorf("failed to load SDK generation config: %w", err)
+		}
+
+		// Track if we found any languages to update
+		updated := false
+
+		// Enable webhooks for each configured language
+		for _, lang := range cfg.Config.Languages {
+			// Create webhooks config if it doesn't exist
+			if lang.Cfg["webhooks"] == nil {
+				lang.Cfg["webhooks"] = map[string]any{}
+			}
+
+			// Enable webhooks
+			lang.Cfg["webhooks"].(map[string]any)["enabled"] = true
+			updated = true
+		}
+
+		if !updated {
+			return fmt.Errorf("no supported language configuration found in gen.yaml")
+		}
+
+		// Save the updated config
+		if err := sdkGenConfig.SaveConfig(workingDir, cfg.Config); err != nil {
+			return fmt.Errorf("failed to save SDK generation config: %w", err)
+		}
+
+		logger.Println("Successfully upgraded - webhooks are now enabled")
+		logger.Println("For more information, see:")
+		logger.Println("https://www.speakeasyapi.dev/docs/advanced-setup/webhooks")
+		return nil
+	},
+}
+
+func init() {
+	billingCmd.AddCommand(activateWebhooksCmd)
+	rootCmd.AddCommand(billingCmd)
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -72,6 +72,7 @@ func Init(version, artifactArch string) {
 	// TODO: migrate this file to use model.CommandGroup once all subcommands have been refactored
 	addCommand(rootCmd, statusCmd)
 	addCommand(rootCmd, quickstartCmd)
+	addCommand(rootCmd, billingCmd)
 	addCommand(rootCmd, runCmd)
 	addCommand(rootCmd, configureCmd)
 	addCommand(rootCmd, generate.GenerateCmd)


### PR DESCRIPTION
This PR adds a new CLI command `speakeasy billing activate-webhooks` activate the webhooks feature and confirm to the user it will be paid.

[Context](https://speakeasyapi.slack.com/archives/C05G299KHQR/p1736192700464449?thread_ts=1736189281.484219&cid=C05G299KHQR)

https://github.com/user-attachments/assets/217a8b68-a520-4990-912f-37e8bcbc25ec

