### PR TITLE
chore: enable debug file writing by default for better error diagnostics

### DIFF
--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -151,9 +151,8 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 		generatorOpts = append(generatorOpts, generate.WithVerboseOutput(true))
 	}
 
-	if opts.Debug {
-		generatorOpts = append(generatorOpts, generate.WithDebuggingEnabled())
-	}
+	// Always enable debug file writing to help with troubleshooting format errors
+	generatorOpts = append(generatorOpts, generate.WithDebuggingEnabled())
 
 	// Enable outputting of internal tests for internal speakeasy use cases
 	if opts.OutputTests {


### PR DESCRIPTION
https://linear.app/speakeasy/issue/CUS-211/bug-consider-writing-failed-format-command-files-without-debug