### PR TITLE
fix(typescript): usage example inside `examples/` directory can point at invalid method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v0.2.4
-	github.com/speakeasy-api/openapi-generation/v2 v2.695.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.695.1
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.31.5
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v0.2.4 h1:XfIiVafDfq2Q3YtpjJPxjXBG9qUdXc/fKjEu4E5TyZQ=
 github.com/speakeasy-api/openapi v0.2.4/go.mod h1:vqBYh4eIgL9mVqrtdbuttji0ggR3/4xqU1ief4rjzY4=
-github.com/speakeasy-api/openapi-generation/v2 v2.695.0 h1:3UTlcUWanHwsUGOqAALoE8rm78cnwq93QuxoM5B4ON8=
-github.com/speakeasy-api/openapi-generation/v2 v2.695.0/go.mod h1:GKeNBA+swlVCem5wH6Dv+NaAFAdJvPb8dg7VBgcXtVg=
+github.com/speakeasy-api/openapi-generation/v2 v2.695.1 h1:ZA7jqDhKwfBnaTBleq9+3uVCzrR9oVeTe+5IkG41pYg=
+github.com/speakeasy-api/openapi-generation/v2 v2.695.1/go.mod h1:GKeNBA+swlVCem5wH6Dv+NaAFAdJvPb8dg7VBgcXtVg=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.31.5 h1:cuRCkdtzP8HRrDSy1byb90jsAYGl854CxkAVEpAZSXs=


### PR DESCRIPTION
fix(typescript): usage example
 > https://github.com/speakeasy-api/openapi-generation/pull/3116