### PR TITLE
feat(release): add automatic shell completion support for homebrew

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ integration/temp
 .DS_Store
 .vscode/launch.json
 __debug_bin*
+/completions/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
+    - ./scripts/completions.sh
 builds:
   - env:
       - CGO_ENABLED=0
@@ -19,6 +20,8 @@ builds:
 archives:
   - name_template: "{{ .ProjectName }}_{{ .Os }}_{{ .Arch }}{{ if .Arm }}v{{ .Arm }}{{ end }}"
     format: zip
+    files:
+      - completions/*
 checksum:
   name_template: "checksums.txt"
 snapshot:
@@ -39,6 +42,11 @@ brews:
     license: Apache-2.0
     test: |
       system "#{bin}/speakeasy --version"
+    extra_install: |
+      bash_completion.install "completions/speakeasy.bash" => "speakeasy"
+      zsh_completion.install "completions/speakeasy.zsh" => "_speakeasy"
+      fish_completion.install "completions/speakeasy.fish"
+
   - name: speakeasy@{{ .Major }}.{{ .Minor }}.{{ .Patch }}
     repository:
       owner: speakeasy-api
@@ -48,6 +56,10 @@ brews:
     license: Apache-2.0
     test: |
       system "#{bin}/speakeasy --version"
+    extra_install: |
+      bash_completion.install "completions/speakeasy.bash" => "speakeasy"
+      zsh_completion.install "completions/speakeasy.zsh" => "_speakeasy"
+      fish_completion.install "completions/speakeasy.fish"
 
 chocolateys:
   - name: speakeasy

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+rm -rf completions
+mkdir completions
+for sh in bash zsh fish; do
+  go run main.go completion "$sh" >"completions/speakeasy.$sh"
+done


### PR DESCRIPTION
I noticed that when installing `speakeasy` via the recommended method (`brew install speakeasy-api/homebrew-tap/speakeasy`) that
I didn't get completions setup for me like I normally would with homebrew installed commands.

I followed basically what the goreleaser folks themselves do (see [this commit](https://github.com/goreleaser/goreleaser/commit/fafeb9b0dc91c75bb1992d5578492eb1078636be)), but other packages do something very similar (see [go-task's goreleaser.yml](https://github.com/go-task/task/blob/6cb0a5a2f2d5db23a2a882d3c9aa5f1fea37106a/.goreleaser.yml#L90-L92)).

Once this lands (assuming one of y'all are able to test it out locally), it will enable shell completion automatically for homebrew users. 🎉 

---

Note, I cannot test this locally (it's not possible to run `go mod download` locally, which means I can't run `./scripts/completions.sh`).