### PR TITLE
feat: Cloudflare MCP deployment support & stability fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,7 +35,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.2.4
-	github.com/speakeasy-api/openapi-generation/v2 v2.657.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.658.3
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.31.2
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -581,8 +581,8 @@ github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed h1:wnCsprnR6nlo
 github.com/speakeasy-api/libopenapi v0.21.8-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.2.4 h1:XfIiVafDfq2Q3YtpjJPxjXBG9qUdXc/fKjEu4E5TyZQ=
 github.com/speakeasy-api/openapi v0.2.4/go.mod h1:vqBYh4eIgL9mVqrtdbuttji0ggR3/4xqU1ief4rjzY4=
-github.com/speakeasy-api/openapi-generation/v2 v2.657.1 h1:naWHw3aj9oBXnvtGg52mCDpFbWMMCYA5sNap4SvedcQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.657.1/go.mod h1:OWCJvRiASJRaTJFhWG6QfO1qGpjiO1KVmNVqcL3Oc+o=
+github.com/speakeasy-api/openapi-generation/v2 v2.658.3 h1:/m/DWww/l02FBfk9UW82HxP2KNhB+pbSOwDjPFvhACk=
+github.com/speakeasy-api/openapi-generation/v2 v2.658.3/go.mod h1:OWCJvRiASJRaTJFhWG6QfO1qGpjiO1KVmNVqcL3Oc+o=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.31.2 h1:5xquHCkMr/IVt/EUfU0wsu8pj5EFFm3Q7/398kZOCWI=


### PR DESCRIPTION
Enables support for deploying Speakeasy's generated MCP server to Cloudflare, in addition to other stability fixes.