### PR TITLE
feat: add ability to rebuild selective operation tests in arazzo documents

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/samber/lo v1.47.0
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
-	github.com/speakeasy-api/openapi v0.2.0
+	github.com/speakeasy-api/openapi v0.2.1
 	github.com/speakeasy-api/openapi-generation/v2 v2.629.1
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.30.21

--- a/go.sum
+++ b/go.sum
@@ -579,8 +579,8 @@ github.com/speakeasy-api/jsonpath v0.6.2 h1:Mys71yd6u8kuowNCR0gCVPlVAHCmKtoGXYoA
 github.com/speakeasy-api/jsonpath v0.6.2/go.mod h1:ymb2iSkyOycmzKwbEAYPJV/yi2rSmvBCLZJcyD+VVWw=
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlouDXUU8J+cMv01hSOdKqHentbIfQuc88=
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
-github.com/speakeasy-api/openapi v0.2.0 h1:UetH06czYY1UJv6j1EZglO0OS0RqOgKwYLNVoiGNpF0=
-github.com/speakeasy-api/openapi v0.2.0/go.mod h1:/JmcsptZE2q1xi+oencU8rOJlJzgv5RMInKdqPsX2rg=
+github.com/speakeasy-api/openapi v0.2.1 h1:0mtVOnLTcBdNXHGDMhk9ri41nek1f/K8/iepT9V7Z8s=
+github.com/speakeasy-api/openapi v0.2.1/go.mod h1:ilmVT3LXMsqLZcHOp3JN/DjZZS0PK9v6H7Jt8iPeC48=
 github.com/speakeasy-api/openapi-generation/v2 v2.629.1 h1:imlzXCVbDLXKQuWQSbve/S9yqDuN+i/3OLApdZfGYis=
 github.com/speakeasy-api/openapi-generation/v2 v2.629.1/go.mod h1:rzd0RW/K82YiG43g8vewVcFXfwOWp1wUoZib2oCJ4l0=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=

--- a/internal/model/flag/flag.go
+++ b/internal/model/flag/flag.go
@@ -36,4 +36,5 @@ var _ = []Flag{
 	&IntFlag{},
 	&MapFlag{},
 	&StringSliceFlag{},
+	&StringFlagWithOptionalValue{},
 }

--- a/internal/model/flag/stringFlagWithOptionalValue.go
+++ b/internal/model/flag/stringFlagWithOptionalValue.go
@@ -1,0 +1,49 @@
+package flag
+
+import (
+	"github.com/speakeasy-api/speakeasy/internal/charm"
+	"github.com/spf13/cobra"
+)
+
+type StringFlagWithOptionalValue struct {
+	Name, Shorthand, Description string
+	Required, Hidden             bool
+	DefaultValue                 string
+	AutocompleteFileExtensions   []string
+	Deprecated                   bool
+	DeprecationMessage           string
+}
+
+func (f StringFlagWithOptionalValue) Init(cmd *cobra.Command) error {
+	// Create a regular string flag first
+	cmd.Flags().StringP(f.Name, f.Shorthand, f.DefaultValue, f.Description)
+
+	// Set the NoOptDefVal to enable optional argument behavior
+	flag := cmd.Flags().Lookup(f.Name)
+	if flag != nil {
+		flag.NoOptDefVal = f.DefaultValue
+	}
+
+	if err := setRequiredAndHidden(cmd, f.Name, f.Required, f.Hidden); err != nil {
+		return err
+	}
+	if f.Deprecated {
+		if err := setDeprecated(cmd, f.Name, f.DeprecationMessage); err != nil {
+			return err
+		}
+	}
+	if len(f.AutocompleteFileExtensions) > 0 {
+		if err := cmd.Flags().SetAnnotation(f.Name, charm.AutoCompleteAnnotation, f.AutocompleteFileExtensions); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (f StringFlagWithOptionalValue) GetName() string {
+	return f.Name
+}
+
+func (f StringFlagWithOptionalValue) ParseValue(v string) (interface{}, error) {
+	return v, nil
+}


### PR DESCRIPTION
This PR introduces the ability to rebuild just specific operation tests in arazzo documents, providing more granular control over test execution and rebuilding processes.

## Changes
- Added new `stringFlagWithOptionalValue` flag type for flexible command-line options
- Updated flag handling logic to support selective operation targeting
- Modified testing infrastructure to support selective rebuilds
- Updated openapi library to maintain arazzo document ordering
- Updated dependencies to support new functionality

## Benefits
- Improved efficiency by allowing targeted test rebuilds
- Better developer experience with more granular control
- Reduced build times for large arazzo documents with many operations
- Maintains proper arazzo document structure and ordering during operations