### PR TITLE
fix: speakeasy run doesn't print out registry uris used for code samples in the output

### DIFF
--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -252,10 +252,8 @@ func (w *Workflow) printGenerationOverview(ctx context.Context) error {
 	// Covers the case where code samples are configured to be written to a local file
 	if t.CodeSamples != nil && t.CodeSamples.Output != "" {
 		additionalLines = append(additionalLines, fmt.Sprintf("Code samples overlay file written to %s", t.CodeSamples.Output))
-	}
-
-	// Covers the case where code samples are configured to be published to a registry URI
-	if t.CodeSamples != nil && t.CodeSamples.Registry != nil {
+		// Covers the case where code samples are configured to be published to a registry URI
+	} else if t.CodeSamples != nil && t.CodeSamples.Registry != nil {
 		additionalLines = append(additionalLines, fmt.Sprintf("Code samples uploaded to: %s", string(t.CodeSamples.Registry.Location)))
 	}
 


### PR DESCRIPTION
# What

The CLI code didn't take into account the case where a user opted to upload code samples to one of our registry URIs rather than a local file. 