### PR TITLE
fix(typescript,mcp): debug logger no longer buffers JSONL/NDJSON streaming responses; fix(cli): prevent infinite loop for recursive oneOf schemas

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.881.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.881.2
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.0 h1:3YvLWN6NFAGAhKjebeh7g0Oxe9A3APQyD8oWCIBxpE4=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.0/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.2 h1:7JJD4ESMpe1emCFf1Y149kwVdYomEsP7BzQc0zzpUZs=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.2/go.mod h1:v+LnvSXKaS5XX5ub75L5kRXbKu7UMrPXbSwY6n1/Aoc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
## Core
- [Prevent infinite loop in CLI help generation for recursive oneOf schemas](https://github.com/speakeasy-api/openapi-generation/pull/4198)

## TypeScript
- [Debug logger no longer buffers JSONL/NDJSON streaming responses — streams now return as soon as headers arrive instead of waiting for the full body](https://github.com/speakeasy-api/openapi-generation/pull/4199)

## MCP TypeScript
- [Debug logger no longer buffers JSONL/NDJSON streaming responses — streams now return as soon as headers arrive instead of waiting for the full body](https://github.com/speakeasy-api/openapi-generation/pull/4199)