### PR TITLE
fix: bump sdk-gen-config to v1.57.0 to preserve mcpRegistry in workflow.yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
 	github.com/speakeasy-api/openapi-generation/v2 v2.879.13
-	github.com/speakeasy-api/sdk-gen-config v1.56.0
+	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
 	github.com/speakeasy-api/speakeasy-core v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -554,6 +554,8 @@ github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-2026020602382
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=
 github.com/speakeasy-api/sdk-gen-config v1.56.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
+github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=
+github.com/speakeasy-api/sdk-gen-config v1.57.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0 h1:xqEoL+MY3gqJkDMjBqP++fieYilgI1pOeYycHfG3EUE=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7 h1:SoWZkRlpFlv8qibCfXWrBZay1JeLS9uqJ+1cu+DFgXo=

--- a/go.sum
+++ b/go.sum
@@ -552,8 +552,6 @@ github.com/speakeasy-api/openapi-generation/v2 v2.879.13 h1:1LvBnRHdizLIV4FxzlBF
 github.com/speakeasy-api/openapi-generation/v2 v2.879.13/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
-github.com/speakeasy-api/sdk-gen-config v1.56.0 h1:1tVW8mV/7o9/iFwHd7cGGZ7UCxCcU12QN9zOMwb/zCI=
-github.com/speakeasy-api/sdk-gen-config v1.56.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=
 github.com/speakeasy-api/sdk-gen-config v1.57.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0 h1:xqEoL+MY3gqJkDMjBqP++fieYilgI1pOeYycHfG3EUE=


### PR DESCRIPTION


v1.56.0 did not include the MCPRegistry field in the Publishing struct. When speakeasyVersion is set to "latest" in workflow.yaml, command.go unconditionally calls updateWorkflowFile() which marshals the in-memory workflow struct back to disk. Because MCPRegistry was an unknown field, Go's yaml library silently dropped it on unmarshal — and the subsequent write permanently removed it from the file.

v1.57.0 adds MCPRegistry to Publishing (feat: add MCPRegistry publishing config, sdk-gen-config#130), so the field is now round-tripped correctly.