### PR TITLE
fix: mock server generation for SDKs without tests and expose Java SDK debug logging flag

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.2.3
-	github.com/speakeasy-api/openapi-generation/v2 v2.638.5
+	github.com/speakeasy-api/openapi-generation/v2 v2.639.2
 	github.com/speakeasy-api/openapi-overlay v0.10.1
 	github.com/speakeasy-api/sdk-gen-config v1.31.1
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.1

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlo
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.2.3 h1:jxeYXcAn1r5PyUZzXeG7T65hpJMcdTg84nDF0YUCdAw=
 github.com/speakeasy-api/openapi v0.2.3/go.mod h1:vqBYh4eIgL9mVqrtdbuttji0ggR3/4xqU1ief4rjzY4=
-github.com/speakeasy-api/openapi-generation/v2 v2.638.5 h1:J29jzXR3+KiEitjf93ohpJbhe8EDyBXzDYA20DadPCE=
-github.com/speakeasy-api/openapi-generation/v2 v2.638.5/go.mod h1:jvi4wIrasRMSARbGz2I784+VAmcWVocW9ifiDSXMFaY=
+github.com/speakeasy-api/openapi-generation/v2 v2.639.2 h1:aNtkQT5UiHZLWvy4hf5I22WXYq74YxNS0QgNSLKiBl0=
+github.com/speakeasy-api/openapi-generation/v2 v2.639.2/go.mod h1:jvi4wIrasRMSARbGz2I784+VAmcWVocW9ifiDSXMFaY=
 github.com/speakeasy-api/openapi-overlay v0.10.1 h1:XFx/GvJvtAGf4dcQ6bxzsLNf76x/QWE2X0SSZrWojBQ=
 github.com/speakeasy-api/openapi-overlay v0.10.1/go.mod h1:n0iOU7AqKpNFfEt6tq7qYITC4f0yzVVdFw0S7hukemg=
 github.com/speakeasy-api/sdk-gen-config v1.31.1 h1:peGHmojOH4OzCpKHoaQ++a7J6hLy6iOpWjoBtxwHykY=


### PR DESCRIPTION
• Upgraded openapi-generation dependency from v2.638.5 to v2.639.2
• Fix: prevent erroneous mock server generation for SDKs without tests
• Fix: java make debug logging flag accessible from sdkconfiguration