### PR TITLE
fix: Ensure mcp-typescript support for configure publishing and sdk-generation-action

### DIFF
--- a/cmd/generate/generate.go
+++ b/cmd/generate/generate.go
@@ -19,13 +19,8 @@ import (
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 )
 
-func SDKSupportedLanguageTargets() []string {
-	targetNames := generate.GetSupportedSDKTargetNames()
-
-	// Legacy "SDK" language, kept for backwards compatibility.
-	targetNames = append(targetNames, "terraform")
-
-	return targetNames
+func GeneratorSupportedTargetNames() []string {
+	return generate.GetSupportedTargetNames()
 }
 
 var (

--- a/cmd/generate/sdk.go
+++ b/cmd/generate/sdk.go
@@ -32,7 +32,7 @@ type GenerateFlags struct {
 
 var genSDKCmd = &model.ExecutableCommand[GenerateFlags]{
 	Usage:        "sdk",
-	Short:        fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s)", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+	Short:        fmt.Sprintf("Generating Client SDKs from OpenAPI specs (%s)", strings.Join(GeneratorSupportedTargetNames(), ", ")),
 	Long:         generateLongDesc,
 	Run:          genSDKs,
 	RequiresAuth: true,
@@ -41,8 +41,8 @@ var genSDKCmd = &model.ExecutableCommand[GenerateFlags]{
 			Name:          "lang",
 			Shorthand:     "l",
 			Required:      true,
-			AllowedValues: SDKSupportedLanguageTargets(),
-			Description:   fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(SDKSupportedLanguageTargets(), ", ")),
+			AllowedValues: GeneratorSupportedTargetNames(),
+			Description:   fmt.Sprintf("language to generate sdk for (available options: [%s])", strings.Join(GeneratorSupportedTargetNames(), ", ")),
 		},
 		schemaFlag,
 		outFlag,
@@ -200,4 +200,4 @@ generate:
 `+"```"+`
 
 For additional documentation visit: https://speakeasy.com/docs/using-speakeasy/create-client-sdks/intro
-`, strings.Join(SDKSupportedLanguageTargets(), "\n	- "))
+`, strings.Join(GeneratorSupportedTargetNames(), "\n	- "))

--- a/cmd/generate/supportedTargets.go
+++ b/cmd/generate/supportedTargets.go
@@ -21,6 +21,6 @@ var suportedTargetsCmd = &model.ExecutableCommand[supportedTargetsFlags]{
 
 func runSupportedTargets(ctx context.Context, flags supportedTargetsFlags) error {
 	// Do not change this output structure, the sdk-generation-action depends on it
-	fmt.Println(strings.Join(SDKSupportedLanguageTargets(), ","))
+	fmt.Println(strings.Join(GeneratorSupportedTargetNames(), ","))
 	return nil
 }

--- a/integration/utils.go
+++ b/integration/utils.go
@@ -67,7 +67,7 @@ func expectedFilesByLanguage(language string) []string {
 	switch language {
 	case "go":
 		return []string{"README.md", "sdk.go", "go.mod"}
-	case "typescript":
+	case "mcp-typescript", "typescript":
 		return []string{"README.md", "package.json", "tsconfig.json"}
 	case "python":
 		return []string{"README.md", "setup.py"}

--- a/internal/migrate/migrate.go
+++ b/internal/migrate/migrate.go
@@ -349,7 +349,7 @@ func getPublishing(genWorkflow config.GenerateWorkflow, lang string) *workflow.P
 	if shouldPublish {
 		// These secret values are hardcoded because they are the names of the secrets in the action
 		switch lang {
-		case "typescript":
+		case "mcp-typescript", "typescript":
 			return &workflow.Publishing{
 				NPM: &workflow.NPM{
 					Token: "$NPM_TOKEN",

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -29,6 +29,9 @@ var quickstartScopedKeys = map[string][]string{
 	"go": {
 		"packageName",
 	},
+	"mcp-typescript": {
+		"packageName",
+	},
 	"typescript": {
 		"packageName",
 	},

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -39,21 +39,22 @@ const (
 )
 
 var SupportedPublishingTargets = []string{
-	"typescript",
-	"python",
 	"csharp",
-	"ruby",
-	"php",
-	"java",
 	"go",
+	"java",
+	"mcp-typescript",
+	"php",
+	"python",
+	"ruby",
 	"terraform",
+	"typescript",
 }
 
 var SupportedTestingTargets = []string{
-	"typescript",
-	"python",
 	"go",
 	"java",
+	"python",
+	"typescript",
 }
 
 //go:embed terraform_release.yaml
@@ -121,7 +122,7 @@ func ConfigurePublishing(target *workflow.Target, name string) (*workflow.Target
 
 	if hasPublishingDefined {
 		switch target.Target {
-		case "typescript":
+		case "mcp-typescript", "typescript":
 			if target.Publishing.NPM != nil {
 				return target, nil
 			}
@@ -153,7 +154,7 @@ func ConfigurePublishing(target *workflow.Target, name string) (*workflow.Target
 	}
 
 	switch target.Target {
-	case "typescript":
+	case "mcp-typescript", "typescript":
 		target.Publishing = &workflow.Publishing{
 			NPM: &workflow.NPM{
 				Token: formatWorkflowSecret(npmTokenDefault),


### PR DESCRIPTION
This set of changes ensures that for the `configure publishing` command, the mcp-typescript target works similar to the typescript target. It also ensures that new target name is returned from the hidden `generate supported-targets` command, which is a requirement for sdk-generation-action to support the new target name.