### PR TITLE
fix: remove TS as an MCP target

### DIFF
--- a/prompts/utils.go
+++ b/prompts/utils.go
@@ -31,9 +31,7 @@ func getSourcesFromWorkflow(inputWorkflow *workflow.Workflow) []string {
 }
 
 func getMCPTargetOptions() []huh.Option[string] {
-	options := []huh.Option[string]{
-		huh.NewOption("TypeScript SDK with Server", "typescript"),
-	}
+	options := []huh.Option[string]{}
 	targets := generate.GetSupportedMCPTargets()
 
 	for _, target := range targets {


### PR DESCRIPTION
Get rid of the bundled TS-MCP option under MCP target since we no longer generate an MCP server alongside the TS target automatically.

Fixed:

<img width="1127" height="583" alt="image" src="https://github.com/user-attachments/assets/c311b797-5510-4738-82e8-4bd5d6da1dfa" />

