### PR TITLE
fix(typescript,mcp): wrap optional helpers for Zod 4.4 compat

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.881.16
+	github.com/speakeasy-api/openapi-generation/v2 v2.881.17
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -550,6 +550,8 @@ github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
 github.com/speakeasy-api/openapi-generation/v2 v2.881.16 h1:HpDbBjCcwTDfSiOvqQ1hNkAHGoKADtfoTWFQazIX2Jg=
 github.com/speakeasy-api/openapi-generation/v2 v2.881.16/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.17 h1:sU1ibG4NAayCAHxnmxX+b/6kFWa5pfFsX02GpyoE9hg=
+github.com/speakeasy-api/openapi-generation/v2 v2.881.17/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
GEN-2935

Context: Zod 4.4.0 ([released 2026-04-29 22:39 UTC](https://www.npmjs.com/package/zod)) tightened object-level validation: a bare `z.union` including `z.undefined()` is no longer treated as optional inside `z.object()`. The schema raises `expected: 'nonoptional'` whenever the key is missing, even though the value-side union accepts `undefined`.
