### PR TITLE
fix(csharp): Fix pagination issue when request bodies do not contain pagination fields

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -38,7 +38,7 @@ require (
 	github.com/sethvargo/go-githubactions v1.1.0
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/openapi v1.7.3
-	github.com/speakeasy-api/openapi-generation/v2 v2.723.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.723.4
 	github.com/speakeasy-api/openapi-overlay v0.10.3
 	github.com/speakeasy-api/sdk-gen-config v1.35.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -541,8 +541,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.7.3 h1:QM9VglcsxRPH19Xr47nYRtDsKOlczCdRRxPYa0pAGz0=
 github.com/speakeasy-api/openapi v1.7.3/go.mod h1:fy+CvRcKj+HDU0QNdnyG6UkfJOEjhqCuNC7o4AtLPAk=
-github.com/speakeasy-api/openapi-generation/v2 v2.723.2 h1:oHh4N39b3Fc8Tdj8ten2T/bFzPpTckz4eZHIi5otJPg=
-github.com/speakeasy-api/openapi-generation/v2 v2.723.2/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
+github.com/speakeasy-api/openapi-generation/v2 v2.723.4 h1:BSPKMPpqI/9WkKpuT0F5wKLWUFOFTf69tlfZghueTpw=
+github.com/speakeasy-api/openapi-generation/v2 v2.723.4/go.mod h1:fy5/XuA7hfY9pJkesh8av1l6PoQT1KFjzLZe38OAYFI=
 github.com/speakeasy-api/openapi-overlay v0.10.3 h1:70een4vwHyslIp796vM+ox6VISClhtXsCjrQNhxwvWs=
 github.com/speakeasy-api/openapi-overlay v0.10.3/go.mod h1:RJjV0jbUHqXLS0/Mxv5XE7LAnJHqHw+01RDdpoGqiyY=
 github.com/speakeasy-api/sdk-gen-config v1.35.0 h1:9yM5BwCqs+HmbyjIXwy+bciIdZROSJJWp98prFwe0OE=


### PR DESCRIPTION
Updating generator to latest release, includes these changes:
- [61dbf0b](https://github.com/speakeasy-api/openapi-generation/commit/61dbf0b1fde8f384c3efa6b4792ac3fc26b4a8bc) - csharp: Fix pagination issue when request bodies do not contain pagination fields (https://github.com/speakeasy-api/openapi-generation/pull/3302) (commit by @BlakeTheAwesome)
- [7c791d7](https://github.com/speakeasy-api/openapi-generation/commit/7c791d7fbf1f7db4ed2dcac839a9093984feb9ea) - Prevent infinite FieldDef and TypeDef cloning recursion from circular references (https://github.com/speakeasy-api/openapi-generation/pull/3297) (commit by @bflad)