### PR TITLE
feat: SPEAKEASY_CONFIRM_WORKSPACE prevent destructive actions for admins

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -3,10 +3,14 @@ package auth
 import (
 	"context"
 	"fmt"
+	"os"
 
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/operations"
 	core "github.com/speakeasy-api/speakeasy-core/auth"
 	"github.com/speakeasy-api/speakeasy/internal/config"
+	"github.com/speakeasy-api/speakeasy/internal/interactivity"
 	"github.com/speakeasy-api/speakeasy/internal/log"
+	"github.com/speakeasy-api/speakeasy/internal/sdk"
 )
 
 func Authenticate(ctx context.Context, force bool) (context.Context, error) {
@@ -51,6 +55,73 @@ func Logout(ctx context.Context) error {
 	log.From(ctx).
 		WithInteractiveOnly().
 		Success("Logout successful!")
+
+	return nil
+}
+
+func ConfirmWorkspace(ctx context.Context) error {
+	confirmEnv := os.Getenv("SPEAKEASY_CONFIRM_WORKSPACE")
+	if confirmEnv == "" {
+		return nil
+	}
+
+	workspaceID, err := core.GetWorkspaceIDFromContext(ctx)
+	if err != nil {
+		return nil
+	}
+
+	client, err := sdk.InitSDK()
+	if err != nil {
+		return nil
+	}
+
+	wsReq := operations.GetWorkspaceRequest{
+		WorkspaceID: &workspaceID,
+	}
+
+	wsRes, err := client.Workspaces.GetByID(ctx, wsReq)
+	if err != nil {
+		return nil
+	}
+
+	if wsRes.StatusCode != 200 || wsRes.Workspace == nil {
+		return nil
+	}
+
+	orgReq := operations.GetOrganizationRequest{
+		OrganizationID: wsRes.Workspace.OrganizationID,
+	}
+
+	orgRes, err := client.Organizations.Get(ctx, orgReq)
+	if err != nil {
+		return nil
+	}
+
+	if orgRes.StatusCode != 200 || orgRes.Organization == nil {
+		return nil
+	}
+
+	workspaceName := wsRes.Workspace.Name
+	if workspaceName == "" {
+		workspaceName = wsRes.Workspace.Slug
+	}
+
+	orgName := orgRes.Organization.Name
+	if orgName == "" {
+		orgName = orgRes.Organization.Slug
+	}
+
+	if workspaceID == "self" || (orgRes.Organization.Internal != nil && *orgRes.Organization.Internal) {
+		log.From(ctx).Info(fmt.Sprintf("Running command in workspace: %s/%s", orgName, workspaceName))
+		return nil
+	}
+
+	message := fmt.Sprintf("You are about to run this command in workspace: %s/%s", orgName, workspaceName)
+	confirmed := interactivity.SimpleConfirm(message, false)
+
+	if !confirmed {
+		return fmt.Errorf("command cancelled by user")
+	}
 
 	return nil
 }

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -124,6 +124,11 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 				return err
 			}
 			cmd.SetContext(authCtx)
+
+			if err := auth.ConfirmWorkspace(authCtx); err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
 		} else {
 			authCtx, err := auth.UseExistingAPIKeyIfAvailable(cmd.Context())
 			if err != nil {
@@ -131,6 +136,11 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 				return err
 			}
 			cmd.SetContext(authCtx)
+
+			if err := auth.ConfirmWorkspace(authCtx); err != nil {
+				cmd.SilenceUsage = true
+				return err
+			}
 		}
 
 		// If the command uses a workflow file, run using the version specified in the workflow file


### PR DESCRIPTION
Admins can be switching between different workspaces and sometimes end up acting in the wrong workspace. Admins can now set `export SPEAKEASY_CONFIRM_WORKSPACE=1` in their ~/.bashrc or ~/.zshrc to prevent that.

If they're logged in to an internal workspace or they're using speakeasy-self the confirm will not appear.