### PR TITLE
fix(python): preserve types package support exports; fix envVarPrefix fallback in security-less SDKs

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
         run: git config --global url."https://speakeasybot:${GIT_AUTH_TOKEN}@github.com".insteadOf "https://github.com"
       - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
-          version: v2.4.0
+          version: v2.12.2
           args: --timeout=10m --verbose
   build-test:
     name: Build & Test

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,6 +1,4 @@
 version: "2"
-run:
-  go: "1.25"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,6 @@
 version: "2"
+run:
+  go: "1.25"
 issues:
   max-issues-per-linter: 0
   max-same-issues: 0

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -500,9 +500,9 @@ func diagnosisToTabContents(diagnosis suggestions.Diagnosis) []interactivity.Ins
 		var details strings.Builder
 		for _, d := range diagnostics {
 			if len(d.SchemaPath) > 0 {
-				details.WriteString(fmt.Sprintf("• %s - %s\n", styles.Dimmed.Render(strings.Join(d.SchemaPath, " > ")), d.Message))
+				fmt.Fprintf(&details, "• %s - %s\n", styles.Dimmed.Render(strings.Join(d.SchemaPath, " > ")), d.Message)
 			} else {
-				details.WriteString(fmt.Sprintf("• %s\n", d.Message))
+				fmt.Fprintf(&details, "• %s\n", d.Message)
 			}
 		}
 

