### PR TITLE
chore: upgrade openapi-generation to v2.879.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.879.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.879.6
 	github.com/speakeasy-api/sdk-gen-config v1.56.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.1 h1:SH5n/NeXcZNaNR6oyTgms+6nNJaR8fRTO+WXvNsFEGY=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.1/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.6 h1:NL2H0yB0u+N/CZZnfGxP+BbXBmvUvJqtVhVjmwwroDo=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.6/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=

--- a/internal/fs/fs.go
+++ b/internal/fs/fs.go
@@ -47,6 +47,10 @@ func (f *FileSystem) Stat(path string) (os.FileInfo, error) {
 	return os.Stat(path)
 }
 
+func (f *FileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
 func (f *FileSystem) Remove(path string) error {
 	return os.Remove(path)
 }

--- a/internal/usagegen/usagegen.go
+++ b/internal/usagegen/usagegen.go
@@ -312,6 +312,10 @@ func (fs *fileSystem) OpenFile(name string, flag int, perm fs.FileMode) (filesys
 	return os.OpenFile(name, flag, perm)
 }
 
+func (f *fileSystem) ReadDir(name string) ([]fs.DirEntry, error) {
+	return os.ReadDir(name)
+}
+
 func (fs *fileSystem) ScanForGeneratedIDs() (map[string]string, error) {
 	return nil, nil
 }


### PR DESCRIPTION
Fixes [GEN-2861: Add ReadDir to filesystem.FileSystem interface](https://linear.app/speakeasy/issue/GEN-2861/add-readdir-to-filesystemfilesystem-interface)

## Summary
- Upgrades `openapi-generation` from v2.879.5 to v2.879.6
- Implements `ReadDir` on `FileSystem` in `internal/fs/fs.go` and `internal/usagegen/usagegen.go` to satisfy the updated `filesystem.FileSystem` interface

## Test plan
- [x] `go build ./cmd/...` passes locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)