### PR TITLE
chore: Release only for feat and fix commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,9 @@ jobs:
         name: Release
         runs-on:
             group: windows-latest-large
-        if: startsWith(github.event.head_commit.message, 'ci:') != true
+        if: |
+          startsWith(github.event.head_commit.message, 'feat')
+            || startsWith(github.event.head_commit.message, 'fix')
         steps:
             - name: Setup environment
               run: |-


### PR DESCRIPTION
This should only run the release workflow for customer-impacting changes to this repository.