### PR TITLE
docs(configure): Passing multiple value to `tests --rebuild`

### DIFF
--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -169,7 +169,7 @@ var configureTestingCmd = &model.ExecutableCommand[ConfigureTestsFlags]{
 		},
 		flag.StringFlagWithOptionalValue{
 			Name:         "rebuild",
-			Description:  "clears out all existing tests and regenerates them from scratch or if operations are specified will rebuild the tests for those operations",
+			Description:  "clears out all existing tests and regenerates them from scratch or if operations are specified will rebuild the tests for those operations (multiple operations can be specified as a single comma separated value)",
 			DefaultValue: "*",
 		},
 	},


### PR DESCRIPTION
Implementation wise, `--rebuild` takes a single string. If it's value is `*` (the default) all tests are rebuilt, but you can specify a list of operationIds to clear only specific ones. The way you do that is by passing a single comma separated list of operationIds like `--rebuild listFoo,deleteBar` etc. 

It was unclear from the docs just how to specify multiple entries, so I added a bit more prose to the help output. I'm happy to tweak / iterate on the prose if y'all have suggestions.

---

Note: CI will not pass due to being from a fork (forks don't get access to secrets which are needed to setup CI for testing).