--- a/cmd/pull.go
+++ b/cmd/pull.go
@@ -339,25 +339,25 @@ func (m *pullModel) View() string {
 	switch m.step {
 	case 1:
 		if m.loadingSpecs {
-			s.WriteString(fmt.Sprintf("%s %s", styles.Info.Margin(0, 2).Render("Loading specs..."), m.spinner.View()))
+			fmt.Fprintf(&s, "%s %s", styles.Info.Margin(0, 2).Render("Loading specs..."), m.spinner.View())
 		} else {
 			s.WriteString(m.specsList.View())
 		}
 	case 2:
 		if m.loadingRevisions {
-			s.WriteString(fmt.Sprintf("%s %s", styles.Info.Margin(0, 2).Render("Loading revisions..."), m.spinner.View()))
+			fmt.Fprintf(&s, "%s %s", styles.Info.Margin(0, 2).Render("Loading revisions..."), m.spinner.View())
 		} else {
-			s.WriteString(fmt.Sprintf("%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name)))
+			fmt.Fprintf(&s, "%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name))
 			s.WriteString(m.revisionsList.View())
 		}
 	case 3:
-		s.WriteString(fmt.Sprintf("%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name)))
-		s.WriteString(fmt.Sprintf("%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected revision:"), styles.Focused.Render(m.selectedRevision.Name)))
+		fmt.Fprintf(&s, "%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name))
+		fmt.Fprintf(&s, "%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected revision:"), styles.Focused.Render(m.selectedRevision.Name))
 		s.WriteString(m.outputDir.View())
 	case 4:
-		s.WriteString(fmt.Sprintf("%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name)))
-		s.WriteString(fmt.Sprintf("%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected revision:"), styles.Focused.Render(m.selectedRevision.Name)))
-		s.WriteString(fmt.Sprintf("%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected output directory:"), styles.Focused.Render(m.selectedOutputDir)))
+		fmt.Fprintf(&s, "%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected spec:"), styles.Focused.Render(m.selectedSpec.Name))
+		fmt.Fprintf(&s, "%s %s\n", styles.Dimmed.Margin(0, 2).Render("Selected revision:"), styles.Focused.Render(m.selectedRevision.Name))
+		fmt.Fprintf(&s, "%s %s\n\n", styles.Dimmed.Margin(0, 2).Render("Selected output directory:"), styles.Focused.Render(m.selectedOutputDir))
 		// add a clickable button to run the pull
 		button := interactivity.Button{
 			Label:    "Pull",

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/speakeasy-api/speakeasy
 
-go 1.25.9
+go 1.26.2
 
 replace github.com/pb33f/doctor => github.com/speakeasy-api/doctor v0.20.0-fixvacuum
 
@@ -46,8 +46,8 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.884.7
-	github.com/speakeasy-api/sdk-gen-config v1.57.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.884.11
+	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
 	github.com/speakeasy-api/speakeasy-core v0.22.1

--- a/go.sum
+++ b/go.sum
@@ -548,12 +548,12 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.7 h1:Fg5xOUeKHphewvirTJEgSWlyXJO73GmWhowjbDu6+gY=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.7/go.mod h1:XqAK6/QZitHMD60SF9QCAtuUAw0rOsOgxy55ANPQ7sc=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.11 h1:2SFAgdXNIjR0yKbKtmQIeT0RuoVCQCRvtS+MiVn0LBs=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.11/go.mod h1:wqbB1VTzyqavXI/FO7FNMORsMOnsSodKfEfP13PcAJI=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
-github.com/speakeasy-api/sdk-gen-config v1.57.0 h1:JQ2XcDbZkmYZhsQoQ9BH9TJR4KiO1uN+GVOOc0EGMA8=
-github.com/speakeasy-api/sdk-gen-config v1.57.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
+github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=
+github.com/speakeasy-api/sdk-gen-config v1.57.1/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0 h1:xqEoL+MY3gqJkDMjBqP++fieYilgI1pOeYycHfG3EUE=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.0/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7 h1:SoWZkRlpFlv8qibCfXWrBZay1JeLS9uqJ+1cu+DFgXo=

--- a/internal/ci/actions/test.go
+++ b/internal/ci/actions/test.go
@@ -184,7 +184,7 @@ func writeTestReportComment(g *git.Git, prNumber *int, testReports map[string]Te
 		if !report.Success {
 			statusEmoji = "❌"
 		}
-		tableRows.WriteString(fmt.Sprintf("| %s | <p align='center'>%s</p> | [view report](%s) |\n", target, statusEmoji, report.URL))
+		fmt.Fprintf(&tableRows, "| %s | <p align='center'>%s</p> | [view report](%s) |\n", target, statusEmoji, report.URL)
 	}
 
 	// Combine everything

--- a/internal/github/validation_comment.go
+++ b/internal/github/validation_comment.go
@@ -36,14 +36,14 @@ func BuildValidationComment(results []SpecValidationResult) string {
 	md.WriteString("|------|--------|--------|----------|-------|-------------|\n")
 
 	for _, r := range results {
-		md.WriteString(fmt.Sprintf("| %s | %s | %d | %d | %d | %d |\n",
+		fmt.Fprintf(&md, "| %s | %s | %d | %d | %d | %d |\n",
 			r.SpecPath,
 			summaryStatus(r),
 			len(r.Errors),
 			len(r.Warnings),
 			len(r.Hints),
 			len(r.InvalidOperations),
-		))
+		)
 	}
 
 	md.WriteString("\n")
@@ -73,7 +73,7 @@ func BuildValidationComment(results []SpecValidationResult) string {
 		summary := fmt.Sprintf("%s %s — %s", icon, r.SpecPath, strings.Join(parts, ", "))
 
 		md.WriteString("<details>\n")
-		md.WriteString(fmt.Sprintf("<summary>%s</summary>\n\n", summary))
+		fmt.Fprintf(&md, "<summary>%s</summary>\n\n", summary)
 
 		if len(r.Errors) > 0 || len(r.Warnings) > 0 || len(r.Hints) > 0 {
 			md.WriteString("| Severity | Rule | Message | Line |\n")
@@ -85,23 +85,23 @@ func BuildValidationComment(results []SpecValidationResult) string {
 			for _, err := range allErrs {
 				vErr := errors.GetValidationErr(err)
 				if vErr != nil {
-					md.WriteString(fmt.Sprintf("| %s | %s | %s | %s |\n",
+					fmt.Fprintf(&md, "| %s | %s | %s | %s |\n",
 						strings.ToUpper(string(vErr.Severity)),
 						vErr.Rule,
 						vErr.Message,
-						strconv.Itoa(vErr.GetLineNumber())))
+						strconv.Itoa(vErr.GetLineNumber()))
 					continue
 				}
 
 				uErr := errors.GetUnsupportedErr(err)
 				if uErr != nil {
-					md.WriteString(fmt.Sprintf("| WARN | unsupported | %s | %s |\n",
+					fmt.Fprintf(&md, "| WARN | unsupported | %s | %s |\n",
 						uErr.Error(),
-						strconv.Itoa(uErr.GetLineNumber())))
+						strconv.Itoa(uErr.GetLineNumber()))
 					continue
 				}
 
-				md.WriteString(fmt.Sprintf("| UNKNOWN | unknown | %s | |\n", err.Error()))
+				fmt.Fprintf(&md, "| UNKNOWN | unknown | %s | |\n", err.Error())
 			}
 			md.WriteString("\n")
 		}
@@ -109,7 +109,7 @@ func BuildValidationComment(results []SpecValidationResult) string {
 		if len(r.InvalidOperations) > 0 {
 			md.WriteString("**Skipped operations** (would be excluded from generated SDK):\n")
 			for _, op := range r.InvalidOperations {
-				md.WriteString(fmt.Sprintf("- `%s`\n", op))
+				fmt.Fprintf(&md, "- `%s`\n", op)
 			}
 			md.WriteString("\n")
 		}

--- a/internal/log/utils.go
+++ b/internal/log/utils.go
@@ -52,7 +52,7 @@ func PrettyPrint(ctx context.Context, value interface{}, fieldNameReplacements m
 
 	refVal := reflect.ValueOf(value)
 
-	if refVal.Kind() == reflect.Ptr {
+	if refVal.Kind() == reflect.Pointer {
 		refVal = refVal.Elem()
 	}
 
@@ -65,7 +65,7 @@ func PrettyPrint(ctx context.Context, value interface{}, fieldNameReplacements m
 		fieldName := field.Name
 		val := refVal.Field(i)
 
-		if field.Type.Kind() == reflect.Ptr && !val.IsNil() {
+		if field.Type.Kind() == reflect.Pointer && !val.IsNil() {
 			val = val.Elem()
 		}
 

--- a/internal/prdescription/prdescription.go
+++ b/internal/prdescription/prdescription.go
@@ -136,10 +136,10 @@ func buildBody(input Input) string {
 	// Footer
 	if !input.SourceGeneration {
 		if input.SpeakeasyVersion != "" {
-			body.WriteString(fmt.Sprintf("\nBased on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) %s\n", input.SpeakeasyVersion))
+			fmt.Fprintf(&body, "\nBased on [Speakeasy CLI](https://github.com/speakeasy-api/speakeasy) %s\n", input.SpeakeasyVersion)
 		}
 		if input.ActionRunURL != "" {
-			body.WriteString(fmt.Sprintf("\nLast updated by [Speakeasy workflow](%s)\n", input.ActionRunURL))
+			fmt.Fprintf(&body, "\nLast updated by [Speakeasy workflow](%s)\n", input.ActionRunURL)
 		}
 	}
 

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -391,7 +391,7 @@ func renderConflictsError(logger log.Logger, conflictErr *merge.ConflictsError) 
 	// Build file list with "both modified:" prefix like git status
 	var fileLines strings.Builder
 	for _, file := range conflictErr.Files {
-		fileLines.WriteString(fmt.Sprintf("    both modified:   %s\n", file))
+		fmt.Fprintf(&fileLines, "    both modified:   %s\n", file)
 	}
 
 	// Render instructional error box

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -208,7 +208,7 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 	var sb strings.Builder
 
 	errAndLine := styles.SeverityToStyle(err.Severity).Render(fmt.Sprintf("%s on line %d:%d", err.Severity, err.GetLineNumber(), err.GetColumnNumber()))
-	sb.WriteString(fmt.Sprintf("%s %s\n", errAndLine, styles.Dimmed.Render(err.Rule)))
+	fmt.Fprintf(&sb, "%s %s\n", errAndLine, styles.Dimmed.Render(err.Rule))
 	sb.WriteString(err.Message)
 	sb.WriteString("\n\n")
 
@@ -248,7 +248,7 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 
 		trimmedContent := strings.TrimPrefix(line, shortestWhitespacePrefix)
 
-		sb.WriteString(fmt.Sprintf("%s %s\n", lineNumString, trimmedContent))
+		fmt.Fprintf(&sb, "%s %s\n", lineNumString, trimmedContent)
 	}
 
 	return sb.String()

--- a/internal/workflowTracking/workflowMermaidVisualizer.go
+++ b/internal/workflowTracking/workflowMermaidVisualizer.go
@@ -50,7 +50,7 @@ func (w *WorkflowStep) toMermaidInternal(nodeNum *int) (string, error) {
 		return nil
 	}
 	writeConnection := func(from, to int) {
-		builder.WriteString(fmt.Sprintf("%d --> %d\n", from, to))
+		fmt.Fprintf(&builder, "%d --> %d\n", from, to)
 	}
 
 	*nodeNum++
@@ -77,9 +77,9 @@ func (w *WorkflowStep) toMermaidInternal(nodeNum *int) (string, error) {
 	nodeNameDisplay := fmt.Sprintf("%s%s", w.name, statusMessage)
 
 	if len(w.substeps) == 0 {
-		builder.WriteString(fmt.Sprintf("%d(\"%s\"):::%s\n", selfNodeNum, nodeNameDisplay, class))
+		fmt.Fprintf(&builder, "%d(\"%s\"):::%s\n", selfNodeNum, nodeNameDisplay, class)
 	} else {
-		builder.WriteString(fmt.Sprintf("subgraph %d [\"%s\"]\n", selfNodeNum, nodeNameDisplay))
+		fmt.Fprintf(&builder, "subgraph %d [\"%s\"]\n", selfNodeNum, nodeNameDisplay)
 		for i, child := range w.substeps {
 			childNodeNum := *nodeNum + 1
 			if err := writeChildNode(child); err != nil {
@@ -91,7 +91,7 @@ func (w *WorkflowStep) toMermaidInternal(nodeNum *int) (string, error) {
 			}
 		}
 		builder.WriteString("end\n")
-		builder.WriteString(fmt.Sprintf("class %d %s\n", selfNodeNum, class)) // Subgraph class assignment needs to happen after the subgraph is defined
+		fmt.Fprintf(&builder, "class %d %s\n", selfNodeNum, class) // Subgraph class assignment needs to happen after the subgraph is defined
 	}
 
 	return builder.String(), nil

--- a/prompts/target_form_field.go
+++ b/prompts/target_form_field.go
@@ -254,7 +254,7 @@ func (f *TargetFormField) HuhField(targetFormFields TargetFormFields) huh.Field 
 		// unwrap f.Value
 		unwrap := func(x interface{}) interface{} {
 			rv := reflect.ValueOf(x)
-			for rv.IsValid() && (rv.Kind() == reflect.Interface || rv.Kind() == reflect.Ptr) {
+			for rv.IsValid() && (rv.Kind() == reflect.Interface || rv.Kind() == reflect.Pointer) {
 				if rv.IsNil() {
 					return nil
 				}


### PR DESCRIPTION
## Python
- [Preserve types package support exports](https://github.com/speakeasy-api/openapi-generation/pull/4262)
- [Respect envVarPrefix fallback when SDK constructed with no security args](https://github.com/speakeasy-api/openapi-generation/pull/4255)