### PR TITLE
fix(ci): shell out default-branch push in CommitAndPush

### DIFF
--- a/internal/ci/git/git.go
+++ b/internal/ci/git/git.go
@@ -652,11 +652,13 @@ func (g *Git) CommitAndPush(openAPIDocVersion, speakeasyVersion, doc string, act
 				return "", err
 			}
 		} else {
-			// Default: force push (branch was reset to main at the beginning of the workflow)
-			if err := g.repo.Push(&git.PushOptions{
-				Auth:  sharedgit.BasicAuth(g.accessToken),
-				Force: true,
-			}); err != nil {
+			// Force push: branch was reset to main at workflow start.
+			dir := filepath.Join(g.repoRoot, environment.GetWorkingDirectory())
+			branch, err := g.GetCurrentBranch()
+			if err != nil {
+				return "", fmt.Errorf("error getting current branch for push: %w", err)
+			}
+			if _, err := sharedgit.RunGitCommand(dir, "push", "--force", "origin", branch); err != nil {
 				return "", pushErr(err)
 			}
 		}

--- a/internal/ci/git/git_commitandpush_integration_test.go
+++ b/internal/ci/git/git_commitandpush_integration_test.go
@@ -1,0 +1,85 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/speakeasy-api/versioning-reports/versioning"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommitAndPush_Integration_UnsignedDefaultBranch drives CommitAndPush
+// end-to-end through the unsigned default-branch path against a real bare
+// remote. Confirms the full Add → Commit → push chain lands on the remote.
+func TestCommitAndPush_Integration_UnsignedDefaultBranch(t *testing.T) {
+	// Uses t.Setenv, so not parallel.
+	t.Setenv("INPUT_SIGNED_COMMITS", "false")
+	t.Setenv("INPUT_BRANCH_NAME", "")
+	t.Setenv("INPUT_MODE", "pr")
+	t.Setenv("INPUT_WORKING_DIRECTORY", "")
+	t.Setenv("INPUT_FEATURE_BRANCH", "")
+	t.Setenv("INPUT_ENABLE_SDK_CHANGELOG", "false")
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote")
+	clone := filepath.Join(root, "clone")
+
+	require.NoError(t, exec.Command("git", "init", "--bare", "-b", "main", remote).Run())
+
+	seed := filepath.Join(root, "seed")
+	require.NoError(t, exec.Command("git", "init", "-b", "main", seed).Run())
+	runGitCLI(t, seed, "config", "user.email", "speakeasybot@speakeasyapi.dev")
+	runGitCLI(t, seed, "config", "user.name", "speakeasybot")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "sdk.ts"), []byte("// v0\n"), 0644))
+	runGitCLI(t, seed, "add", "sdk.ts")
+	runGitCLI(t, seed, "commit", "-m", "initial")
+	runGitCLI(t, seed, "remote", "add", "origin", remote)
+	runGitCLI(t, seed, "push", "origin", "main")
+
+	require.NoError(t, exec.Command("git", "clone", remote, clone).Run())
+	runGitCLI(t, clone, "config", "user.email", "speakeasybot@speakeasyapi.dev")
+	runGitCLI(t, clone, "config", "user.name", "speakeasybot")
+
+	branch := "speakeasy-sdk-regen-1779200000"
+	runGitCLI(t, clone, "checkout", "-b", branch)
+
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "sdk.ts"), []byte("// v1 regenerated\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "new_generated.ts"), []byte("// new file\n"), 0644))
+
+	t.Chdir(clone)
+	g := New("test-token")
+	require.NoError(t, g.OpenRepo())
+
+	headBefore := strings.TrimSpace(string(gitOutput(t, "-C", clone, "rev-parse", "HEAD")))
+	require.False(t, remoteHasBranch(t, remote, branch))
+
+	commitHash, err := g.CommitAndPush(
+		"openapi-doc-v1",
+		"1.500.0",
+		"",
+		"run-workflow",
+		false,
+		(*versioning.MergedVersionReport)(nil),
+	)
+	require.NoError(t, err)
+	require.NotEmpty(t, commitHash)
+
+	remoteHead := strings.TrimSpace(string(gitOutput(t, "-C", remote, "rev-parse", branch)))
+	localHead := strings.TrimSpace(string(gitOutput(t, "-C", clone, "rev-parse", "HEAD")))
+	require.Equal(t, localHead, remoteHead)
+	require.NotEqual(t, headBefore, localHead)
+
+	listOut := gitOutput(t, "-C", remote, "show", "--name-only", "--pretty=format:", branch)
+	files := strings.Fields(string(listOut))
+	require.Contains(t, files, "sdk.ts")
+	require.Contains(t, files, "new_generated.ts")
+}
+
+func remoteHasBranch(t *testing.T, bareDir, branch string) bool {
+	t.Helper()
+	out, err := exec.Command("git", "-C", bareDir, "rev-parse", "--verify", branch).CombinedOutput()
+	return err == nil && len(out) > 0
+}

