### PR TITLE
fix: java publishing sources jar name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.1.7
-	github.com/speakeasy-api/openapi-generation/v2 v2.555.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.556.1
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1

--- a/go.sum
+++ b/go.sum
@@ -579,6 +579,8 @@ github.com/speakeasy-api/openapi v0.1.7 h1:INU1+Pu9/ub6JtABRj8cWCpU3CCE/Z8q1FTyg
 github.com/speakeasy-api/openapi v0.1.7/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
 github.com/speakeasy-api/openapi-generation/v2 v2.555.1 h1:rbWCosBlK4uoEFkTEKnkS9vYj5nz3873cxFRXqEAnpA=
 github.com/speakeasy-api/openapi-generation/v2 v2.555.1/go.mod h1:RrFJ7IqwjXvJxmxKLzY42DkaVlyFvA0FiwRGww+koC0=
+github.com/speakeasy-api/openapi-generation/v2 v2.556.1 h1:06yJabBP5jw8IU44lruhmydEkHfSmS8i013IUAPniCk=
+github.com/speakeasy-api/openapi-generation/v2 v2.556.1/go.mod h1:RrFJ7IqwjXvJxmxKLzY42DkaVlyFvA0FiwRGww+koC0=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.30.11 h1:y9ssqsVLlty+tQ4/A+lpkYvi6OcN37r5s3PxbFYXm4U=


### PR DESCRIPTION
Correctly use artifactId as the sources jar name in `build.gradle`