### PR TITLE
fix: non-interactive pull cmd bug

### DIFF
--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -129,7 +129,8 @@ func pullExec(cmd *cobra.Command, args []string) error {
 			return
 		}
 
-		if !f.Changed {
+		// If the flag has not been changed from its default value, and the default value is empty, it is missing
+		if !f.Changed && f.Value.String() == "" {
 			missingFlags = append(missingFlags, f.Name)
 		}
 	}


### PR DESCRIPTION
The logic for the non-interactive `pull` cmd was slightly wrong because it didn't take into account flags that have a non empty default value. This change makes it so that flags are only marked as missing (and therefore we need to present the user with interactive mode) in the case where a flag was provided which doesn't have a default