### PR TITLE
fix(all): mockserver orphan cleanup; fix(python): union ordering for nested discriminators

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.884.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.884.4
 	github.com/speakeasy-api/sdk-gen-config v1.57.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.0 h1:XLIX4IteTsTEqevRwG6zCQ+gJnanRZ3r6nHgbOqSqYA=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.0/go.mod h1:XqAK6/QZitHMD60SF9QCAtuUAw0rOsOgxy55ANPQ7sc=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.4 h1:c1DSvDcxE6Uz38CGe4MjaJ1tPU7HuKMK1KMoUTtpzMw=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.4/go.mod h1:XqAK6/QZitHMD60SF9QCAtuUAw0rOsOgxy55ANPQ7sc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=


### PR DESCRIPTION
## Core
- [Remove orphaned mockserver files on regeneration to prevent duplicate Go declarations and broken builds when files exist on disk but are not tracked in `gen.lock`](https://github.com/speakeasy-api/openapi-generation/pull/4235)

## Python
- [Selectively sort unions in `TopologicalSortTypeDefs` to fix used-before-definition errors with nested discriminated unions (gated by `conflictResistantModelImportsFeb2026`)](https://github.com/speakeasy-api/openapi-generation/pull/4236)