### PR TITLE
fix(java,csharp,typescript,mcp,python,go): pagination/error/template fixes across multiple languages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.881.4
+	github.com/speakeasy-api/openapi-generation/v2 v2.881.16
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.4 h1:k44L/RJRT28PzvCy4EDa2sGOc2tkKs0dca9sEQ17H9k=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.4/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.16 h1:HpDbBjCcwTDfSiOvqQ1hNkAHGoKADtfoTWFQazIX2Jg=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.16/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
## Java
- [springBootStarter / spring-boot-autoconfigure subprojects now respect `java.languageVersion` from gen.yaml (was hardcoded to 11)](https://github.com/speakeasy-api/openapi-generation/pull/4219)
- [fix error accessor type mismatch for required+nullable fields under `nullFriendlyParameters: false` (compile failure with `JsonNullable<T>` vs `Optional<T>`)](https://github.com/speakeasy-api/openapi-generation/pull/4207)
- [narrow nullable pagination params before arithmetic (compile error on `required + nullable` offset/limit)](https://github.com/speakeasy-api/openapi-generation/pull/4209)

## C#
- [sanitize `x-speakeasy-error-message` field name when it conflicts with the containing class name (avoids `CS1061` build failure)](https://github.com/speakeasy-api/openapi-generation/pull/4217)

## TypeScript
- [fix `targetting` → `targeting` typo in generated `FUNCTIONS.md`](https://github.com/speakeasy-api/openapi-generation/pull/4213)

## MCP
- [fix landing page `GET /` 500 caused by `new URL(req.host)` parse error (broke ALB health checks); drop redundant `Content-Type` from CORS allow-headers wildcard](https://github.com/speakeasy-api/openapi-generation/pull/4210)

## Python
- [narrow nullable pagination params before arithmetic to fix mypy failure on `nullable: true` paging fields](https://github.com/speakeasy-api/openapi-generation/pull/4209)
- [prevent pyright `reportInvalidTypeForm` errors in recursive `oneOf` unions](https://github.com/speakeasy-api/openapi-generation/pull/4206)

## Go
- [narrow nullable pagination params before arithmetic (compile error on `required + nullable` offset/limit)](https://github.com/speakeasy-api/openapi-generation/pull/4209)