### PR TITLE
fix: prevent multiple concurrent runs of the CLI and retry github action trigger

### DIFF
--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -133,6 +133,9 @@ func quickstartExec(ctx context.Context, flags QuickstartFlags) error {
 		if err != nil {
 			return err
 		}
+		if state == nil {
+			return nil
+		}
 		nextState = *state
 	}
 

--- a/integration/main_test.go
+++ b/integration/main_test.go
@@ -11,6 +11,8 @@ import (
 
 // Entrypoint for CLI integration tests
 func TestMain(m *testing.M) {
+	os.Setenv("SPEAKEASY_CONCURRENCY_LOCK_DISABLED", "true")
+
 	// Create a temporary directory
 	if _, err := os.Stat(tempDir); err == nil {
 		if err := os.RemoveAll(tempDir); err != nil {

--- a/integration/workflow_test.go
+++ b/integration/workflow_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/utils"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -13,6 +12,8 @@ import (
 	"strings"
 	"sync"
 	"testing"
+
+	"github.com/speakeasy-api/speakeasy/internal/utils"
 
 	"github.com/speakeasy-api/speakeasy/cmd"
 	"github.com/speakeasy-api/versioning-reports/versioning"
@@ -248,8 +249,10 @@ func execute(t *testing.T, wd string, args ...string) Runnable {
 }
 
 // executeI is a helper function to execute the main.go file inline. It can help when debugging integration tests
-var mutex sync.Mutex
-var rootCmd = cmd.CmdForTest(version, artifactArch)
+var (
+	mutex   sync.Mutex
+	rootCmd = cmd.CmdForTest(version, artifactArch)
+)
 
 func executeI(t *testing.T, wd string, args ...string) Runnable {
 	mutex.Lock()

--- a/internal/charm/internalModel.go
+++ b/internal/charm/internalModel.go
@@ -2,7 +2,6 @@ package charm
 
 import (
 	"fmt"
-	"os"
 
 	tea "github.com/charmbracelet/bubbletea"
 )
@@ -59,7 +58,7 @@ func RunModel(m InternalModel, opts ...tea.ProgramOption) (InternalModel, error)
 	} else {
 		if m, ok := mResult.(modelWrapper); ok {
 			if m.signalExit {
-				os.Exit(0)
+				return nil, nil
 			}
 
 			return m.model, nil

--- a/internal/concurrency/concurrency.go
+++ b/internal/concurrency/concurrency.go
@@ -1,0 +1,131 @@
+package concurrency
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/speakeasy-api/speakeasy/internal/config"
+)
+
+// ErrLockExists indicates another process already holds the lock
+var ErrLockExists = errors.New("lock already exists: another Speakeasy process is running. You can: 1) wait for it to complete, 2) wait 1 minute for the lock to expire, or 3) manually remove the .lock file in your ~/.speakeasy directory if no other Speakeasy process is running")
+
+// MaxLockAge defines how old a lock can be before it's considered stale (1 minute)
+const MaxLockAge = time.Minute
+
+// AcquireLock attempts to atomically create a lock file
+// Returns nil if successful, ErrLockExists if another process holds the lock
+func AcquireLock() error {
+	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
+	if err != nil {
+		return err
+	}
+
+	lockFile := filepath.Join(speakeasyHomeDir, ".lock")
+
+	// Check if lock exists and is stale
+	if _, err := os.Stat(lockFile); err == nil {
+		// Lock exists, check if it's stale
+		if isStale, _ := isLockStale(lockFile); isStale {
+			// Lock is stale, remove it
+			os.Remove(lockFile)
+		} else {
+			return ErrLockExists
+		}
+	}
+
+	// O_EXCL with O_CREATE ensures the call fails if the file already exists
+	// This makes the check-and-create atomic
+	file, err := os.OpenFile(lockFile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o600)
+	if err != nil {
+		if os.IsExist(err) {
+			return ErrLockExists
+		}
+		return err
+	}
+
+	// Write the current PID and timestamp to help with debugging
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	if _, err := file.WriteString(filepath.Base(os.Args[0]) + "\n" + timestamp + "\n"); err != nil {
+		file.Close()
+		os.Remove(lockFile)
+		return err
+	}
+
+	return file.Close()
+}
+
+// UpdateLock updates the timestamp in the lock file
+func UpdateLock() error {
+	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
+	if err != nil {
+		return err
+	}
+
+	lockFile := filepath.Join(speakeasyHomeDir, ".lock")
+
+	// Check if we own the lock
+	content, err := os.ReadFile(lockFile)
+	if err != nil {
+		return err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if len(lines) == 0 || lines[0] != filepath.Base(os.Args[0]) {
+		return errors.New("lock not owned by this process")
+	}
+
+	// Update the lock file with a new timestamp
+	file, err := os.OpenFile(lockFile, os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	timestamp := strconv.FormatInt(time.Now().Unix(), 10)
+	_, err = file.WriteString(filepath.Base(os.Args[0]) + "\n" + timestamp + "\n")
+	return err
+}
+
+// isLockStale checks if the lock file is older than MaxLockAge
+func isLockStale(lockFile string) (bool, error) {
+	content, err := os.ReadFile(lockFile)
+	if err != nil {
+		return false, err
+	}
+
+	lines := strings.Split(string(content), "\n")
+	if len(lines) < 2 {
+		// Malformed lock file, consider it stale
+		return true, nil
+	}
+
+	timestamp, err := strconv.ParseInt(lines[1], 10, 64)
+	if err != nil {
+		// Malformed timestamp, consider it stale
+		return true, nil
+	}
+
+	lockTime := time.Unix(timestamp, 0)
+	return time.Since(lockTime) > MaxLockAge, nil
+}
+
+// ReleaseLock removes the lock file
+func ReleaseLock() error {
+	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
+	if err != nil {
+		return err
+	}
+
+	lockFile := filepath.Join(speakeasyHomeDir, ".lock")
+	return os.Remove(lockFile)
+}
+
+func SafeExit(code int) {
+	ReleaseLock()
+	os.Exit(code)
+}

--- a/internal/concurrency/concurrency.go
+++ b/internal/concurrency/concurrency.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/speakeasy-api/speakeasy/internal/config"
+	"github.com/speakeasy-api/speakeasy/internal/env"
 )
 
 // ErrLockExists indicates another process already holds the lock
@@ -20,6 +21,10 @@ const MaxLockAge = time.Minute
 // AcquireLock attempts to atomically create a lock file
 // Returns nil if successful, ErrLockExists if another process holds the lock
 func AcquireLock() error {
+	if env.IsConcurrencyLockDisabled() {
+		return nil
+	}
+
 	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
 	if err != nil {
 		return err
@@ -61,6 +66,10 @@ func AcquireLock() error {
 
 // UpdateLock updates the timestamp in the lock file
 func UpdateLock() error {
+	if env.IsConcurrencyLockDisabled() {
+		return nil
+	}
+
 	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
 	if err != nil {
 		return err
@@ -116,6 +125,10 @@ func isLockStale(lockFile string) (bool, error) {
 
 // ReleaseLock removes the lock file
 func ReleaseLock() error {
+	if env.IsConcurrencyLockDisabled() {
+		return nil
+	}
+
 	speakeasyHomeDir, err := config.GetSpeakeasyHomeDir()
 	if err != nil {
 		return err

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -22,17 +22,26 @@ const (
 	workspaceKeysKey = "workspace_api_keys"
 )
 
-func Load() error {
+func GetSpeakeasyHomeDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cfgDir = filepath.Join(home, ".speakeasy")
 
+	return cfgDir, nil
+}
+
+func Load() error {
+	speakeasyHomeDir, err := GetSpeakeasyHomeDir()
+	if err != nil {
+		return err
+	}
+
 	vCfg.SetConfigName("config")
 	vCfg.SetConfigType("yaml")
-	vCfg.AddConfigPath(cfgDir)
+	vCfg.AddConfigPath(speakeasyHomeDir)
 
 	if err := vCfg.ReadInConfig(); err != nil {
 		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {

--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -34,3 +34,7 @@ func IsLocalDev() bool {
 func SpeakeasyRunLocation() string {
 	return os.Getenv("SPEAKEASY_RUN_LOCATION")
 }
+
+func IsConcurrencyLockDisabled() bool {
+	return os.Getenv("SPEAKEASY_CONCURRENCY_LOCK_DISABLED") == "true"
+}

--- a/internal/interactivity/button.go
+++ b/internal/interactivity/button.go
@@ -5,7 +5,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"os"
+	"github.com/speakeasy-api/speakeasy/internal/concurrency"
 )
 
 var (
@@ -119,7 +119,7 @@ func (b *Button) OnUserExit() {}
 func (b *Button) Run() bool {
 	newM, err := charm_internal.RunModel(b)
 	if err != nil {
-		os.Exit(1)
+		concurrency.SafeExit(1)
 	}
 
 	resultingModel := newM.(*Button)

--- a/internal/interactivity/listSelect.go
+++ b/internal/interactivity/listSelect.go
@@ -1,10 +1,10 @@
 package interactivity
 
 import (
-	"os"
 	"slices"
 
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
+	"github.com/speakeasy-api/speakeasy/internal/concurrency"
 	"github.com/speakeasy-api/speakeasy/internal/utils"
 
 	"github.com/charmbracelet/bubbles/key"
@@ -140,7 +140,11 @@ func SelectFrom[T interface{}](label string, options []list.Item) T {
 
 	mResult, err := charm_internal.RunModel(&m)
 	if err != nil {
-		os.Exit(1)
+		concurrency.SafeExit(1)
+	}
+
+	if mResult == nil {
+		return *new(T)
 	}
 
 	final, _ := mResult.(*ListSelect[T])

--- a/internal/interactivity/multiInput.go
+++ b/internal/interactivity/multiInput.go
@@ -2,7 +2,6 @@ package interactivity
 
 import (
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/charmbracelet/bubbles/cursor"
@@ -11,6 +10,7 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/concurrency"
 )
 
 var (
@@ -255,7 +255,7 @@ func (m *MultiInput) OnUserExit() {}
 func (m *MultiInput) Run() map[string]string {
 	newM, err := charm_internal.RunModel(m)
 	if err != nil {
-		os.Exit(1)
+		concurrency.SafeExit(1)
 	}
 
 	resultingModel := newM.(*MultiInput)

--- a/internal/interactivity/simpleInput.go
+++ b/internal/interactivity/simpleInput.go
@@ -2,13 +2,13 @@ package interactivity
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/charmbracelet/bubbles/cursor"
 	"github.com/charmbracelet/bubbles/textinput"
 	tea "github.com/charmbracelet/bubbletea"
 	charm_internal "github.com/speakeasy-api/speakeasy/internal/charm"
 	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/concurrency"
 )
 
 type SimpleInput struct {
@@ -119,7 +119,7 @@ func (m *SimpleInput) OnUserExit() {}
 func (m *SimpleInput) Run() string {
 	newM, err := charm_internal.RunModel(m)
 	if err != nil {
-		os.Exit(1)
+		concurrency.SafeExit(1)
 	}
 
 	resultingModel := newM.(*SimpleInput)

--- a/pkg/merge/merge.go
+++ b/pkg/merge/merge.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"reflect"
 
+	"github.com/speakeasy-api/speakeasy/internal/concurrency"
 	utils2 "github.com/speakeasy-api/speakeasy/internal/utils"
 
 	"github.com/hashicorp/go-multierror"
@@ -40,7 +41,7 @@ func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, baseP
 	doc, err := libopenapi.NewDocumentWithConfiguration(data, &config)
 	if err != nil {
 		fmt.Printf("Error creating document: %v\n", err)
-		os.Exit(1)
+		concurrency.SafeExit(1)
 	}
 
 	v3Model, errors := doc.BuildV3Model()
@@ -48,7 +49,7 @@ func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, baseP
 		for _, err = range errors {
 			fmt.Printf("Error building model: %v\n", err)
 		}
-		os.Exit(1)
+		concurrency.SafeExit(1)
 	}
 
 	bytes, e := bundler.BundleDocument(&v3Model.Model)
@@ -56,7 +57,7 @@ func MergeByResolvingLocalReferences(ctx context.Context, inFile, outFile, baseP
 		panic(fmt.Errorf("bundling failed: %w", e))
 	}
 
-	err = os.WriteFile(outFile, bytes, 0644)
+	err = os.WriteFile(outFile, bytes, 0o644)
 	if err != nil {
 		panic(fmt.Errorf("failed to write bundled file: %w", err))
 	}

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -3,11 +3,12 @@ package prompts
 import (
 	"context"
 	"fmt"
-	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
-	"github.com/speakeasy-api/speakeasy/internal/log"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/speakeasy-api/speakeasy/internal/charm/styles"
+	"github.com/speakeasy-api/speakeasy/internal/log"
 
 	"github.com/pkg/errors"
 	"github.com/speakeasy-api/huh"
@@ -111,7 +112,7 @@ func targetBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 			"Chat with us for access: `https://go.speakeasy.com/chat`")
 
 		log.From(ctx).Println(msg)
-		os.Exit(0)
+		return nil, nil
 	}
 
 	quickstart.WorkflowFile.Targets[targetName] = *target


### PR DESCRIPTION
This pull request introduces several changes to improve concurrency handling, enhance error handling, and refine the codebase. The most significant updates include implementing a concurrency locking mechanism, replacing direct calls to `os.Exit` with a safer exit method, and enhancing GitHub action retries. Additionally, minor cleanup and refactoring were performed in various files.

### Concurrency Handling Enhancements:
* Introduced a `concurrency` package to manage process locks, including methods for acquiring, updating, and releasing locks to prevent multiple instances of the application from running simultaneously. (`internal/concurrency/concurrency.go`, [internal/concurrency/concurrency.goR1-R131](diffhunk://#diff-893614966c5d3b9b6c3685471925658b84348f66fd3fc8376076ad8d54525bdeR1-R131))
* Updated the main command execution flow to use the new locking mechanism, including periodic lock updates and signal handling for graceful shutdown. (`cmd/root.go`, [cmd/root.goL117-R178](diffhunk://#diff-ab967ab1a2f3a1b769106eeb7bfe892ef0e81d1d27811fa15be08e6749feee1fL117-R178))

### Error Handling Improvements:
* Replaced all `os.Exit` calls with a new `SafeExit` method from the `concurrency` package to ensure locks are released before exiting. (`internal/interactivity/button.go`, [[1]](diffhunk://#diff-600c6170648dc98b37b666efc19e00350cd8efad8035f90f392f6963dadd51f7L122-R122); `internal/interactivity/listSelect.go`, [[2]](diffhunk://#diff-18db6ef98884f0795575414883005156de964fe5d2a7231a15b09fe132a32015L143-R147); `pkg/merge/merge.go`, [[3]](diffhunk://#diff-0d68a86e5e2531accb4958c059c09ff7369b83b6fbbf011f7844c43b981da68dL43-R60)

### GitHub Action Enhancements:
* Added retry logic for triggering GitHub actions up to two additional times if they fail to start within the timeout period. (`internal/run/remote.go`, [internal/run/remote.goL96-R112](diffhunk://#diff-0973a4d35be55ba3d0cdd8249d3a6b295dc46de2dcf56b6539f4456dd7e844efL96-R112))

### Codebase Refinements:
* Cleaned up unused imports and improved file readability in several files. (`internal/charm/internalModel.go`, [[1]](diffhunk://#diff-60c1748bdd13148ba47dd900b64966e8b08b3e57b909c4cb22b748f7ba14a14fL5); `prompts/targets.go`, [[2]](diffhunk://#diff-985d67aa4f3ae74fe3684315246e9b799780a045f74a9bdebdea14434356b0c3L6-R12)
* Adjusted file permissions to use octal notation for clarity. (`pkg/merge/merge.go`, [pkg/merge/merge.goL43-R60](diffhunk://#diff-0d68a86e5e2531accb4958c059c09ff7369b83b6fbbf011f7844c43b981da68dL43-R60))

These changes collectively improve the stability, maintainability, and user experience of the application.