### PR TITLE
feat: bump generator: Python upgrades, bug fixes, and feature flags

### DIFF
--- a/cmd/billing.go
+++ b/cmd/billing.go
@@ -81,7 +81,6 @@ func activateWebhooks(ctx context.Context) error {
 		return nil
 	}
 
-	// TODO: Send request to activate webhooks set feature flag
 	sdk, err := auth.GetSDKFromContext(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to get sdk from context: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi-generation/v2 v2.488.4
+	github.com/speakeasy-api/openapi-generation/v2 v2.492.3
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.30.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.19.1

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.5 h1:a3Uy2gCvgrjY4iV79GNVZ6HZjUCFkB6wZPcSYBr27s0=
 github.com/speakeasy-api/openapi v0.1.5/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.488.4 h1:gZHsS6b2HYLb+NEiL8jiHNQeZ6h1yaLL0jkHpYy0ue8=
-github.com/speakeasy-api/openapi-generation/v2 v2.488.4/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
+github.com/speakeasy-api/openapi-generation/v2 v2.492.3 h1:DTwhob536R6wS0FQW6ldJWRwXkz6L4hnioDxbogNpJs=
+github.com/speakeasy-api/openapi-generation/v2 v2.492.3/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.30.0 h1:LCH4TgCVBxpAmcgTR+TvEzlDZv5eR9vgTEyAv3mkLPg=


### PR DESCRIPTION
- prevent map examples from retaining obsolete key-value pairs (#2089) (commit by @2ynn)
- python: add missing import for per-operation servers (#2090) (commit by @disintegrator)
- typescript: webhooks security parsing of consumer should provide secret (#2088) (commit by @mfbx9da4)
- expose sdk versioning data as constants in python (#2077) (commit by @walker-tx)
- feature flag based licensing (#2078) (commit by @mfbx9da4)
- Upgrade to poetry 2.0 in pythonv2 (#2074) (commit by @bflad)
- Bump pythonv2 minimum version to 3.9 as 3.8 is no longer supported (#2072) (commit by @bflad)