### PR TITLE
fix: baseErrorName default + multipart/form-data unions TypescriptV2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -36,7 +36,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.2.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.623.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.623.4
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.21
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlo
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.2.0 h1:UetH06czYY1UJv6j1EZglO0OS0RqOgKwYLNVoiGNpF0=
 github.com/speakeasy-api/openapi v0.2.0/go.mod h1:/JmcsptZE2q1xi+oencU8rOJlJzgv5RMInKdqPsX2rg=
-github.com/speakeasy-api/openapi-generation/v2 v2.623.2 h1:ZLzOtEkdofbLijX/eeuuEA6CP4jZ578wGZmZNfrhxrk=
-github.com/speakeasy-api/openapi-generation/v2 v2.623.2/go.mod h1:mC7UorBwjUi9Xkq6+f1N1k7/Qw1NhWo8PQRuCod46tA=
+github.com/speakeasy-api/openapi-generation/v2 v2.623.4 h1:3X+NtI0anso/XrgTIEwiUikp3+lo1gV/mma3rwfw11o=
+github.com/speakeasy-api/openapi-generation/v2 v2.623.4/go.mod h1:mC7UorBwjUi9Xkq6+f1N1k7/Qw1NhWo8PQRuCod46tA=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.30.21 h1:gfyApIjMItLjAL1/y0Z5UjJX7EcesliJeypRMkzeuo8=


### PR DESCRIPTION
- handle unions for multipart/form-data request body in Typescript (GEN-1508)
- fix `baseErrorName` default value to prevent failures on fresh SDK generation in `speakeasy quickstart` (addresses `#inc-2025-06-09-typescript-base-error-name-failing-for-quickstart-and-config`)