### PR TITLE
feat(typescript): SSE overloads typescript; also fixes to `.env.templates` fix(python): fix overload doc comments

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v1.6.4
-	github.com/speakeasy-api/openapi-generation/v2 v2.711.4
+	github.com/speakeasy-api/openapi-generation/v2 v2.713.0
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.31.9
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -539,8 +539,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.6.4 h1:WLoZYEK9xZQVb2JNkbXWS0HBwHYQ3GNqf+8Q3E/kXmA=
 github.com/speakeasy-api/openapi v1.6.4/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
-github.com/speakeasy-api/openapi-generation/v2 v2.711.4 h1:nVulCM2Uv2RSkfj74h738CqFh8RtcFkhlXgl4pVSVhA=
-github.com/speakeasy-api/openapi-generation/v2 v2.711.4/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
+github.com/speakeasy-api/openapi-generation/v2 v2.713.0 h1:FvDgRE/KkIFG27pr0JveZCx65RnSGXypJZxEd6e8ujg=
+github.com/speakeasy-api/openapi-generation/v2 v2.713.0/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.31.9 h1:sXO+FacVAy/vfC+uDgbf3BthDTIWPh7g0gQ6RdNWa3E=


### PR DESCRIPTION
feat: support SSE overloads in TypeScript v2
 > https://github.com/speakeasy-api/openapi-generation/pull/3226

fix: env template typescript debug mode
 > https://github.com/speakeasy-api/openapi-generation/pull/3225

feat(python): overload doc comments
 > https://github.com/speakeasy-api/openapi-generation/pull/3214