### PR TITLE
feat: set default output for sources

### DIFF
--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -507,7 +507,7 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	if outputLocation != "" {
 		source.Output = &outputLocation
-	} else {
+	} else if authHeader == "" {
 		// Set default output path for source
 		defaultOutput := ".speakeasy/out.openapi.yaml"
 		source.Output = &defaultOutput

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -290,7 +290,7 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 	source.Inputs = append(source.Inputs, *document)
 
 	if source.Output == nil {
-	// Set default output path for source
+		// Set default output path for source
 		defaultOutput := ".speakeasy/out.openapi.yaml"
 		source.Output = &defaultOutput
 	}

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -289,7 +289,7 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 	}
 	source.Inputs = append(source.Inputs, *document)
 
-	if source.Output == nil {
+	if source.Output == nil || *source.Output == "" {
 		// Set default output path for source
 		defaultOutput := ".speakeasy/out.openapi.yaml"
 		source.Output = &defaultOutput

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -289,7 +289,7 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 	}
 	source.Inputs = append(source.Inputs, *document)
 
-	if source.Output == nil || *source.Output == "" {
+	if authHeader == "" && (source.Output == nil || *source.Output == "") {
 		// Set default output path for source
 		defaultOutput := ".speakeasy/out.openapi.yaml"
 		source.Output = &defaultOutput

--- a/prompts/sources.go
+++ b/prompts/sources.go
@@ -289,6 +289,12 @@ func sourceBaseForm(ctx context.Context, quickstart *Quickstart) (*QuickstartSta
 	}
 	source.Inputs = append(source.Inputs, *document)
 
+	if source.Output == nil {
+	// Set default output path for source
+		defaultOutput := ".speakeasy/out.openapi.yaml"
+		source.Output = &defaultOutput
+	}
+
 	if registry.IsRegistryEnabled(ctx) && orgSlug != "" && auth.GetWorkspaceSlugFromContext(ctx) != "" {
 		if err := configureRegistry(source, orgSlug, auth.GetWorkspaceSlugFromContext(ctx), sourceName); err != nil {
 			return nil, err
@@ -501,6 +507,10 @@ func PromptForNewSource(currentWorkflow *workflow.Workflow) (string, *workflow.S
 
 	if outputLocation != "" {
 		source.Output = &outputLocation
+	} else {
+		// Set default output path for source
+		defaultOutput := ".speakeasy/out.openapi.yaml"
+		source.Output = &defaultOutput
 	}
 
 	if err := source.Validate(); err != nil {


### PR DESCRIPTION
It's nice to have the resulting spec checked into the repo (under the .speakeasy folder) for debugging and reviewing PRs more easily.