### PR TITLE
fix: mark validation step as failed if there are lint errors

### DIFF
--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -237,8 +237,11 @@ func (w *Workflow) validateDocument(ctx context.Context, parentStep *workflowTra
 	res, err := validation.ValidateOpenAPI(ctx, source, schemaPath, "", "", limits, defaultRuleset, projectDir, w.FromQuickstart, w.SkipGenerateLintReport, target)
 
 	w.validatedDocuments = append(w.validatedDocuments, schemaPath)
-
-	step.SucceedWorkflow()
+	if err != nil {
+		step.Fail()
+	} else {
+		step.Succeed()
+	}
 
 	return res, err
 }

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -238,9 +238,9 @@ func (w *Workflow) validateDocument(ctx context.Context, parentStep *workflowTra
 
 	w.validatedDocuments = append(w.validatedDocuments, schemaPath)
 	if err != nil {
-		step.Fail()
+		step.FailWorkflow()
 	} else {
-		step.Succeed()
+		step.SucceedWorkflow()
 	}
 
 	return res, err


### PR DESCRIPTION
Presumably, the validation step was previously marked as successful to indicate the execution of the step itself was successful. Even so, this is confusing for users - we now mark it as failed if we identify a validation error.

**Unhappy Path**:
<img width="2572" height="1048" alt="image" src="https://github.com/user-attachments/assets/6b57a918-abf1-40e6-99cd-fad82ed88160" />

**Happy Path**:
<img width="1191" height="433" alt="image" src="https://github.com/user-attachments/assets/d1281917-b303-444c-b0cd-3bed5a130164" />
