### PR TITLE
fix: Ensure install.sh uses authenticated GitHub API calls

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -15,6 +15,15 @@ BINARY_NAME=${BINARY_NAME:-"speakeasy"}
 REPO_NAME="speakeasy-api/speakeasy"
 ISSUE_URL="https://github.com/speakeasy-api/speakeasy/issues/new"
 
+# github_api_curl - make authenticated GitHub API calls
+github_api_curl() {
+  if [ -n "$GITHUB_TOKEN" ]; then
+    curl -H "Authorization: Bearer $GITHUB_TOKEN" "$@"
+  else
+    curl "$@"
+  fi
+}
+
 # get_latest_release "speakeasy-api/speakeasy"
 get_latest_release() {
   local retry=0
@@ -23,7 +32,7 @@ get_latest_release() {
   local delay=1
 
   while [ $retry -lt $max_retries ]; do
-    release_info=$(curl --retry 5 --silent "https://api.github.com/repos/$1/releases/latest")
+    release_info=$(github_api_curl --retry 5 --silent "https://api.github.com/repos/$1/releases/latest")
     tag_name=$(echo "$release_info" | grep '"tag_name":' | sed -E 's/.*"([^"]+)".*/\1/')
 
     if echo "$tag_name" | grep -q '^v'; then


### PR DESCRIPTION
When ran from a GitHub Actions workflow like:

```yaml
    - name: Install Speakeasy CLI
      run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh
```

You would very very often run into an issue with rate limiting (causing your actions workflow to fail). This is because, by default, the rate limit for requests to api.github.com is 60 requests per hour per originating IP address. In a GHA runner context you end up using shared IP address pools, and hit rate limiting issues pretty often.

This change updates the install script to use an authenticated request if the environment has `$GITHUB_TOKEN` available, if not it does what it's always done (uses an unauthenticated request). Authenticated requests have much higher rate limits. In a GHA scenario it's 1000 per hour per repo (with a PAT it is 5000 per hour per user).

In order for folks to avoid the rate limiting issue they still will need to change their workflow to set the `GITHUB_TOKEN` (so it's not a "magic" fix):

```yaml
    - name: Install Speakeasy CLI
      run: curl -fsSL https://go.speakeasy.com/cli-install.sh | sh
      env:
        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
```

Refs:

- https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28