### PR TITLE
feat(typescript): no-zod variant; fix(python): base64 file input exports

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.20.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.888.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.889.1
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.7
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.20.0 h1:dfQaRL/1+NRPho/CnG0McONceyam7HrWJnpU7mwz570=
 github.com/speakeasy-api/openapi v1.20.0/go.mod h1:5gOzfAL1nSm57JswBgbpLqoBMGFlabSlTbxTNgHHO/0=
-github.com/speakeasy-api/openapi-generation/v2 v2.888.0 h1:S0m3BB7oaY3NmICmlH68DZjqJgtGw1Szw69/n1/BWAY=
-github.com/speakeasy-api/openapi-generation/v2 v2.888.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.889.1 h1:4ImBxTJj3sRUxud67g/IiL2qKHyy5A6c3pbFmOLPxY0=
+github.com/speakeasy-api/openapi-generation/v2 v2.889.1/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Python
- [Add `Base64FileInput`/`Base64EncodedString` to `types/__init__.py` eager exports — fixes `Variable "...Base64FileInput" is not valid as a type` mypy errors on fields using `x-speakeasy-base64-input-mode: file`](https://github.com/speakeasy-api/openapi-generation/pull/4290)

## TypeScript
- [Add opt-in `zodVersion: "none"` no-zod variant: generated SDK ships with no zod runtime — no validation, no transforms, `JSON.parse`/`JSON.stringify` only. Models emit only the user-facing TS type; enums collapse to string-literal unions; `ResponseValidationError`/`Schema$`/`passthrough` not emitted. Field renames (`x-speakeasy-name-override`, auto-casing) are not supported — gen fails fast with a clear error. Migration path: set `preserveModelFieldNames: true` in gen.yaml.](https://github.com/speakeasy-api/openapi-generation/pull/4276)