### PR TITLE
fix: pass fs abstraction in language server init

### DIFF
--- a/cmd/languageserver.go
+++ b/cmd/languageserver.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"github.com/speakeasy-api/openapi-generation/v2/languageserver"
+	"github.com/speakeasy-api/speakeasy/internal/fs"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"github.com/spf13/cobra"
 )
@@ -23,6 +24,8 @@ func languageServerExec(version string) func(cmd *cobra.Command, args []string) 
 		// setup logging to be discarded, it will invalidate the LSP protocol
 		logger := log.NewNoop()
 
-		return languageserver.NewServer(version, logger).Run()
+		fs := fs.NewFileSystem()
+
+		return languageserver.NewServer(version, logger, fs).Run()
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.2.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.604.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.604.4
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.16
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlo
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.2.0 h1:UetH06czYY1UJv6j1EZglO0OS0RqOgKwYLNVoiGNpF0=
 github.com/speakeasy-api/openapi v0.2.0/go.mod h1:/JmcsptZE2q1xi+oencU8rOJlJzgv5RMInKdqPsX2rg=
-github.com/speakeasy-api/openapi-generation/v2 v2.604.2 h1:3rakDtdTMBzoQrWNbUCmmt5HqwzPl3q4nf2oEiINueo=
-github.com/speakeasy-api/openapi-generation/v2 v2.604.2/go.mod h1:7XhCuUwep6cM+3mZeD/YGgJGgWRMYxdisA7rwlqkIqo=
+github.com/speakeasy-api/openapi-generation/v2 v2.604.4 h1:qV1nvCsSB8NGNCDkLrUAreI5XZlgQkNhufDxZI2/H/s=
+github.com/speakeasy-api/openapi-generation/v2 v2.604.4/go.mod h1:7XhCuUwep6cM+3mZeD/YGgJGgWRMYxdisA7rwlqkIqo=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.30.16 h1:mqqZN8uYo54EHLej/SU+G9JoDrxCR4wcqrZEYhEaWCQ=

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -1,0 +1,50 @@
+package fs
+
+import (
+	"io/fs"
+	"os"
+
+	"github.com/speakeasy-api/openapi-generation/v2/pkg/filesystem"
+)
+
+// FileSystem is a wrapper around the os.FS type that implements the filesystem.FileSystem interface needed by the openapi-generation package
+type FileSystem struct {
+}
+
+var _ filesystem.FileSystem = &FileSystem{}
+
+func NewFileSystem() *FileSystem {
+	return &FileSystem{}
+}
+
+func (f *FileSystem) ReadFile(path string) ([]byte, error) {
+	return os.ReadFile(path)
+}
+
+func (f *FileSystem) WriteFile(path string, data []byte, perm os.FileMode) error {
+	return os.WriteFile(path, data, perm)
+}
+
+func (f *FileSystem) MkdirAll(path string, perm os.FileMode) error {
+	return os.MkdirAll(path, perm)
+}
+
+func (f *FileSystem) Open(path string) (fs.File, error) {
+	return os.Open(path)
+}
+
+func (f *FileSystem) OpenFile(path string, flag int, perm os.FileMode) (filesystem.File, error) {
+	return os.OpenFile(path, flag, perm)
+}
+
+func (f *FileSystem) Stat(path string) (os.FileInfo, error) {
+	return os.Stat(path)
+}
+
+func (f *FileSystem) Remove(path string) error {
+	return os.Remove(path)
+}
+
+func (f *FileSystem) RemoveAll(path string) error {
+	return os.RemoveAll(path)
+}


### PR DESCRIPTION
The language server (via WASM) needs to pass in a virtual file system implementation, and so therefore we need to update the CLI's callsite with the same interface (but using standard OS calls)