### PR TITLE
fix: custom security scheme alongside other security options tsv2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -33,7 +33,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.1.7
-	github.com/speakeasy-api/openapi-generation/v2 v2.564.5
+	github.com/speakeasy-api/openapi-generation/v2 v2.564.6
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1

--- a/go.sum
+++ b/go.sum
@@ -588,8 +588,8 @@ github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlo
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.1.7 h1:INU1+Pu9/ub6JtABRj8cWCpU3CCE/Z8q1FTygczYkes=
 github.com/speakeasy-api/openapi v0.1.7/go.mod h1:t1HA3wPC8jpGRr0UHW+SIvIB8dT5RXXi39XLrIG/URU=
-github.com/speakeasy-api/openapi-generation/v2 v2.564.5 h1:veFfHu9b26TCmvt2Fq8VYU3GpLNwoot/ZglsBRUujdU=
-github.com/speakeasy-api/openapi-generation/v2 v2.564.5/go.mod h1:CNwrwX1EyZy3Rlos8AjfRyGx5QGGL+A3qCApmDU8Q2Q=
+github.com/speakeasy-api/openapi-generation/v2 v2.564.6 h1:IZB16XcDQROonWwPLETlJM+rkxjyVi4hxP6rtSm1ImA=
+github.com/speakeasy-api/openapi-generation/v2 v2.564.6/go.mod h1:CNwrwX1EyZy3Rlos8AjfRyGx5QGGL+A3qCApmDU8Q2Q=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.30.11 h1:y9ssqsVLlty+tQ4/A+lpkYvi6OcN37r5s3PxbFYXm4U=


### PR DESCRIPTION
GEN-1263

This PR addresses generation failures in Typescript v2 in cases where a custom security schemes is intermingled with other security options