### PR TITLE
fix: fix regression introduced in openapi spec change summary due to code refactoring.

### DIFF
--- a/internal/run/sourceTracking.go
+++ b/internal/run/sourceTracking.go
@@ -147,8 +147,8 @@ func (w *Workflow) computeChanges(ctx context.Context, rootStep *workflowTrackin
 
 	// Do not write github action changes if we have already processed this source
 	// If we don't do this check we will see duplicate openapi changes summaries in the PR
-	if _, ok := w.computedChanges[targetLock.Source]; !ok {
-		github.GenerateChangesSummary(ctx, r.URL, *summary)
+	if _, ok := w.computedChanges[targetLock.Source]; !ok && computedChanges.report != nil {
+		github.GenerateChangesSummary(ctx, computedChanges.report.URL, *summary)
 	}
 
 	w.computedChanges[targetLock.Source] = true


### PR DESCRIPTION
When refactoring computeChanges method as part of this [PR ](https://github.com/speakeasy-api/speakeasy/commit/79c4f509f9146f473f3914ab2a78d6510a33d64f) missed replacing `r` with `changesComputed.report`


Relevant section of the above PR where the bug was introduced
<img width="2113" height="718" alt="image" src="https://github.com/user-attachments/assets/4f3291b0-9a5e-4f61-9c1c-ec8f99868b7c" />
