### PR TITLE
feat: source-location flag for speakeasy run

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -175,6 +175,10 @@ func (w *Workflow) RunInner(ctx context.Context) error {
 		return fmt.Errorf("cannot manually apply a version when more than one target is specified ")
 	}
 
+	if w.SourceLocation != "" && len(sourceIDs) > 1 {
+		return fmt.Errorf("cannot specify a source location when more than one source is required")
+	}
+
 	for _, sourceID := range sourceIDs {
 		if sourceID == "" {
 			continue

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -106,8 +106,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 
 	var currentDocument string
 	if w.SourceLocation != "" {
-		step := rootStep.NewSubstep("Using Source Location Override")
-		step.Succeed()
+		rootStep.NewSubstep("Using Source Location Override")
 		currentDocument = w.SourceLocation
 		frozenSource = true
 	} else if w.FrozenWorkflowLock {

--- a/internal/run/source.go
+++ b/internal/run/source.go
@@ -102,8 +102,16 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		return "", nil, err
 	}
 
+	frozenSource := false
+
 	var currentDocument string
-	if w.FrozenWorkflowLock {
+	if w.SourceLocation != "" {
+		step := rootStep.NewSubstep("Using Source Location Override")
+		step.Succeed()
+		currentDocument = w.SourceLocation
+		frozenSource = true
+	} else if w.FrozenWorkflowLock {
+		frozenSource = true
 		currentDocument, err = NewFrozenSource(w, rootStep, sourceID).Do(ctx, "unused")
 		if err != nil {
 			return "", nil, err
@@ -144,7 +152,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		return "", nil, err
 	}
 
-	if len(source.Overlays) > 0 && !w.FrozenWorkflowLock {
+	if len(source.Overlays) > 0 && !frozenSource {
 		w.OnSourceResult(sourceRes, SourceStepOverlay)
 		sourceRes.OverlayResult, err = NewOverlay(rootStep, source).Do(ctx, currentDocument)
 		if err != nil {
@@ -153,7 +161,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		currentDocument = sourceRes.OverlayResult.Location
 	}
 
-	if len(source.Transformations) > 0 && !w.FrozenWorkflowLock {
+	if len(source.Transformations) > 0 && !frozenSource {
 		w.OnSourceResult(sourceRes, SourceStepTransform)
 		currentDocument, err = NewTransform(rootStep, source).Do(ctx, currentDocument)
 		if err != nil {
@@ -161,7 +169,7 @@ func (w *Workflow) RunSource(ctx context.Context, parentStep *workflowTracking.W
 		}
 	}
 
-	if !w.FrozenWorkflowLock {
+	if !frozenSource {
 		if err := writeToOutputLocation(ctx, currentDocument, outputLocation); err != nil {
 			return "", nil, fmt.Errorf("failed to write to output location: %w %s", err, outputLocation)
 		}

--- a/internal/run/workflow.go
+++ b/internal/run/workflow.go
@@ -36,6 +36,7 @@ type Workflow struct {
 	SkipCleanup            bool
 	FromQuickstart         bool
 	SkipGenerateLintReport bool
+	SourceLocation         string
 	RepoSubDirs            map[string]string
 	InstallationURLs       map[string]string
 	RegistryTags           []string
@@ -140,6 +141,18 @@ func WithWorkflowName(name string) Opt {
 func WithSource(source string) Opt {
 	return func(w *Workflow) {
 		w.Source = source
+	}
+}
+
+func WithSourceLocation(sourceLocation string) Opt {
+	return func(w *Workflow) {
+		w.SourceLocation = sourceLocation
+		if sourceLocation != "" {
+			// Implies no snapshot
+			w.SkipSnapshot = true
+			// Implies no change report
+			w.SkipChangeReport = true
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a flag source-location that gives the option to override the source location for a single SDK run
Uses this new flag to power `dependents` in a cleaner way