### PR TITLE
chore: fix change detection when there is a single registry source as an input

### DIFF
--- a/internal/run/sourceTracking.go
+++ b/internal/run/sourceTracking.go
@@ -159,6 +159,8 @@ func (w *Workflow) snapshotSource(ctx context.Context, parentStep *workflowTrack
 		if err != nil {
 			return err
 		}
+
+		namespaceName = document.NamespaceName
 		w.lockfile.Sources[sourceID] = workflow.SourceLock{
 			SourceNamespace:      namespaceName,
 			SourceRevisionDigest: document.ManifestDigest,


### PR DESCRIPTION
Also fixes speakeasy's internal regression tests, once the next generation happens, for any affected repos. Will require 1 generation to fix bad data in workflow.lock first.