### PR TITLE
fix: enable OAuth2 ClientCredentials hook when no scopes specified

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.1.7
-	github.com/speakeasy-api/openapi-generation/v2 v2.562.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.562.4
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1

--- a/go.sum
+++ b/go.sum
@@ -577,8 +577,8 @@ github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939 h1:LGtzWU
 github.com/speakeasy-api/libopenapi v0.0.0-20241006201546-c9e5f704a939/go.mod h1:9ap4lXBHgxGyFwxtOfa+B1C3IQ0rvnqteqjJvJ11oiQ=
 github.com/speakeasy-api/openapi v0.1.7 h1:INU1+Pu9/ub6JtABRj8cWCpU3CCE/Z8q1FTygczYkes=
 github.com/speakeasy-api/openapi v0.1.7/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.562.2 h1:4yxMRUfObYzumzmmfUj1uJ5GEGh/U1OhcafoVqgZeH4=
-github.com/speakeasy-api/openapi-generation/v2 v2.562.2/go.mod h1:RrFJ7IqwjXvJxmxKLzY42DkaVlyFvA0FiwRGww+koC0=
+github.com/speakeasy-api/openapi-generation/v2 v2.562.4 h1:9TCfvKqCZ5VA+X893YTVTAk+SdYXvTsPsPJ6YmIjwUc=
+github.com/speakeasy-api/openapi-generation/v2 v2.562.4/go.mod h1:RrFJ7IqwjXvJxmxKLzY42DkaVlyFvA0FiwRGww+koC0=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.30.11 h1:y9ssqsVLlty+tQ4/A+lpkYvi6OcN37r5s3PxbFYXm4U=


### PR DESCRIPTION
GEN-1280

This release ensures the ClientCredentials hook is enabled even when no scopes are specified