### PR TITLE
feat(generator): MCP registry publishing, Terraform open-enums + binary/json media support, and CLI beta maturity

### DIFF
--- a/cmd/sdk/go/.speakeasy/gen.yaml
+++ b/cmd/sdk/go/.speakeasy/gen.yaml
@@ -35,6 +35,8 @@ go:
   additionalDependencies: {}
   clientServerStatusCodesAsErrors: true
   defaultErrorName: APIError
+  enableCustomCodeRegions: false
+  enableSkipDeserialization: false
   flattenGlobalSecurity: true
   forwardCompatibleEnumsByDefault: true
   forwardCompatibleUnionsByDefault: tagged-and-untagged

--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf
+	github.com/speakeasy-api/openapi-generation/v2 v2.879.1
 	github.com/speakeasy-api/sdk-gen-config v1.56.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.mod
+++ b/go.mod
@@ -45,8 +45,8 @@ require (
 	github.com/speakeasy-api/gram v0.0.0-20260121234743-5a36906a8929
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
-	github.com/speakeasy-api/openapi v1.19.5
-	github.com/speakeasy-api/openapi-generation/v2 v2.873.1
+	github.com/speakeasy-api/openapi v1.20.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf
 	github.com/speakeasy-api/sdk-gen-config v1.56.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
@@ -60,7 +60,7 @@ require (
 	go.uber.org/zap v1.27.1
 	goa.design/goa/v3 v3.24.1
 	golang.org/x/oauth2 v0.33.0
-	golang.org/x/sync v0.19.0
+	golang.org/x/sync v0.20.0
 	golang.org/x/term v0.39.0
 	golang.org/x/text v0.34.0
 	gopkg.in/yaml.v3 v3.0.1

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf h1:oJMjtJ1TqH9ZYAhmUoCX7z/5QtpxP4DAsi9zNhDAKOY=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.1 h1:SH5n/NeXcZNaNR6oyTgms+6nNJaR8fRTO+WXvNsFEGY=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.1/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=

--- a/go.sum
+++ b/go.sum
@@ -546,10 +546,10 @@ github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xh
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBmwLjg6l7J4amgSrPf3CNWReGNdwrRqJQ=
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
-github.com/speakeasy-api/openapi v1.19.5 h1:Wtz18b/lez1b2yzRezsNkTmIBXyi1IkA5SWPvYzfS40=
-github.com/speakeasy-api/openapi v1.19.5/go.mod h1:UfKa7FqE4jgexJZuj51MmdHAFGmDv0Zaw3+yOd81YKU=
-github.com/speakeasy-api/openapi-generation/v2 v2.873.1 h1:wC384RrqTo/4mEFFYirsBlY5yf3KT8jEb2PwgjqQCtQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.873.1/go.mod h1:mKM2bY7GKkSX1tt+cV1R3LL3CXNOBzDeEK9dkLSMJyk=
+github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
+github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf h1:oJMjtJ1TqH9ZYAhmUoCX7z/5QtpxP4DAsi9zNhDAKOY=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.1-0.20260331022554-2e1ca84a99bf/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=
@@ -722,8 +722,8 @@ golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJ
 golang.org/x/sync v0.0.0-20201020160332-67f06af15bc9/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.1.0/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
-golang.org/x/sync v0.19.0 h1:vV+1eWNmZ5geRlYjzm2adRgW2/mcpevXNg50YZtPCE4=
-golang.org/x/sync v0.19.0/go.mod h1:9KTHXmSnoGruLpwFjVSX0lNNA75CykiMECbovNTZqGI=
+golang.org/x/sync v0.20.0 h1:e0PTpb7pjO8GAtTs2dQ6jYa5BWYlMuX047Dco/pItO4=
+golang.org/x/sync v0.20.0/go.mod h1:9xrNwdLfx4jkKbNva9FpL6vEN7evnE43NNNJQ2LF3+0=
 golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20181128092732-4ed8d59d0b35/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/prompts/targets.go
+++ b/prompts/targets.go
@@ -353,9 +353,7 @@ var enterpriseOnlyTargets = []string{}
 // registryGatedTargets lists targets whose access is controlled server-side by
 // the registry's checkAccess endpoint. These targets bypass all local access
 // checks since the registry is the single source of truth.
-var registryGatedTargets = []string{
-	"cli",
-}
+var registryGatedTargets = []string{}
 
 // checkTargetAccess validates that the user has the required account tier and
 // that the target maturity allows generation. Enterprise-only targets require

--- a/prompts/utils.go
+++ b/prompts/utils.go
@@ -32,7 +32,7 @@ func getSourcesFromWorkflow(inputWorkflow *workflow.Workflow) []string {
 
 func getCLITargetOptions() []huh.Option[string] {
 	return []huh.Option[string]{
-		huh.NewOption("CLI "+getMaturityDisplay("Alpha"), "cli"),
+		huh.NewOption("CLI "+getMaturityDisplay(getTargetMaturity("cli")), "cli"),
 	}
 }
 


### PR DESCRIPTION
## Summary
- remove local filesystem replace and pin `openapi-generation` to the branch commit containing CLI beta maturity
- keep CLI target accessible from prompts without the prior registry-gated carveout

## Changes
- `go.mod` / `go.sum`
  - pin `github.com/speakeasy-api/openapi-generation/v2` to:
    - `v2.879.1-0.20260331022554-2e1ca84a99bf`
- `prompts/utils.go`
  - CLI maturity display now reads from `getTargetMaturity("cli")` instead of hardcoded `Alpha`
- `prompts/targets.go`
  - remove obsolete `registryGatedTargets` CLI handling
  - keep standard maturity/access checks

## Linked dependency PR
- openapi-generation: https://github.com/speakeasy-api/openapi-generation/pull/4167
