### PR TITLE
fix: add panic recovery to ComputeAndStoreSDKChangelog

### DIFF
--- a/internal/sdkchangelog/sdkChangelog.go
+++ b/internal/sdkchangelog/sdkChangelog.go
@@ -18,7 +18,16 @@ type Requirements struct {
 	Target      string
 }
 
-func ComputeAndStoreSDKChangelog(ctx context.Context, changelogRequirements Requirements) (string, error) {
+func ComputeAndStoreSDKChangelog(ctx context.Context, changelogRequirements Requirements) (changelogContent string, err error) {
+	// Add panic recovery to prevent crashes during changelog generation
+	defer func() {
+		if r := recover(); r != nil {
+			log.From(ctx).Errorf("Panic recovered in ComputeAndStoreSDKChangelog: %v", r)
+			changelogContent = ""
+			err = fmt.Errorf("panic occurred during SDK changelog generation: %v", r)
+		}
+	}()
+
 	// Check if we have valid spec paths before proceeding
 	if changelogRequirements.OldSpecPath == "" || changelogRequirements.NewSpecPath == "" {
 		// If we don't have valid spec paths, skip changelog generation
@@ -40,7 +49,7 @@ func ComputeAndStoreSDKChangelog(ctx context.Context, changelogRequirements Requ
 	if len(diff.Changes) == 0 {
 		return "", nil
 	}
-	changelogContent, err := storeSDKChangelogForPullRequestDescription(ctx, changelogRequirements.Target, diff)
+	changelogContent, err = storeSDKChangelogForPullRequestDescription(ctx, changelogRequirements.Target, diff)
 	if err != nil {
 		// Swallow error so that we dont block generation
 		log.From(ctx).Warnf("Error generating new changelog: %s", err.Error())


### PR DESCRIPTION
## Summary
- Added panic recovery mechanism to `ComputeAndStoreSDKChangelog` function to prevent crashes during SDK changelog generation
- Function now gracefully handles panics by logging errors and returning an error instead of crashing
- Uses named return values to allow defer/recover to properly set return values

## Motivation
The `ComputeAndStoreSDKChangelog` function processes external spec files and generates changelogs. Without panic recovery, any unexpected panic during this process would crash the entire application. This change ensures that even if a panic occurs during changelog generation, the process can continue gracefully.

## Changes
- Added `defer` with `recover()` at the beginning of the function
- Changed function signature to use named returns (`changelogContent string, err error`)
- Updated variable assignment from `:=` to `=` for the named return values
- Added error logging when a panic is recovered

## Test Plan
- [x] Verify the function still works normally when no panic occurs
- [ ] Test that panics are properly caught and logged
- [ ] Ensure the generation process continues even when changelog generation fails

🤖 Generated with [Claude Code](https://claude.ai/code)