### PR TITLE
fix: only set flags that are actually set

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -272,14 +272,20 @@ func preRun(cmd *cobra.Command, flags *RunFlags) error {
 	}
 
 	// We must set these after prompting for them or else the user will be prompted a second time
-	if err := cmd.Flags().Set("source", flags.Source); err != nil {
-		return err
+	if flags.Source != "" {
+		if err := cmd.Flags().Set("source", flags.Source); err != nil {
+			return err
+		}
 	}
-	if err := cmd.Flags().Set("target", flags.Target); err != nil {
-		return err
+	if flags.Target != "" {
+		if err := cmd.Flags().Set("target", flags.Target); err != nil {
+			return err
+		}
 	}
-	if err := cmd.Flags().Set("dependent", flags.Dependent); err != nil {
-		return err
+	if flags.Dependent != "" {
+		if err := cmd.Flags().Set("dependent", flags.Dependent); err != nil {
+			return err
+		}
 	}
 
 	// Gets a proper value for a mapFlag based on the singleFlag value and the mapFlag value


### PR DESCRIPTION
This was causing issues where empty flags were being passed to old (pinned) CLI versions that may not know how to process them