### PR TITLE
fix(python): retry mechanism correctly retries on error status codes; feat(terraform): providerTypeNameOverride config; fix(mcp-typescript): align dynamic execute_tool with MCP tools/call shape; fix(all): default response handling in AfterErrorHook

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.879.13
+	github.com/speakeasy-api/openapi-generation/v2 v2.881.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.13 h1:1LvBnRHdizLIV4FxzlBFbXG7qzWlvYatW3/KjFthdN0=
-github.com/speakeasy-api/openapi-generation/v2 v2.879.13/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.0 h1:3YvLWN6NFAGAhKjebeh7g0Oxe9A3APQyD8oWCIBxpE4=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.0/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
## Python
- [Retry mechanism now correctly retries on error status codes (5XX, 429, etc.) — the inner `do()` error-status check was raising `APIError` before the retry wrapper could inspect the response, preventing retries from firing](https://github.com/speakeasy-api/openapi-generation/pull/4195)

## TypeScript
- [MCP dynamic-mode `execute_tool` now aligns with the canonical MCP `tools/call` shape (`{ name, arguments }` instead of `{ tool_name, input }`), fixing LLM-initiated calls that carried parameters getting dropped before reaching the underlying tool](https://github.com/speakeasy-api/openapi-generation/pull/4185)

## Terraform
- [Add `providerTypeNameOverride` gen.yaml option so variant providers (e.g. `myprovider-beta`) can publish resources under a shared type-name prefix (`myprovider_thing`), mirroring the `google-beta` pattern](https://github.com/speakeasy-api/openapi-generation/pull/4188)

## All
- [Fix `AfterErrorHook` being called for all status codes (including 200) when `x-speakeasy-errors` uses the `default` keyword — the unsanitized `"default"` entry was leaking into status-code matching](https://github.com/speakeasy-api/openapi-generation/pull/4131)