### PR TITLE
chore: Bump generation to v2.488.4: Bug Fixes (Pagination Defaults), New Features (apiKey Auth Defaults & Webhooks), and Chores (Snapshot Test Updates)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi-generation/v2 v2.486.6
+	github.com/speakeasy-api/openapi-generation/v2 v2.488.4
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.30.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.18.1

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.5 h1:a3Uy2gCvgrjY4iV79GNVZ6HZjUCFkB6wZPcSYBr27s0=
 github.com/speakeasy-api/openapi v0.1.5/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.486.6 h1:u4RyWHJtM3d8bnt2X3lzqGsWTYAqs/Eh84i6zgXOlfc=
-github.com/speakeasy-api/openapi-generation/v2 v2.486.6/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
+github.com/speakeasy-api/openapi-generation/v2 v2.488.4 h1:gZHsS6b2HYLb+NEiL8jiHNQeZ6h1yaLL0jkHpYy0ue8=
+github.com/speakeasy-api/openapi-generation/v2 v2.488.4/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.30.0 h1:LCH4TgCVBxpAmcgTR+TvEzlDZv5eR9vgTEyAv3mkLPg=


### PR DESCRIPTION
•	🐛 Bug Fix: Pagination defaults and limit adjustments (C#).
•	🔧 Chore: Ignored vishalg0wda from snapshot-test-executor.
•	🔧 Chore: Added Launch.json template for new starters.
•	🐝 Feature: Default to apiKey auth if the security scheme is missing.
•	🐝 Feature: Improved webhook handling.
•	🔧 Chore: Upgraded snapshot tests.
•	🐛 Bug Fix: Upgraded mypy to 1.14.1 to prevent Python 3.13 errors.
•	🐝 Feature: Support for asymmetric signatures in typescriptv2.
•	🔧 Chore: Bumped tj-actions/changed-files to 45.0.6