### PR TITLE
fix: check if file exists before asking for auth

### DIFF
--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -100,6 +100,10 @@ func getRemoteAuthenticationPrompts(fileLocation, authHeader *string) []*huh.Gro
 				Value(&requiresAuthentication),
 		).WithHideFunc(func() bool {
 			if fileLocation != nil && *fileLocation != "" {
+				// If it's a local file, skip the authentication prompt
+				if _, err := os.Open(*fileLocation); err == nil {
+					return true
+				}
 				if parsedUrl, err := url.ParseRequestURI(*fileLocation); err == nil {
 					resp, err := http.Get(parsedUrl.String())
 					if err != nil {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/SPE-4583/bug-quickstart-doesnt-throw-a-reasonable-error-when-given-oas-file

This is very low risk IMO