### PR TITLE
fix: don't write local overrides to real workflow

### DIFF
--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -294,7 +294,7 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 		localWfExists = true
 	}
 
-	// Try to migrate existing workflows, but only if they aren't on a pinned version and a local workflow doesn't exist. 
+	// Try to migrate existing workflows, but only if they aren't on a pinned version and a local workflow doesn't exist.
 	// If a local workflow exists, calling updateWorkflowFile will cause local overrides to be persisted to the real workflow.yaml file.
 	// There's probably a more robust solution here, perhaps applying the local override at a different point in the process, but this is good enough for now.
 	if wf.SpeakeasyVersion.String() == "latest" && !localWfExists {

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -289,8 +289,15 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 
 	artifactArch := ctx.Value(updates.ArtifactArchContextKey).(string)
 
-	// Try to migrate existing workflows, but only if they aren't on a pinned version
-	if wf.SpeakeasyVersion.String() == "latest" {
+	localWfExists := false
+	if _, err := os.Stat(strings.TrimSuffix(wfPath, "workflow.yaml") + "workflow.local.yaml"); err == nil {
+		localWfExists = true
+	}
+
+	// Try to migrate existing workflows, but only if they aren't on a pinned version and a local workflow doesn't exist. 
+	// If a local workflow exists, calling updateWorkflowFile will cause local overrides to be persisted to the real workflow.yaml file.
+	// There's probably a more robust solution here, perhaps applying the local override at a different point in the process, but this is good enough for now.
+	if wf.SpeakeasyVersion.String() == "latest" && !localWfExists {
 		run.Migrate(ctx, wf)
 		_ = updateWorkflowFile(wf, wfPath)
 	}


### PR DESCRIPTION
This was missed because it only happens outside of local development (e.g. after releasing the CLI)