### PR TITLE
feat(all): mintlify MDX documentation output mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.881.17
+	github.com/speakeasy-api/openapi-generation/v2 v2.882.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,10 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.16 h1:HpDbBjCcwTDfSiOvqQ1hNkAHGoKADtfoTWFQazIX2Jg=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.16/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.17 h1:sU1ibG4NAayCAHxnmxX+b/6kFWa5pfFsX02GpyoE9hg=
-github.com/speakeasy-api/openapi-generation/v2 v2.881.17/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
+github.com/speakeasy-api/openapi-generation/v2 v2.882.0 h1:lwK0GyhMBnO51GBiUVXrGRWO8/g3Jw5/I83s2+Zz8HI=
+github.com/speakeasy-api/openapi-generation/v2 v2.882.0/go.mod h1:dzUuJuHCt5bZO/uK/ES5zp8HUx7Pi0jJj9GwlKtVrFo=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
## Core
- No core CLI changes.

## Python
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## TypeScript
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## Go
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## Java
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## C#
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## PHP
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## Ruby
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## MCP TypeScript
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)

## Unity
- [Add `generation.documentation: mintlify` in gen.yaml to emit Mintlify-flavored MDX docs (with frontmatter, `.md`→`.mdx` link rewriting, and MDX-safe escaping) instead of standard Markdown.](https://github.com/speakeasy-api/openapi-generation/pull/4222)