### PR TITLE
feat: Add python async constructor support, and conditionally remove some Go and C# dependencies

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v1.7.3
-	github.com/speakeasy-api/openapi-generation/v2 v2.715.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.716.0
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.33.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.7.3 h1:QM9VglcsxRPH19Xr47nYRtDsKOlczCdRRxPYa0pAGz0=
 github.com/speakeasy-api/openapi v1.7.3/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
-github.com/speakeasy-api/openapi-generation/v2 v2.715.1 h1:XMKkdhh7vkQEe4wkU0zrjfugwQkbohHD5e+FWTr0VVE=
-github.com/speakeasy-api/openapi-generation/v2 v2.715.1/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
+github.com/speakeasy-api/openapi-generation/v2 v2.716.0 h1:kc5kD1ulWM6yrhud/NDgCF8O90Va3NyV/zzpWvAQG6k=
+github.com/speakeasy-api/openapi-generation/v2 v2.716.0/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.33.0 h1:3aBd3aiwtH+t/Yj2AsGpHg/AD/80WATMqJNPErVZjbY=


### PR DESCRIPTION
Includes generator releases [v2.716.0](https://github.com/speakeasy-api/openapi-generation/releases/tag/v2.716.0) [v2.715.2](https://github.com/speakeasy-api/openapi-generation/releases/tag/v2.715.2)

- python: async split constructor support
- make nodatime and decimal packagage dependencies optional for C# and Go SDKs respectively