### PR TITLE
chore: update speakeasy workspace

### DIFF
--- a/internal/studio/sdk/.speakeasy/workflow.yaml
+++ b/internal/studio/sdk/.speakeasy/workflow.yaml
@@ -7,14 +7,14 @@ sources:
         overlays:
             - location: .speakeasy/speakeasy-modifications-overlay.yaml
         registry:
-            location: registry.speakeasyapi.dev/speakeasy-self/speakeasy-self/speakeasy-studio-oas
+            location: registry.speakeasyapi.dev/speakeasy/speakesay-registry/speakeasy-studio-oas
 targets:
     speakeasy-studio-go:
         target: go
         source: SpeakeasyStudio-OAS
         codeSamples:
             registry:
-                location: registry.speakeasyapi.dev/speakeasy-self/speakeasy-self/speakeasy-studio-oas-go-code-samples
+                location: registry.speakeasyapi.dev/speakeasy/speakesay-registry/speakeasy-studio-oas-go-code-samples
             labelOverride:
                 fixedValue: Go (SDK)
             blocking: false
@@ -24,7 +24,7 @@ targets:
         output: /path/to/speakeasy-registry/web/packages/generated-studio-ts-sdk
         codeSamples:
             registry:
-                location: registry.speakeasyapi.dev/speakeasy-self/speakeasy-self/speakeasy-studio-oas-typescript-code-samples
+                location: registry.speakeasyapi.dev/speakeasy/speakesay-registry/speakeasy-studio-oas-typescript-code-samples
             labelOverride:
                 fixedValue: Typescript (SDK)
             blocking: false


### PR DESCRIPTION
- Updating speakeasy workspace where the studio sdk is generated into`speakeasy/speakesay-registry`
- Related to https://github.com/speakeasy-api/speakeasy-registry/pull/4233