### PR TITLE
fix: quickstart `Workflow failed with error: failed to get schema contents: failed to download OpenAPI schema: failed to download file: Get "": unsupported protocol scheme ""`

### DIFF
--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -193,7 +193,7 @@ func PromptForNewTarget(currentWorkflow *workflow.Workflow, targetName, targetTy
 		return "", nil, err
 	}
 
-	remainingPrompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, false)
+	remainingPrompts := getBaseTargetPrompts(currentWorkflow, &sourceName, &targetName, &targetType, &outDir, true)
 
 	// If there are any additional prompts needed to configure the target, show these.
 	if len(remainingPrompts) > 0 {


### PR DESCRIPTION
Fixes https://linear.app/speakeasy/issue/GEN-1858/bug-quickstart-failure-when-you-provide-a-custom-answer-to-what-is-a

Regression caused by https://github.com/speakeasy-api/speakeasy/pull/1579 

* Regression caused the target name to be prompted which it shouldn't have been
* User would customize the name -> that name was no longer found later
* Assumption in code that it would be found later

https://github.com/user-attachments/assets/c67c0c47-7dc1-4ca9-8c69-a5ee67cac69d

