### PR TITLE
feat: add scheduled hourly test runs with Slack notifications

### DIFF
--- a/.github/workflows/scheduled-tests.yml
+++ b/.github/workflows/scheduled-tests.yml
@@ -3,7 +3,7 @@ name: Scheduled Tests
 on:
   schedule:
     # Run every hour
-    - cron: '0 * * * *'
+    - cron: "0 * * * *"
   workflow_dispatch: # Allow manual triggering for testing
 
 jobs:
@@ -15,44 +15,44 @@ jobs:
       contents: read
       id-token: write
       actions: read
-    
+
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
+
       - name: Set up Go
         uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
         with:
           go-version-file: "go.mod"
-      
+
       - name: Set up Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: "3.9"
-      
+
       - name: Set up Node
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "16.x"
           registry-url: "https://registry.npmjs.org"
-      
+
       - name: Set up gotestfmt
         run: go install github.com/gotesttools/gotestfmt/v2/cmd/gotestfmt@latest
-      
+
       - name: Configure git for private modules
         env:
           GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
         run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
-      
+
       - name: Build
         run: go build ./...
-      
+
       - name: Run Tests
         id: test
         run: |
           go test -json -v -p 1 -timeout=20m ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}
-      
+
       - name: Notify Slack on Failure
         if: failure()
         uses: 8398a7/action-slack@807a8cb6243c41285b60b87ea5da7c6c5b1de3b9 # v3.18.0
@@ -60,47 +60,9 @@ jobs:
           status: failure
           text: |
             :x: Scheduled tests failed!
-            
+
             *Workflow:* ${{ github.workflow }}
             *Job:* ${{ github.job }}
             *Branch:* ${{ github.ref }}
             *Run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          webhook_url: ${{ secrets.SLACK_DOCS_WEBHOOK_URL }}
-          
-  golangci-lint:
-    name: Go Linting
-    runs-on:
-      group: ubuntu-latest-large
-    permissions:
-      contents: read
-      
-    steps:
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-      
-      - uses: actions/setup-go@d35c59abb061a4a6fb18e82ac0862c26744d6ab5 # v5.5.0
-        with:
-          go-version-file: "go.mod"
-          
-      - name: Configure git for private modules
-        env:
-          GIT_AUTH_TOKEN: ${{ secrets.BOT_REPO_TOKEN }}
-        run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
-        
-      - uses: golangci/golangci-lint-action@4afd733a84b1f43292c63897423277bb7f4313a9 # v8.0.0
-        with:
-          version: v2.1.6
-          args: --timeout=10m --verbose
-          
-      - name: Notify Slack on Failure
-        if: failure()
-        uses: 8398a7/action-slack@807a8cb6243c41285b60b87ea5da7c6c5b1de3b9 # v3.18.0
-        with:
-          status: failure
-          text: |
-            :x: Scheduled golangci-lint failed!
-            
-            *Workflow:* ${{ github.workflow }}
-            *Job:* ${{ github.job }}
-            *Branch:* ${{ github.ref }}
-            *Run:* ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
-          webhook_url: ${{ secrets.SLACK_DOCS_WEBHOOK_URL }}
+          webhook_url: ${{ secrets.SLACK_DEV_SDKS_WEBHOOK_URL }}


### PR DESCRIPTION
Tests will run on an hourly cron so that we can catch issues with unpinned dependencies in generated SDKs

