### PR TITLE
fix: improve error handling, templating, and Python config options 

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi-generation/v2 v2.493.15
+	github.com/speakeasy-api/openapi-generation/v2 v2.493.19
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.30.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.19.1

--- a/go.sum
+++ b/go.sum
@@ -577,10 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.5 h1:a3Uy2gCvgrjY4iV79GNVZ6HZjUCFkB6wZPcSYBr27s0=
 github.com/speakeasy-api/openapi v0.1.5/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.13 h1:qG9TbD4oKk5ALbneiGn+3hOMv8r4ZXVacuMgZgi/G44=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.13/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.15 h1:BOqakJJ26Er282PKwlJYEUjI+GPyV3+Bi7Ouq/Is8LI=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.15/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
+github.com/speakeasy-api/openapi-generation/v2 v2.493.19 h1:cH44Uxr4G+r1mNFhcEfEgKvN2MNM1xNtWYYEBU99viU=
+github.com/speakeasy-api/openapi-generation/v2 v2.493.19/go.mod h1:3cC3fZVpP/QL300g6+sJxhVIFM9N8WWbW+V4RdN4Mr4=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.30.0 h1:LCH4TgCVBxpAmcgTR+TvEzlDZv5eR9vgTEyAv3mkLPg=


### PR DESCRIPTION
 - Handle 4XX and 5XX error ranges separately to ensure proper response ordering and avoid unreachable code paths. 
 - Escape template-sensitive characters in examples across all targets to prevent templating errors in usage snippets.
 - Add `enableCustomCodeRegions` configuration option to Pythonv2 SDK.