### PR TITLE
chore: Upgrade script improvements

### DIFF
--- a/scripts/upgrade.bash
+++ b/scripts/upgrade.bash
@@ -11,32 +11,19 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
   read -r CURRENT_OPENAPI_GENERATION_VERSION <<<$(cat go.mod | grep github.com/speakeasy-api/openapi-generation/v2 | awk '{ print $2 }' | awk '{print substr($1,2); }')
   # echo "  => CURRENT_OPENAPI_GENERATION_VERSION=${CURRENT_OPENAPI_GENERATION_VERSION}"
-
-  read -r ALL_OPENAPI_GENERATION_VERSION <<<$(go list -m -versions -json github.com/speakeasy-api/openapi-generation/v2 | jq -r '.Versions | .[]' | awk '{print substr($1,2); }' | tr '\n' ' ')
-  # echo "  => ALL_OPENAPI_GENERATION_VERSION=${ALL_OPENAPI_GENERATION_VERSION}"
-  LAST=
-  START_DATE=
-  for VERSION in $ALL_OPENAPI_GENERATION_VERSION; do
-    read -r IS_BIGGER <<<$("${SCRIPT_DIR}/semver.bash" compare "${VERSION}" "${CURRENT_OPENAPI_GENERATION_VERSION}")
-    if [[ $IS_BIGGER == "1" && -z $START_DATE ]]; then
-      START_DATE=$(gh search commits "v$LAST" --repo speakeasy-api/openapi-generation --json "commit" | jq -r '.[] | .commit.committer.date')
-      # echo "  => START_DATE=${START_DATE}"
-      LAST=$VERSION
-    fi
-    LAST=$VERSION
-  done
+  START_DATE=$(gh release view "v${CURRENT_OPENAPI_GENERATION_VERSION}" --repo speakeasy-api/openapi-generation --json createdAt | jq -r '.createdAt')
 
   if [[ -z $START_DATE ]]; then
-    echo "Could not find any recent commits"
+    echo "Could not find current version (v${CURRENT_OPENAPI_GENERATION_VERSION}) release"
     exit 1
   fi
 
-  ALL_COMMIT_MESSAGES=$(gh search commits " " --committer-date=">$START_DATE" --repo speakeasy-api/openapi-generation --json "commit" | jq '.[] | .commit.message')
-#  echo "  => ALL_COMMIT_MESSAGES=${ALL_COMMIT_MESSAGES}"
-  NEXT_OPENAPI_GENERATION_VERSION=$LAST
-#  echo "  => NEXT_OPENAPI_GENERATION_VERSION=${NEXT_OPENAPI_GENERATION_VERSION}"
+  PRS=$(gh pr list --repo speakeasy-api/openapi-generation --state merged --search "merged:>${START_DATE}" --json title,url | jq -r '.[] | .title+"\n > "+.url+"\n"')
+#  echo "  => PRS=${PRS}"
+  LATEST_OPENAPI_GENERATION_VERSION=$(gh release list --limit 1 --repo speakeasy-api/openapi-generation --json tagName | jq -r '.[0].tagName')
+#  echo "  => LATEST_OPENAPI_GENERATION_VERSION=${LATEST_OPENAPI_GENERATION_VERSION}"
 
-  read -r SEMVER_CHANGE <<<$("${SCRIPT_DIR}/semver.bash" diff "${CURRENT_OPENAPI_GENERATION_VERSION}" "${NEXT_OPENAPI_GENERATION_VERSION}")
+  read -r SEMVER_CHANGE <<<$("${SCRIPT_DIR}/semver.bash" diff "${CURRENT_OPENAPI_GENERATION_VERSION}" "${LATEST_OPENAPI_GENERATION_VERSION}")
 #  echo "  => SEMVER_CHANGE=${SEMVER_CHANGE}"
 
   if [[ "$SEMVER_CHANGE" == "none" || -z $SEMVER_CHANGE ]]; then
@@ -46,9 +33,11 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
   read -r BUMPED_CURRENT_VERSION <<<$("${SCRIPT_DIR}/semver.bash" bump "${SEMVER_CHANGE}" "${CURRENT_VERSION}")
 #  echo "  => BUMPED_CURRENT_VERSION=${BUMPED_CURRENT_VERSION}"
-  echo "  ===== Commit Messages ==== "
-  echo "$ALL_COMMIT_MESSAGES"
-  echo "  ===== End Commit Messages ==== "
+  echo "  ===== Pull Requests ==== "
+  while IFS= read -r PR; do
+    echo -e "${PR}"
+  done <<< "$PRS"
+  echo "  ===== End Pull Requests ==== "
   if command -v gum &> /dev/null; then
     SUMMARY=$(gum input --placeholder "Commit Message (please summarize changes above): ")
   else
@@ -56,7 +45,7 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     read -p "Commit Message (please summarize changes above): " SUMMARY
   fi
 
-  go get -v "github.com/speakeasy-api/openapi-generation/v2@v${NEXT_OPENAPI_GENERATION_VERSION}"
+  go get -v "github.com/speakeasy-api/openapi-generation/v2@${LATEST_OPENAPI_GENERATION_VERSION}"
   go mod tidy
 
   echo "$ git add go.mod go.sum"


### PR DESCRIPTION
These changes:

* Fixes situations where the commit message section was empty due to multiple start date values (e.g. DATETIME1\nDATETIME2) making an invalid search pattern
* Simplifies current and latest openapi-generation version lookups to single `gh release` commands
* Outputs PRs as titles and URLs (where better titles reduce need for link) instead of more complex full commit message handling/output

For example, the output is now:

```
  ===== Pull Requests ====
fix(pythonv2): Conditionally use README-PYPI.md and remove from .gitignore
 > https://github.com/speakeasy-api/openapi-generation/pull/2743

fix: const handling
 > https://github.com/speakeasy-api/openapi-generation/pull/2740

fix: `infer-optional-args`
 > https://github.com/speakeasy-api/openapi-generation/pull/2738

fix: recover from panics as promise rejections in WASM
 > https://github.com/speakeasy-api/openapi-generation/pull/2737

chore: upgrade snapshot tests
 > https://github.com/speakeasy-api/openapi-generation/pull/2736

feat: javav2 - add packageName to new SDK gen.yaml, fix javadoc warnings GEN-1493, GEN-1498
 > https://github.com/speakeasy-api/openapi-generation/pull/2728
  ===== End Pull Requests ====
```