--- a/internal/ci/git/git_pushshellout_test.go
+++ b/internal/ci/git/git_pushshellout_test.go
@@ -1,0 +1,83 @@
+package git
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/go-git/go-git/v5"
+	sharedgit "github.com/speakeasy-api/speakeasy/internal/git"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCommitAndPush_DefaultBranchShellsOut exercises the shell-out push
+// helper call against a real bare remote.
+func TestCommitAndPush_DefaultBranchShellsOut(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "remote")
+	clone := filepath.Join(root, "clone")
+
+	require.NoError(t, exec.Command("git", "init", "--bare", "-b", "main", remote).Run())
+
+	seed := filepath.Join(root, "seed")
+	require.NoError(t, exec.Command("git", "init", "-b", "main", seed).Run())
+	runGitCLI(t, seed, "config", "user.email", "t@t")
+	runGitCLI(t, seed, "config", "user.name", "t")
+	require.NoError(t, os.WriteFile(filepath.Join(seed, "README.md"), []byte("init\n"), 0644))
+	runGitCLI(t, seed, "add", "README.md")
+	runGitCLI(t, seed, "commit", "-m", "init")
+	runGitCLI(t, seed, "remote", "add", "origin", remote)
+	runGitCLI(t, seed, "push", "origin", "main")
+
+	require.NoError(t, exec.Command("git", "clone", remote, clone).Run())
+	runGitCLI(t, clone, "config", "user.email", "t@t")
+	runGitCLI(t, clone, "config", "user.name", "t")
+
+	branch := "speakeasy-sdk-regen-test"
+	runGitCLI(t, clone, "checkout", "-b", branch)
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "generated.txt"), []byte("v1\n"), 0644))
+	runGitCLI(t, clone, "add", ".")
+	runGitCLI(t, clone, "commit", "-m", "regenerated")
+
+	repo, err := git.PlainOpenWithOptions(clone, &git.PlainOpenOptions{DetectDotGit: true})
+	require.NoError(t, err)
+	wt, err := repo.Worktree()
+	require.NoError(t, err)
+	g := &Git{repo: repo, repoRoot: wt.Filesystem.Root()}
+
+	gotBranch, err := g.GetCurrentBranch()
+	require.NoError(t, err)
+	require.Equal(t, branch, gotBranch)
+
+	out, err := sharedgit.RunGitCommand(g.repoRoot, "push", "--force", "origin", gotBranch)
+	require.NoError(t, err, "push --force: %s", out)
+
+	localHead := strings.TrimSpace(string(gitOutput(t, "-C", clone, "rev-parse", "HEAD")))
+	remoteHead := strings.TrimSpace(string(gitOutput(t, "-C", remote, "rev-parse", branch)))
+	require.Equal(t, localHead, remoteHead)
+
+	// Force-push semantics: rewind, recommit, push again, remote must move.
+	runGitCLI(t, clone, "reset", "--hard", "HEAD^")
+	require.NoError(t, os.WriteFile(filepath.Join(clone, "generated.txt"), []byte("v2\n"), 0644))
+	runGitCLI(t, clone, "add", ".")
+	runGitCLI(t, clone, "commit", "-m", "regenerated v2")
+
+	out, err = sharedgit.RunGitCommand(g.repoRoot, "push", "--force", "origin", gotBranch)
+	require.NoError(t, err, "force push: %s", out)
+
+	newLocalHead := strings.TrimSpace(string(gitOutput(t, "-C", clone, "rev-parse", "HEAD")))
+	newRemoteHead := strings.TrimSpace(string(gitOutput(t, "-C", remote, "rev-parse", branch)))
+	require.Equal(t, newLocalHead, newRemoteHead)
+	require.NotEqual(t, remoteHead, newRemoteHead)
+}
+
+func gitOutput(t *testing.T, args ...string) []byte {
+	t.Helper()
+	out, err := exec.Command("git", args...).CombinedOutput()
+	require.NoError(t, err, "git %v: %s", args, out)
+	return out
+}


### PR DESCRIPTION
`CommitAndPush`'s default-branch push was the last write op in `internal/ci/git/git.go` still going through go-git's `repo.Push`. Every other write here (`rebaseAndPush`, `Reset`, `Add`, `MergeBranch`'s merge step) already shells out via `sharedgit.RunGitCommand`. This brings the default-branch push in line.

It also fixes a class of intermittent `error pushing changes: object not found` failures: go-git's in-process pack-index cache can go stale when subprocess git operations rewrite packs mid-run, and push enumeration then can't find an object that's on disk under a new filename. System git re-reads pack state every invocation and isn't affected.

`MergeBranch`'s push has the same buggy block and will be ported in a follow-up.

### Test plan

- `git_commitandpush_integration_test.go` drives `CommitAndPush` end-to-end through the changed path against a real bare remote
- existing `internal/ci/...` tests still pass

GEN-2992