### PR TITLE
chore: Enable golangci-lint in CI for go vet reports

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,6 +12,24 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  build-lint:
+    permissions:
+      contents: read
+    runs-on:
+      group: ubuntu-latest-large
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
+        with:
+          go-version-file: "go.mod"
+      - name: Configure git for private modules
+        env:
+          GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
+        run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
+      - uses: golangci/golangci-lint-action@2226d7cb06a077cd73e56eedd38eecad18e5d837 # v6.5.0
+        with:
+          version: v1.64.5
+          args: --timeout=10m --verbose
   build-test:
     name: Build & Test
     if: ${{ github.event.pull_request.draft == false }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: amannn/action-semantic-pull-request@0723387faaf9b38adef4775cd42cfd5155ed6017 # v5.5.3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-lint:
+  golangci-lint:
     permissions:
       contents: read
     runs-on:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,37 @@
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+linters:
+  disable-all: true
+  enable:
+    # - copyloopvar
+    # - durationcheck
+    # - errcheck
+    # - forcetypeassert
+    # - gocheckcompilerdirectives
+    # - gofmt
+    # - gosimple
+    - govet
+    # - ineffassign
+    # - intrange
+    # - loggercheck
+    # - makezero
+    # - mirror
+    - misspell
+    # - nilerr
+    # - nolintlint
+    # - paralleltest
+    # - perfsprint
+    # - prealloc
+    # - predeclared
+    # - spancheck
+    # - staticcheck
+    # - tenv
+    # - thelper
+    # - testifylint
+    # - unconvert
+    # - unparam
+    # - unused
+    # - usestdlibvars
+    # - wastedassign


### PR DESCRIPTION
This specifically is being added to enable `go vet` static analysis reports, as `go test | gotestfmt` build errors caused by `go vet` issues are an opaque panic. Other linters can and should be enabled over time.

Verified by introducing a Go 1.24 errant change and noting that both `go vet ./...` and `golangci-lint run ./...` with this configuration both report the same error:

```console
$ go vet ./...
# github.com/speakeasy-api/speakeasy/cmd/generate
cmd/generate/generate.go:254:17: non-constant format string in call to (github.com/speakeasy-api/speakeasy/internal/log.Logger).Printf
$ golangci-lint run ./...
cmd/generate/generate.go:254:17: printf: non-constant format string in call to (github.com/speakeasy-api/speakeasy/internal/log.Logger).Printf (govet)
                logger.Printf(changeLog)
                              ^
```