### PR TITLE
Security: Insecure Temporary File Creation with Predictable Path

### DIFF
--- a/internal/defaultcodesamples/defaultcodesamples.go
+++ b/internal/defaultcodesamples/defaultcodesamples.go
@@ -35,7 +35,11 @@ func DefaultCodeSamples(ctx context.Context, flags DefaultCodeSamplesFlags) erro
 	if err != nil {
 		return fmt.Errorf("failed to read default code samples file: %w", err)
 	}
-	tempDir := os.TempDir()
+	tempDir, err := os.MkdirTemp("", "defaultcodesamples-*")
+	if err != nil {
+		return fmt.Errorf("failed to create temporary directory: %w", err)
+	}
+	defer os.RemoveAll(tempDir)
 	tempFile := fmt.Sprintf("%s/defaultcodesamples.js", tempDir)
 	err = os.WriteFile(tempFile, result, 0o644)
 	if err != nil {


### PR DESCRIPTION
## Summary

Security: Insecure Temporary File Creation with Predictable Path

## Problem

**Severity**: `Medium` | **File**: `internal/defaultcodesamples/defaultcodesamples.go:L38`

In `internal/defaultcodesamples/defaultcodesamples.go`, the code creates a temporary file using `os.TempDir()` with a hardcoded filename `defaultcodesamples.js`. This is predictable and could lead to a race condition or symlink attack if an attacker can create this file before the program does. The file is written with `0o644` permissions and then executed via `exec.Command`.

## Solution

Use `os.CreateTemp` or `os.MkdirTemp` to create a temporary directory with a random name, then write the file there. This prevents predictable path attacks. Also ensure the temporary directory is cleaned up after execution.

## Changes

- `internal/defaultcodesamples/defaultcodesamples.go` (modified)