### PR TITLE
chore: Enable wastedassign linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -33,4 +33,4 @@ linters:
     # - unused
     # - usestdlibvars
     # - usetesting
-    # - wastedassign
+    - wastedassign

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -728,6 +728,10 @@ func configureTesting(ctx context.Context, flags ConfigureTestsFlags) error {
 		run.WithBoostrapTests(),
 	)
 
+	if err != nil {
+		return fmt.Errorf("failed to parse workflow: %w", err)
+	}
+
 	if err = wf.RunWithVisualization(ctx); err != nil {
 		return errors.Wrapf(err, "failed to generate tests")
 	}

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -174,7 +174,7 @@ func lintOpenapiInteractive(ctx context.Context, flags LintOpenapiFlags) error {
 func lintConfig(ctx context.Context, flags lintConfigFlags) error {
 	// To support the old version of this command, check if there is no workflow.yaml. If there isn't, run the old version
 	wf, _, err := utils.GetWorkflowAndDir()
-	if wf == nil {
+	if wf == nil || err != nil {
 		log.From(ctx).Info("No workflow.yaml found, running legacy version of this command...")
 		return sdkgen.ValidateConfig(ctx, flags.Dir)
 	}

--- a/cmd/quickstart.go
+++ b/cmd/quickstart.go
@@ -485,6 +485,10 @@ func retryWithSampleSpec(ctx context.Context, workflowFile *workflow.Workflow, i
 		run.WithShouldCompile(!skipCompile),
 	)
 
+	if err != nil {
+		return false, fmt.Errorf("failed to parse workflow: %w", err)
+	}
+
 	// Execute the workflow based on output mode
 	switch output {
 	case "summary":

--- a/cmd/testcmd.go
+++ b/cmd/testcmd.go
@@ -87,7 +87,7 @@ func testCmdRunnerOpts(flags testCmdFlags) ([]testcmd.RunnerOpt, error) {
 		return nil, err
 	}
 
-	target := ""
+	var target string
 
 	if flags.Target == "" {
 		if len(wf.Targets) == 1 {

--- a/internal/charm/styles/styles.go
+++ b/internal/charm/styles/styles.go
@@ -168,7 +168,7 @@ func MakeSection(title, content string, color lipgloss.AdaptiveColor) string {
 func MakeBreak(heading string, character rune, color lipgloss.AdaptiveColor, isStart bool) string {
 	termWidth := TerminalWidth()
 
-	line := ""
+	var line string
 	if heading == "" {
 		line = strings.Repeat(string(character), termWidth)
 	} else {

--- a/internal/github/github.go
+++ b/internal/github/github.go
@@ -128,7 +128,7 @@ func GenerateChangesSummary(ctx context.Context, url string, summary changes.Sum
 		}
 		log.From(ctx).Infof("wrote changes summary to \"%s\"", filepath)
 	}
-	prMD := ""
+	var prMD string
 	if len(summary.Text) > 0 {
 		prMD = "<details>\n<summary>OpenAPI Change Summary</summary>\n" + summary.Text + "\n" + "</details>\n"
 	} else {
@@ -158,7 +158,7 @@ func GenerateWorkflowSummary(ctx context.Context, summary WorkflowSummary) {
 	}
 
 	logger := log.From(ctx)
-	md := ""
+	var md string
 	chart, err := summary.ToMermaidDiagram()
 	if err == nil {
 		md = fmt.Sprintf("# Generation Workflow Summary\n\n_This is a breakdown of the 'Generate Target' step above_\n%s", chart)

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -185,9 +185,6 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 		return nil, err
 	}
 
-	short := strings.Trim(c.Short, " .")
-	short = utils.CapitalizeFirst(short)
-
 	cmd := &cobra.Command{
 		Use:     c.Usage,
 		Short:   c.Short,

--- a/internal/run/sourceTracking.go
+++ b/internal/run/sourceTracking.go
@@ -103,7 +103,7 @@ func (w *Workflow) computeChanges(ctx context.Context, rootStep *workflowTrackin
 	orgSlug := auth.GetOrgSlugFromContext(ctx)
 	workspaceSlug := auth.GetWorkspaceSlugFromContext(ctx)
 
-	oldRegistryLocation := ""
+	var oldRegistryLocation string
 	if targetLock.SourceRevisionDigest != "" && targetLock.SourceNamespace != "" {
 		oldRegistryLocation = fmt.Sprintf("%s/%s/%s/%s@%s", "registry.speakeasyapi.dev", orgSlug, workspaceSlug,
 			targetLock.SourceNamespace, targetLock.SourceRevisionDigest)

--- a/internal/studio/studioHelpers.go
+++ b/internal/studio/studioHelpers.go
@@ -512,13 +512,11 @@ func updateSourceAndTarget(workflowRunner run.Workflow, sourceID, overlayPath st
 	}
 
 	for targetID, input := range runRequestBody.Targets {
-		sdkPath := ""
-
 		wfTarget, ok := workflowRunner.GetWorkflowFile().Targets[targetID]
 		if !ok {
 			return overlayPath, errors.ErrBadRequest.Wrap(fmt.Errorf("target %s not found", targetID))
 		}
-		sdkPath = workflowRunner.ProjectDir
+		sdkPath := workflowRunner.ProjectDir
 		if wfTarget.Output != nil {
 			sdkPath = filepath.Join(sdkPath, *wfTarget.Output)
 		}

--- a/internal/suggest/errorCodes/errorCodes_test.go
+++ b/internal/suggest/errorCodes/errorCodes_test.go
@@ -2,13 +2,14 @@ package errorCodes_test
 
 import (
 	"context"
+	"os"
+	"testing"
+
 	"github.com/speakeasy-api/speakeasy-core/suggestions"
 	"github.com/speakeasy-api/speakeasy/internal/schemas"
 	"github.com/speakeasy-api/speakeasy/internal/suggest/errorCodes"
 	"github.com/stretchr/testify/require"
 	"gopkg.in/yaml.v3"
-	"os"
-	"testing"
 )
 
 func TestBuildErrorCodesOverlay(t *testing.T) {
@@ -27,7 +28,7 @@ func TestBuildErrorCodesOverlay(t *testing.T) {
 			ctx := context.Background()
 
 			overlay, err := errorCodes.BuildErrorCodesOverlay(ctx, tt.in)
-
+			require.NoError(t, err)
 			_, _, model, err := schemas.LoadDocument(ctx, tt.in)
 			require.NoError(t, err)
 			root := model.Index.GetRootNode()

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -225,7 +225,7 @@ func parseOperationInfoAndCodeSample(lang, usageOutputSection string) (*UsageSni
 }
 
 func writeExampleCode(lang, path, code string) error {
-	outFile := ""
+	var outFile string
 	switch lang {
 	case "go":
 		outFile = path + "/main.go"

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -168,7 +168,7 @@ func errorsToTabContents(schema []byte, errs []error) []interactivity.Inspectabl
 	for _, err := range errs {
 		vErr := errors.GetValidationErr(err)
 
-		s := ""
+		var s string
 		var details *string
 
 		// Need to account for non-validation errors

--- a/internal/workflowTracking/workflowTracking.go
+++ b/internal/workflowTracking/workflowTracking.go
@@ -158,7 +158,7 @@ func (w *WorkflowStep) ListenForSubsteps(c chan log.Msg) {
 //   - failure: A -> B -> C
 func (w *WorkflowStep) LastStepToString() string {
 	step := w
-	var status Status = StatusSucceeded
+	var status Status
 	var stepNames = []string{}
 
 	for {

--- a/pkg/merge/merge_test.go
+++ b/pkg/merge/merge_test.go
@@ -33,7 +33,9 @@ func Test_merge_determinism(t *testing.T) {
 
 	// Run merge twice and ensure the output is the same.
 	got1, err := merge(absSchemas, true)
+	require.NoError(t, err)
 	got2, err := merge(absSchemas, true)
+	require.NoError(t, err)
 	doc1, err := libopenapi.NewDocumentWithConfiguration(got1, &datamodel.DocumentConfiguration{
 		AllowFileReferences:                 true,
 		IgnorePolymorphicCircularReferences: true,

--- a/pkg/transform/cleanup.go
+++ b/pkg/transform/cleanup.go
@@ -2,15 +2,16 @@ package transform
 
 import (
 	"context"
+	"io"
+	"strings"
+	"unicode"
+
 	"github.com/pb33f/libopenapi"
 	v3 "github.com/pb33f/libopenapi/datamodel/high/v3"
 	"github.com/pb33f/libopenapi/orderedmap"
 	"github.com/speakeasy-api/speakeasy-core/openapi"
 	"github.com/speakeasy-api/speakeasy/internal/log"
 	"gopkg.in/yaml.v3"
-	"io"
-	"strings"
-	"unicode"
 )
 
 func CleanupDocument(ctx context.Context, schemaPath string, yamlOut bool, w io.Writer) error {
@@ -66,6 +67,10 @@ func Cleanup(ctx context.Context, doc libopenapi.Document, model *libopenapi.Doc
 	}
 
 	docNew, model, err := openapi.Load(updatedDoc, doc.GetConfiguration().BasePath)
+
+	if err != nil {
+		return doc, model, err
+	}
 
 	return *docNew, model, nil
 }

--- a/prompts/configs.go
+++ b/prompts/configs.go
@@ -153,7 +153,7 @@ func PromptForTargetConfig(targetName string, wf *workflow.Workflow, target *wor
 func setDevContainerDefaults(output *config.Configuration, wf *workflow.Workflow, target *workflow.Target) {
 	if target.Target == "go" || target.Target == "typescript" || target.Target == "python" {
 		if source, ok := wf.Sources[target.Source]; ok {
-			schemaPath := ""
+			var schemaPath string
 			if source.Output != nil {
 				schemaPath = *source.Output
 			} else {

--- a/prompts/github.go
+++ b/prompts/github.go
@@ -293,7 +293,7 @@ func FindGithubRepository(outDir string) *git.Repository {
 	if err != nil {
 		return nil
 	}
-	prior := ""
+	var prior string
 	for {
 		if _, err := os.Stat(path.Join(gitFolder, ".git")); err == nil {
 			break


### PR DESCRIPTION
Catch coding issues before merge, such as #1644.

Previous reports before code fixes:

```
cmd/configure.go:725:6: assigned to err, but reassigned without using the value (wastedassign)
        wf, err := run.NewWorkflow(
            ^
cmd/lint/lint.go:176:9: assigned to err, but reassigned without using the value (wastedassign)
        wf, _, err := utils.GetWorkflowAndDir()
               ^
cmd/quickstart.go:482:6: assigned to err, but reassigned without using the value (wastedassign)
        wf, err := run.NewWorkflow(
            ^
cmd/tag.go:101:12: assigned to err, but reassigned without using the value (wastedassign)
        lockfile, err := workflow.LoadLockfile(projectDir)
                  ^
cmd/testcmd.go:90:2: assigned to target, but reassigned without using the value (wastedassign)
        target := ""
        ^
internal/charm/styles/styles.go:171:2: assigned to line, but reassigned without using the value (wastedassign)
        line := ""
        ^
internal/github/github.go:131:2: assigned to prMD, but reassigned without using the value (wastedassign)
        prMD := ""
        ^
internal/github/github.go:161:2: assigned to md, but reassigned without using the value (wastedassign)
        md := ""
        ^
internal/model/command.go:189:2: assigned to short, but never used afterwards (wastedassign)
        short = utils.CapitalizeFirst(short)
        ^
internal/run/sourceTracking.go:106:2: assigned to oldRegistryLocation, but reassigned without using the value (wastedassign)
        oldRegistryLocation := ""
        ^
internal/studio/studioHelpers.go:515:3: assigned to sdkPath, but reassigned without using the value (wastedassign)
                sdkPath := ""
                ^
internal/suggest/errorCodes/errorCodes_test.go:29:13: assigned to err, but reassigned without using the value (wastedassign)
                        overlay, err := errorCodes.BuildErrorCodesOverlay(ctx, tt.in)
                                 ^
internal/usagegen/usagegen.go:228:2: assigned to outFile, but reassigned without using the value (wastedassign)
        outFile := ""
        ^
internal/validation/openapi.go:171:3: assigned to s, but reassigned without using the value (wastedassign)
                s := ""
                ^
internal/workflowTracking/workflowTracking.go:161:6: assigned to status, but reassigned without using the value (wastedassign)
        var status Status = StatusSucceeded
            ^
pkg/merge/merge_test.go:35:8: assigned to err, but reassigned without using the value (wastedassign)
        got1, err := merge(absSchemas, true)
              ^
pkg/merge/merge_test.go:36:8: assigned to err, but reassigned without using the value (wastedassign)
        got2, err := merge(absSchemas, true)
              ^
pkg/transform/cleanup.go:68:17: assigned to err, but never used afterwards (wastedassign)
        docNew, model, err := openapi.Load(updatedDoc, doc.GetConfiguration().BasePath)
                       ^
prompts/configs.go:156:4: assigned to schemaPath, but reassigned without using the value (wastedassign)
                        schemaPath := ""
                        ^
prompts/github.go:296:2: assigned to prior, but reassigned without using the value (wastedassign)
        prior := ""
        ^
20 issues:
* wastedassign: 20
```