### PR TITLE
fix(release): fix completion generation on windows

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,7 +7,7 @@ before:
     - go mod tidy
     # you may remove this if you don't need go generate
     - go generate ./...
-    - ./scripts/completions.sh
+    - go run scripts/completions.go
 builds:
   - env:
       - CGO_ENABLED=0

--- a/scripts/completions.go
+++ b/scripts/completions.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+)
+
+func main() {
+	// Remove existing completions directory
+	os.RemoveAll("completions")
+
+	// Create new completions directory
+	err := os.Mkdir("completions", 0755)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error creating completions directory: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Generate completions for different shells
+	shells := []string{"bash", "zsh", "fish"}
+	for _, shell := range shells {
+		outputFile := filepath.Join("completions", "speakeasy."+shell)
+		cmd := exec.Command("go", "run", "main.go", "completion", shell)
+		output, err := cmd.Output()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error generating %s completion: %v\n", shell, err)
+			os.Exit(1)
+		}
+
+		err = os.WriteFile(outputFile, output, 0644)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error writing to %s: %v\n", outputFile, err)
+			os.Exit(1)
+		}
+	}
+}

--- a/scripts/completions.sh
+++ b/scripts/completions.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-set -e
-rm -rf completions
-mkdir completions
-for sh in bash zsh fish; do
-  go run main.go completion "$sh" >"completions/speakeasy.$sh"
-done


### PR DESCRIPTION
The GitHub action that does the release actually runs on Windows (likely makes publishing to Choco easier?). The changes to add completions for Homebrew caused errors during release because I had assumed a *nix like runtime environment for the GHA `release` job (incorrectly).

This replaces the shell script with a tiny go script that is platform agnostic.

---

Note: like the other changes, I am unable to test this myself (due to a private repo being referenced in `go.mod`). In order to test the new script, you should be able to run `go run scripts/generate.go` (which is what is done in the `.goreleaser.yaml` file).