### PR TITLE
feat: boostrapping tests should compile

### DIFF
--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -158,7 +158,7 @@ func WithTarget(target string) Opt {
 func WithBoostrapTests() Opt {
 	return func(w *Workflow) {
 		w.BoostrapTests = true
-		w.ShouldCompile = false
+		w.ShouldCompile = true
 		w.SkipTesting = true
 		w.SkipVersioning = true
 	}


### PR DESCRIPTION
Certain targets like go actually need compilation to have run for `speakeasy test` to work. I also generally changed my mind and don't think it's bad to compile here.