### PR TITLE
fix: unpin python dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi-generation/v2 v2.493.31
+	github.com/speakeasy-api/openapi-generation/v2 v2.493.32
 	github.com/speakeasy-api/openapi-overlay v0.9.0
 	github.com/speakeasy-api/sdk-gen-config v1.30.1
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.19.1

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.6 h1:bpBiJ9P4hSVv2Vddk+ny6zeytPsDq0ttxl6DLAwC0zo=
 github.com/speakeasy-api/openapi v0.1.6/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.31 h1:R/59jaoHUYE+YjQkYYgZEYoKqPihLFp6MeLWskiKK30=
-github.com/speakeasy-api/openapi-generation/v2 v2.493.31/go.mod h1:UfxZg41QiMEatXCSx7ILW4ErOHMlgGEAlJeSVxf5AZo=
+github.com/speakeasy-api/openapi-generation/v2 v2.493.32 h1:jucXDAYDn3XCsFfIeBWmkGmcCNfCqQA9wjruBlxIFtw=
+github.com/speakeasy-api/openapi-generation/v2 v2.493.32/go.mod h1:UfxZg41QiMEatXCSx7ILW4ErOHMlgGEAlJeSVxf5AZo=
 github.com/speakeasy-api/openapi-overlay v0.9.0 h1:Wrz6NO02cNlLzx1fB093lBlYxSI54VRhy1aSutx0PQg=
 github.com/speakeasy-api/openapi-overlay v0.9.0/go.mod h1:f5FloQrHA7MsxYg9djzMD5h6dxrHjVVByWKh7an8TRc=
 github.com/speakeasy-api/sdk-gen-config v1.30.1 h1:61gH9i7ZRL2FDpPIkYMY+PmuQjnvUhhBuLTJp8FrNIU=


### PR DESCRIPTION
Setting upper bounds on dependencies is strongly discouraged for packages in the python ecosystem:

- https://discuss.python.org/t/should-i-be-pinning-my-dependencies/13159/2
- https://iscinumpy.dev/post/bound-version-constraints/
- https://hynek.me/articles/semver-will-not-save-you/
- https://github.com/python-poetry/poetry/issues/3747