### PR TITLE
feat: fix usage snippet lib parsing snake care operation IDs

### DIFF
--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -187,7 +187,7 @@ func parseOperationInfoAndCodeSample(lang, usageOutputSection string) (*UsageSni
 	}
 
 	// Define a regular expression to capture the API name, method, and endpoint
-	apiDetailsRegex := regexp.MustCompile(`([/\w{}_]+)\s+\((\w+)\s+(.*)\)`)
+	apiDetailsRegex := regexp.MustCompile(`([\w{}_/-]+)\s+\((\w+)\s+(.*)\)`)
 
 	// Find and extract the API details
 	matches := apiDetailsRegex.FindStringSubmatch(parts[0])

--- a/pkg/codesamples/codesamples.go
+++ b/pkg/codesamples/codesamples.go
@@ -154,7 +154,7 @@ func GenerateUsageSnippet(ctx context.Context, schema, header, token, configPath
 		specifiedOperation,
 		"",
 		filepath.Join(configPath, "speakeasyusagegen"),
-		true,
+		specifiedOperation == "",
 		usageOutput,
 	); err != nil {
 		return nil, err


### PR DESCRIPTION
The lib wasn't correctly parsing out snake case operation IDs causing downstream issues

Also we weren't handling single operations vs multi operation requests correctly