### PR TITLE
feat: Add OSS license type with Business tier privileges

### DIFF
--- a/internal/testcmd/testing.go
+++ b/internal/testcmd/testing.go
@@ -52,7 +52,7 @@ func CheckTestingEnabled(ctx context.Context) error {
 		return fmt.Errorf("Account type not found. Ensure you are logged in via the `speakeasy auth login` command or SPEAKEASY_API_KEY environment variable.")
 	}
 
-	if !slices.Contains([]shared.AccountType{shared.AccountTypeEnterprise, shared.AccountTypeBusiness}, *accountType) {
+	if !IsBusinessTierOrAbove(ctx, *accountType) {
 		return fmt.Errorf("testing is not supported on the %s account tier. Contact %s for more information", *accountType, styles.RenderSalesEmail())
 	}
 
@@ -64,7 +64,40 @@ func CheckTestingEnabled(ctx context.Context) error {
 }
 
 func CheckTestingAccountType(accountType shared.AccountType) bool {
-	return slices.Contains([]shared.AccountType{shared.AccountTypeEnterprise, shared.AccountTypeBusiness}, accountType)
+	return IsBusinessTierOrAboveAccountType(accountType)
+}
+
+// IsBusinessTierOrAbove checks if the account type supports business-tier features.
+// This includes Business, Enterprise, and OSS account types.
+func IsBusinessTierOrAbove(ctx context.Context, accountType shared.AccountType) bool {
+	// Check standard Business and Enterprise tiers
+	if slices.Contains([]shared.AccountType{shared.AccountTypeEnterprise, shared.AccountTypeBusiness}, accountType) {
+		return true
+	}
+	
+	// Check for OSS account type by comparing string representation
+	// Since OSS is not in the external SDK enum, we check the string value
+	if string(accountType) == "OSS" {
+		return true
+	}
+	
+	return false
+}
+
+// IsBusinessTierOrAboveAccountType checks if the account type supports business-tier features.
+// This is a helper function for cases where we only have the AccountType enum.
+func IsBusinessTierOrAboveAccountType(accountType shared.AccountType) bool {
+	// Check standard Business and Enterprise tiers
+	if slices.Contains([]shared.AccountType{shared.AccountTypeEnterprise, shared.AccountTypeBusiness}, accountType) {
+		return true
+	}
+	
+	// Check for OSS account type by comparing string representation
+	if string(accountType) == "OSS" {
+		return true
+	}
+	
+	return false
 }
 
 // RebuildTests will prepare the arazzo and gen.lock files for a target ready to rebuild tests.

--- a/internal/testcmd/testing_test.go
+++ b/internal/testcmd/testing_test.go
@@ -1,0 +1,83 @@
+package testcmd
+
+import (
+	"testing"
+
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+)
+
+func TestIsBusinessTierOrAboveAccountType(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType shared.AccountType
+		expected    bool
+	}{
+		{
+			name:        "Business account type should return true",
+			accountType: shared.AccountTypeBusiness,
+			expected:    true,
+		},
+		{
+			name:        "Enterprise account type should return true",
+			accountType: shared.AccountTypeEnterprise,
+			expected:    true,
+		},
+		{
+			name:        "Free account type should return false",
+			accountType: shared.AccountTypeFree,
+			expected:    false,
+		},
+		{
+			name:        "OSS account type should return true",
+			accountType: shared.AccountType("OSS"),
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := IsBusinessTierOrAboveAccountType(tt.accountType)
+			if result != tt.expected {
+				t.Errorf("IsBusinessTierOrAboveAccountType(%v) = %v, expected %v", tt.accountType, result, tt.expected)
+			}
+		})
+	}
+}
+
+func TestCheckTestingAccountType(t *testing.T) {
+	tests := []struct {
+		name        string
+		accountType shared.AccountType
+		expected    bool
+	}{
+		{
+			name:        "Business account type should allow testing",
+			accountType: shared.AccountTypeBusiness,
+			expected:    true,
+		},
+		{
+			name:        "Enterprise account type should allow testing",
+			accountType: shared.AccountTypeEnterprise,
+			expected:    true,
+		},
+		{
+			name:        "Free account type should not allow testing",
+			accountType: shared.AccountTypeFree,
+			expected:    false,
+		},
+		{
+			name:        "OSS account type should allow testing",
+			accountType: shared.AccountType("OSS"),
+			expected:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := CheckTestingAccountType(tt.accountType)
+			if result != tt.expected {
+				t.Errorf("CheckTestingAccountType(%v) = %v, expected %v", tt.accountType, result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add support for OSS (Open Source Software) license type with Business tier privileges
- Enable OSS projects to access premium features like SDK testing
- Backward compatible implementation that doesn't break existing functionality

## Changes Made
- Added `IsBusinessTierOrAbove()` helper functions that recognize OSS accounts alongside Business/Enterprise
- Updated `CheckTestingEnabled()` to use new helper for account type validation  
- Updated `CheckTestingAccountType()` to support OSS accounts
- Added comprehensive unit tests to verify OSS account type functionality

## Test Plan
- [x] Unit tests pass for all account types (Free, Business, Enterprise, OSS)
- [x] OSS accounts now have same testing privileges as Business accounts
- [x] Existing account types continue to work as before
- [x] Code compiles without syntax errors

## Technical Details
Since the external SDK (`speakeasy-client-sdk-go`) doesn't include "OSS" as an account type enum, the implementation uses string comparison to detect OSS accounts and treats them identically to Business accounts for all feature checks.

🤖 Generated with [Claude Code](https://claude.ai/code)