### PR TITLE
fix: remove net5.0 from dockerfile

### DIFF
--- a/image/Dockerfile
+++ b/image/Dockerfile
@@ -40,12 +40,6 @@ RUN apk add --update --no-cache build-base ruby ruby-bundler ruby-dev
 ENV DOTNET_ROOT=/usr/lib/dotnet
 RUN apk add --update --no-cache dotnet6-sdk
 
-### Install .NET5.0
-RUN apk add --update --no-cache curl bash
-# openssl1.1-compat is gradually getting removed from package managers..
-RUN apk add --update --no-cache --repository=http://dl-cdn.alpinelinux.org/alpine/edge/testing openssl1.1-compat
-RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 5.0 -InstallDir ${DOTNET_ROOT}
-
 ### Install .NET8.0
 RUN curl -sSL https://dot.net/v1/dotnet-install.sh | bash /dev/stdin -Channel 8.0 -InstallDir ${DOTNET_ROOT}
 RUN dotnet --list-sdks
@@ -53,14 +47,14 @@ RUN dotnet --list-sdks
 ### Install PHP and Composer
 #### Source: https://github.com/geshan/docker-php-composer-alpine/blob/master/Dockerfile
 RUN apk --update --no-cache add wget \
-		     curl \
-		     git \
-		     php82 \
-         php-ctype php-dom php-json php-mbstring php-phar php-tokenizer php-xml php-xmlwriter \
-		     php-curl \
-		     php-openssl \
-		     php-iconv \
-		    --repository http://nl.alpinelinux.org/alpine/edge/testing/
+	curl \
+	git \
+	php82 \
+	php-ctype php-dom php-json php-mbstring php-phar php-tokenizer php-xml php-xmlwriter \
+	php-curl \
+	php-openssl \
+	php-iconv \
+	--repository http://nl.alpinelinux.org/alpine/edge/testing/
 
 RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/bin --filename=composer
 RUN mkdir -p /var/www


### PR DESCRIPTION
# What

.NET5.0 has been sunset so we should remove it from our Dockerfile.

