### PR TITLE
feat: support autofilling of sdkClassName and packageName 

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -42,7 +42,9 @@ type QuickstartFlags struct {
 	Schema      string `json:"schema"`
 	OutDir      string `json:"out-dir"`
 	TargetType  string `json:"target"`
-	From        string `json:"from"`
+
+	// If the quickstart should be based on a pre-existing template (hosted in the Speakeasy Registry)
+	From string `json:"from"`
 }
 
 //go:embed sample_openapi.yaml
@@ -120,8 +122,8 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	}
 
 	if flags.From != "" {
-		quickstartObj.Defaults.Blueprint = &flags.From
-		quickstartObj.IsUsingBlueprint = true
+		quickstartObj.Defaults.Template = &flags.From
+		quickstartObj.IsUsingTemplate = true
 	}
 
 	nextState := prompts.SourceBase
@@ -268,7 +270,7 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 	// If we are using a blueprint template, the original location will be a
 	// tempfile. We want therefore to move the tempfile to the output directory,
 	// and update the workflow file to point to the new location.
-	if quickstartObj.IsUsingBlueprint {
+	if quickstartObj.IsUsingTemplate {
 		oldInput := quickstartObj.WorkflowFile.Sources[sourceName].Inputs[0].Location
 
 		oldInputPath := oldInput.Resolve()

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/speakeasy-api/openapi-generation/v2 v2.566.5
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.11
-	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1
+	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1
 	github.com/speakeasy-api/speakeasy-core v0.19.7
 	github.com/speakeasy-api/speakeasy-proxy v0.0.2
 	github.com/speakeasy-api/versioning-reports v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -596,6 +596,8 @@ github.com/speakeasy-api/sdk-gen-config v1.30.11 h1:y9ssqsVLlty+tQ4/A+lpkYvi6OcN
 github.com/speakeasy-api/sdk-gen-config v1.30.11/go.mod h1:e9PjnCRHGa4K4EFKVU+kKmihOZjJ2V4utcU+274+bnQ=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1 h1:RoeWDoDS4H+z3whylb1HIb+ob4/ay4CuKnBku72Zv/c=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.25.1/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1 h1:cX+ip9YHkunvIHBALjDDIyEvo8rCLUCfIo7ldzcIeU4=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
 github.com/speakeasy-api/speakeasy-core v0.19.7 h1:SyVxaTZavkI927cz/UYfvzPXhvF1R2XhxGMeU30O24g=
 github.com/speakeasy-api/speakeasy-core v0.19.7/go.mod h1:M3ZBHTexZINVbpcz+nIEoaFw4Ti0Gc1rnZbdQjiFlaA=
 github.com/speakeasy-api/speakeasy-go-sdk v1.8.1 h1:atzohw12oQ5ipaLb1q7ntTu4vvAgKDJsrvaUoOu6sw0=

--- a/prompts/statemappings.go
+++ b/prompts/statemappings.go
@@ -5,6 +5,7 @@ import (
 
 	config "github.com/speakeasy-api/sdk-gen-config"
 	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
 )
 
 type (
@@ -17,14 +18,21 @@ type Quickstart struct {
 	LanguageConfigs          map[string]*config.Configuration
 	Defaults                 Defaults
 	IsUsingSampleOpenAPISpec bool
-	IsUsingBlueprint         bool
+	IsUsingTemplate          bool
 	SDKName                  string
 }
 
 type Defaults struct {
 	SchemaPath *string
 	TargetType *string
-	Blueprint  *string
+
+	// The template to use for quickstart. A template is a pre-configured OAS spec retrieved
+	// from the registry schema store.
+	// The corresponding CLI flag is --from, e.g:
+	// speakeasy quickstart --from wandering-octopus-129129
+	Template *string
+
+	TemplateData *shared.SchemaStoreItem
 }
 
 // Define constants using iota


### PR DESCRIPTION
# What

Adds support to the quickstart command to automatically fill the settings values for `sdkClassName` and `packageName` from a session in the Speakeasy Sandbox (sandbox.speakeasy.com)

# Demo


https://github.com/user-attachments/assets/14a47594-d8e4-4ecf-affb-ea833ffdd7a4

