### PR TITLE
feat: plumb validation warnings into studio

### DIFF
--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -331,7 +331,7 @@ func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schem
 
 	if len(vErrs) > 0 {
 		status = "OpenAPI document invalid ✖"
-	} else if len(vErrs) > 0 {
+	} else if len(vWarns) > 0 {
 		status = "OpenAPI document valid with warnings ⚠"
 	}
 


### PR DESCRIPTION
The studio currently displays:
-  ValidationErrors – Generated from rule evaluations and explicitly added errors.
- Explicitly added Diagnostics – generally suggestions

Both are transformed into a type (confusingly named Diagnostic) that includes key details like the message, line number, schema path, severity, and type. These diagnostics are then rendered in the studio.

However, a category of validation issues visible in the CLI but missing from the studio are those logged via logging.LogWarning. This change ensures these warnings are also surfaced in the studio, providing a more consistent experience.

https://github.com/user-attachments/assets/bd1cc8f7-2441-4a7f-bcc8-270c93006abf



