### PR TITLE
fix: Python SSE flat resp. + redirects; MCP matcher keys; Go union query parameters; Terraform testing;

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v1.6.4
-	github.com/speakeasy-api/openapi-generation/v2 v2.709.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.711.4
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.31.9
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.6.4 h1:WLoZYEK9xZQVb2JNkbXWS0HBwHYQ3GNqf+8Q3E/kXmA=
 github.com/speakeasy-api/openapi v1.6.4/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
-github.com/speakeasy-api/openapi-generation/v2 v2.709.0 h1:yFR1S36ERZPW8BkzRqbgoiQC8O8aDdalIzlMkxS5IAY=
-github.com/speakeasy-api/openapi-generation/v2 v2.709.0/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
+github.com/speakeasy-api/openapi-generation/v2 v2.711.4 h1:nVulCM2Uv2RSkfj74h738CqFh8RtcFkhlXgl4pVSVhA=
+github.com/speakeasy-api/openapi-generation/v2 v2.711.4/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.31.9 h1:sXO+FacVAy/vfC+uDgbf3BthDTIWPh7g0gQ6RdNWa3E=


### PR DESCRIPTION
fix: remove zod from yarn install instructions
 > https://github.com/speakeasy-api/openapi-generation/pull/3223

fix: allow input/output models without suffixes
 > https://github.com/speakeasy-api/openapi-generation/pull/3222

fix: sanitize MCP response matcher key
 > https://github.com/speakeasy-api/openapi-generation/pull/3218

fix: properly encode unions in query parameters in go
 > https://github.com/speakeasy-api/openapi-generation/pull/3182

fix: error thrown for specs with just `default`
 > https://github.com/speakeasy-api/openapi-generation/pull/3176

fix(python): SSE flat response compilation error
 > https://github.com/speakeasy-api/openapi-generation/pull/3175

fix(typescriptv2): support hyphens in path parameters
 > https://github.com/speakeasy-api/openapi-generation/pull/3157

feat: Adding barebones for Terraform Integration (Acceptance) Tests (along with some actual tests)
 > https://github.com/speakeasy-api/openapi-generation/pull/3061

feat: Change the default behaviour of http-client inside python sdk to follow redirects
 > https://github.com/speakeasy-api/openapi-generation/pull/2890