### PR TITLE
chore: surface persistent edits errors to be parsed snapshot executor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.879.10
+	github.com/speakeasy-api/openapi-generation/v2 v2.879.11
 	github.com/speakeasy-api/sdk-gen-config v1.56.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.10 h1:xMsXqOHi1TtSxSwpjWu0n9eBb1ASuJFLsjtfw8ErclE=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.10/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.11 h1:qcZF2Kkm6CC7K353ORQ2Ki1tYqA2hPKK0YnAKgrlawU=
+github.com/speakeasy-api/openapi-generation/v2 v2.879.11/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -188,10 +188,10 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 	}
 
 	// Track the current generation step for error reporting
-	failedStepMessage := ""
+	var failedStep *generate.ProgressStep
 	trackProgress := func(update generate.ProgressUpdate) {
 		if update.Step != nil {
-			failedStepMessage = update.Step.Message
+			failedStep = update.Step
 		}
 		// Forward to user-provided callback if present
 		if opts.StreamableGeneration != nil && opts.StreamableGeneration.OnProgressUpdate != nil {
@@ -276,18 +276,16 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 
 		if len(errs) > 0 {
 			for _, err := range errs {
-				// Check if it's a ConflictsError - render pretty conflict message
-				var conflictErr *merge.ConflictsError
-				if stderrors.As(err, &conflictErr) {
-					renderConflictsError(logger, conflictErr)
-					// Don't log the generic error for conflicts - we rendered a nice message
-					continue
+
+				if pe := handlePersistentEditsError(logger, err); pe != nil {
+					return fmt.Errorf("could not apply persistent edits for %q: %w", opts.Language, pe)
 				}
+
 				logger.Error("", zap.Error(err))
 			}
 
-			if failedStepMessage != "" {
-				return fmt.Errorf("generation failed for %q during step %q", opts.Language, failedStepMessage)
+			if failedStep != nil {
+				return fmt.Errorf("generation failed for %q during step %q", opts.Language, failedStep.Message)
 			}
 
 			return fmt.Errorf("failed to generate %q", opts.Language)
@@ -369,6 +367,22 @@ func GetGenLockID(outDir string) *string {
 		}
 	}
 
+	return nil
+}
+
+// handlePersistentEditsError checks whether err is a persistent-edits failure.
+// If it is a ConflictsError, it renders the instructional message before returning it.
+// Returns nil if err is not a persistent-edits error.
+func handlePersistentEditsError(logger log.Logger, err error) error {
+	var conflictErr *merge.ConflictsError
+	if stderrors.As(err, &conflictErr) {
+		renderConflictsError(logger, conflictErr)
+		return conflictErr
+	}
+	var snapshotRefErr *merge.SnapshotRefError
+	if stderrors.As(err, &snapshotRefErr) {
+		return snapshotRefErr
+	}
 	return nil
 }
 


### PR DESCRIPTION
https://linear.app/speakeasy/issue/GEN-2853/snapshot-tests-silently-fail-for-sdks-with-persistent-edits-missing

Part 2 of https://github.com/speakeasy-api/openapi-generation/pull/4175