### PR TITLE
chore(cli, go, terraform): bump Go directive for CVE fixes; fix(typescript): unhandled rejection & lax-mode smart primitives; fix(python): envVarPrefix fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.884.11
+	github.com/speakeasy-api/openapi-generation/v2 v2.884.13
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.7
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.11 h1:2SFAgdXNIjR0yKbKtmQIeT0RuoVCQCRvtS+MiVn0LBs=
-github.com/speakeasy-api/openapi-generation/v2 v2.884.11/go.mod h1:wqbB1VTzyqavXI/FO7FNMORsMOnsSodKfEfP13PcAJI=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.13 h1:Jkw1dM4mQgCYZBGnJNTODQOSn8GqsJ2Ij0VLxs3ntuc=
+github.com/speakeasy-api/openapi-generation/v2 v2.884.13/go.mod h1:wqbB1VTzyqavXI/FO7FNMORsMOnsSodKfEfP13PcAJI=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Core
- [Bump Go directive from 1.25 to 1.26 to address CVEs in Go < 1.25.9](https://github.com/speakeasy-api/openapi-generation/pull/4269)

## TypeScript
- [Fix unhandled rejection when APIPromise rejects but caller does not call .catch](https://github.com/speakeasy-api/openapi-generation/pull/4258)
- [Move lax-mode absent required key handling into smart primitives](https://github.com/speakeasy-api/openapi-generation/pull/4269)

## Go
- [Bump Go directive from 1.22 to 1.26 to address CVEs in Go < 1.25.9](https://github.com/speakeasy-api/openapi-generation/pull/4269)

## Python
- [Fix envVarPrefix fallback when SDK is constructed with no security args](https://github.com/speakeasy-api/openapi-generation/pull/4269)

## Terraform
- [Bump Go directive from 1.25 to 1.26 to address CVEs in Go < 1.25.9](https://github.com/speakeasy-api/openapi-generation/pull/4269)