### PR TITLE
feat: Add Nullable wrapper type for Go SDK, this helps distinguish between nil (field not set) and null (field explicitly set to null), Add retractions for Go SDK, fix: Optional parameters must appear after all required parameters in c#.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v1.6.4
-	github.com/speakeasy-api/openapi-generation/v2 v2.698.4
+	github.com/speakeasy-api/openapi-generation/v2 v2.700.3
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.31.8
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -535,8 +535,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.6.4 h1:WLoZYEK9xZQVb2JNkbXWS0HBwHYQ3GNqf+8Q3E/kXmA=
 github.com/speakeasy-api/openapi v1.6.4/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
-github.com/speakeasy-api/openapi-generation/v2 v2.698.4 h1:v8+esFbjMx0Vm6r/6KpB8LY8hSdCsuxcwmSYw0nv2r4=
-github.com/speakeasy-api/openapi-generation/v2 v2.698.4/go.mod h1:Ch1ZBQYwDTehi+gj5sVghKSpxgTKdzvFWorgO/w0Q2I=
+github.com/speakeasy-api/openapi-generation/v2 v2.700.3 h1:8jYQZpO8M3/5UH/ofmmXQEKgN/0Dg1BhTKAul1w0Zjg=
+github.com/speakeasy-api/openapi-generation/v2 v2.700.3/go.mod h1:Ch1ZBQYwDTehi+gj5sVghKSpxgTKdzvFWorgO/w0Q2I=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.31.8 h1:5tra06b/guHwcgMJe+nW4PGsb9Vz6lbsi7IiyZ3y5CM=

--- a/internal/sdkchangelog/sdkChangelog.go
+++ b/internal/sdkchangelog/sdkChangelog.go
@@ -44,8 +44,13 @@ func ComputeAndStoreSDKChangelog(ctx context.Context, changelogRequirements Requ
 		Logger:      log.From(ctx),
 	})
 
-	diff := changes.Changes(oldConfig, newConfig)
+	diff, err := changes.Changes(oldConfig, newConfig)
+	if err != nil {
+		log.From(ctx).Errorf("an error occurred while computing changes between prior generation and current generation for %s target (language: %s). error: %s", changelogRequirements.Target, changelogRequirements.Lang, err.Error())
+		return "", err
+	}
 	if len(diff.Changes) == 0 {
+		log.From(ctx).Infof("0 changes detected for %s target changelog (language: %s)", changelogRequirements.Target, changelogRequirements.Lang)
 		return "", nil
 	}
 	changelogContent, err = storeSDKChangelogForPullRequestDescription(ctx, changelogRequirements.Target, diff)


### PR DESCRIPTION
Makes use of  https://github.com/speakeasy-api/openapi-generation/pull/3132

same as this PR  - https://github.com/speakeasy-api/speakeasy/pull/1594