### PR TITLE
feat(python): add opt-in support for base64 json file inputs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.885.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.886.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.7
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.885.1 h1:gk/e8qRL79/LSPg6EVPrEcDG1HUhsdTlIKYtBQ+9IIQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.885.1/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.886.0 h1:LCfZiZsZ+8ok0TibJ9AMPBXiZK8tYFGIAuvQcc/MiNg=
+github.com/speakeasy-api/openapi-generation/v2 v2.886.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
GEN-3011: add opt-in support for the `x-speakeasy-base64-input-mode` file extension, enabling base64 file inputs on JSON request fields with `format: byte` or `contentEncoding: base64`