### PR TITLE
feat: promote speakeasy version on successful run

### DIFF
--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -327,7 +327,7 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 }
 
 // If promote is true, the version will be promoted to the default version (ie when running `speakeasy`)
-func runWithVersion(cmd *cobra.Command, artifactArch, desiredVersion string, promote bool) error {
+func runWithVersion(cmd *cobra.Command, artifactArch, desiredVersion string, shouldPromote bool) error {
 	vLocation, err := updates.InstallVersion(cmd.Context(), desiredVersion, artifactArch, 30)
 	if err != nil {
 		return ErrInstallFailed.Wrap(err)
@@ -354,7 +354,7 @@ func runWithVersion(cmd *cobra.Command, artifactArch, desiredVersion string, pro
 	}
 
 	// If the workflow succeeded, make the used version the default
-	if promote && !env.IsGithubAction() && !env.IsLocalDev() {
+	if shouldPromote && !env.IsGithubAction() && !env.IsLocalDev() {
 		currentExecPath, err := os.Executable()
 		if err != nil {
 			log.From(cmd.Context()).Warnf("failed to promote version: %s", err.Error())

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -123,10 +123,12 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 	}
 
 	if _, err := os.Stat(dst); err == nil {
+		// It's important that these logs remain. We rely on them as part of `run` output
 		log.From(ctx).PrintfStyled(styles.DimmedItalic, "Found existing install for Speakeasy version %s\n", desiredVersion)
 		return dst, nil
 	}
 
+	// It's important that these logs remain. We rely on them as part of `run` output
 	log.From(ctx).PrintfStyled(styles.DimmedItalic, "Downloading Speakeasy version %s\n", desiredVersion)
 
 	return dst, install(artifactArch, asset.GetBrowserDownloadURL(), dst, timeout)

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -115,12 +115,8 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 
 	currentVersion := events.GetSpeakeasyVersionFromContext(ctx)
 	curVer, err := version.NewVersion(currentVersion)
-	if err != nil {
-		return "", err
-	}
-
 	// If the current version is the same as the desired version, just return the current executable location
-	if curVer.Equal(v) {
+	if err == nil && curVer.Equal(v) {
 		return os.Executable()
 	}
 

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"github.com/speakeasy-api/speakeasy-core/events"
 	"io"
 	"net/http"
 	"os"
@@ -110,6 +111,17 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 	v, err := version.NewVersion(desiredVersion)
 	if err != nil {
 		return "", err
+	}
+
+	currentVersion := events.GetSpeakeasyVersionFromContext(ctx)
+	curVer, err := version.NewVersion(currentVersion)
+	if err != nil {
+		return "", err
+	}
+
+	// If the current version is the same as the desired version, just return the current executable location
+	if curVer.Equal(v) {
+		return os.Executable()
 	}
 
 	release, asset, err := getReleaseForVersion(ctx, *v, artifactArch, 30*time.Second)


### PR DESCRIPTION
If `run` completes successfully using `latest`, promote the used version to be the installed CLI version (as if the user had run `speakeasy update`)

Also cleans up some of the logging to be a bit less obnoxious

https://linear.app/speakeasy/issue/SPE-4408/speakeasy-run-too-many-version-update-mentions

![CleanShot 2025-01-21 at 15 49 28@2x](https://github.com/user-attachments/assets/6a7b01ad-fe9e-4a9d-a285-9212cff3e937)
