### PR TITLE
Fix subdir check when pruning docs

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -49,15 +49,17 @@ func removeDocs(outDir string, exclusionList []string) (bool, error) {
 
 	for _, item := range items {
 		if item.IsDir() {
-			empty, err := removeDocs(filepath.Join(outDir, item.Name()), exclusionList)
+			childEmpty, err := removeDocs(filepath.Join(outDir, item.Name()), exclusionList)
 			if err != nil {
 				return false, err
 			}
 
-			if empty {
+			if childEmpty {
 				if err := os.Remove(filepath.Join(outDir, item.Name())); err != nil {
 					return false, err
 				}
+			} else {
+				empty = false
 			}
 		} else {
 			if slices.Contains(exclusionList, filepath.Join(outDir, item.Name())) {


### PR DESCRIPTION
## Summary
- fix logic in docs pruning to track if subdirectories still contain files

## Testing
- `go vet ./...` *(fails: could not read Username for 'https://github.com')*

------
https://chatgpt.com/codex/tasks/task_e_6872bc0f12f4832b9741e40c2cee4cd5