### PR TITLE
chore: Remove go test serialization from CI

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -91,6 +91,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - run: go test -json -v -p 1 -timeout=20m ./... | gotestfmt
+      - run: go test -json -v -timeout=20m ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}


### PR DESCRIPTION
Trying to reduce CI runtime. If there happens to be testing that requires serialization, can sort out local to those tests.