### PR TITLE
feat: added a resolve flag and resolve by local references using libopenapi bundler

### DIFF
--- a/cmd/merge.go
+++ b/cmd/merge.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"path/filepath"
+
 	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/speakeasy-api/speakeasy/pkg/merge"
@@ -22,7 +24,6 @@ func mergeInit() {
 	_ = mergeCmd.MarkFlagRequired("schemas")
 	mergeCmd.Flags().StringP("out", "o", "", "path to the output file")
 	_ = mergeCmd.MarkFlagRequired("out")
-	mergeCmd.Flags().String("base-path", "", "optional base path to resolve relative $ref file references")
 	mergeCmd.Flags().Bool("resolve", false, "resolve local references in the first schema file")
 
 	rootCmd.AddCommand(mergeCmd)
@@ -39,18 +40,14 @@ func mergeExec(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	basePath, err := cmd.Flags().GetString("base-path")
-	if err != nil {
-		return err
-	}
-
 	resolve, err := cmd.Flags().GetBool("resolve")
 	if err != nil {
 		return err
 	}
 
 	if resolve {
-		if err := merge.MergeByResolvingLocalReferences(cmd.Context(), inSchemas[0], outFile, basePath, "speakeasy-recommended", "", false); err != nil {
+		dir := filepath.Dir(inSchemas[0])
+		if err := merge.MergeByResolvingLocalReferences(cmd.Context(), inSchemas[0], outFile, dir, "speakeasy-recommended", "", false); err != nil {
 			return err
 		}
 	} else {

--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"context"
+
 	"github.com/speakeasy-api/speakeasy/internal/migrate"
 	"github.com/speakeasy-api/speakeasy/internal/model"
 	"github.com/speakeasy-api/speakeasy/internal/model/flag"

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -26,7 +26,6 @@ import (
 )
 
 func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, basePath string, defaultRuleset, workingDir string, skipGenerateLintReport bool) error {
-
 	data, err := os.ReadFile(inFile)
 	if err != nil {
 		panic(fmt.Errorf("error reading file %s: %w", inFile, err))
@@ -46,7 +45,9 @@ func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, baseP
 
 	v3Model, errors := doc.BuildV3Model()
 	if errors != nil {
-		fmt.Printf("Error building model: %v\n", err)
+		for _, err = range errors {
+			fmt.Printf("Error building model: %v\n", err)
+		}
 		os.Exit(1)
 	}
 
@@ -59,8 +60,6 @@ func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, baseP
 	if err != nil {
 		panic(fmt.Errorf("failed to write bundled file: %w", err))
 	}
-
-	fmt.Printf("Bundled OpenAPI spec saved to %s\n", outFile)
 
 	return nil
 }


### PR DESCRIPTION
### What is in this PR

- created `resolve` and `basePath` arguments to the merge command
- created a new function called `MergeByResolvingLocalReferences` in `pkg/merge`
- toggle off of `resolve` to use `MergeByResolvingLocalReferences` or the current `MergeOpenAPIDocuments`  

### What does this PR do

This PR adds support for resolving local references during OpenAPI merges by leveraging [pb33f's libopenapi bundler](https://pb33f.io/libopenapi/bundling/).

Instead of modifying the existing merge behavior—which simply combines multiple OAS documents without resolving references—I’ve introduced a new `--resolve flag` and `--basePath` argument to the merge command:

         --resolve: triggers reference resolution using the first file as the base document

         --basePath: defines the directory to begin resolving references from

This keeps the current merge behavior intact to avoid breaking changes or affecting user CI/CD pipelines.

### How this PR was tested

I used created some simple schemas and also used the digitalocean example in the [libopenapi](https://pb33f.io/libopenapi/bundling/) docs. 

Then locally built `speakeasy` and then ran merges on those schemas locally.

### Why was this change necessary? 

Users working with large APIs often rely on reference resolution during merges to enable generation. 
This update provides a path for those users and non-breaking for current users using merge.

### What should reviewers pay extra attention to?
I went about this trying not to add a new top level command. 
Would love feedback on whether the `--resolve` flag is the best approach.
Or if there's a better design that I'm not seeing.
