### PR TITLE
fix(typescript,python): SSE overload Accept header & query overloads; fix(go,terraform): pin generated Go directive to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.892.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.892.5
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.892.1 h1:nMEFtbFlBS7k9GQ7126f8lxTIUBaN9w3uvk+eqIYuhM=
-github.com/speakeasy-api/openapi-generation/v2 v2.892.1/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.892.5 h1:Q4e7SWpMrGcZ4MzzA0B1jJHuNvWEW+qbus0qSblGhn8=
+github.com/speakeasy-api/openapi-generation/v2 v2.892.5/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades `openapi-generation` from `v2.892.1` → `v2.892.5`.

## TypeScript
- [Support explicit query-parameter SSE overloads (`stream` as a top-level query field), matching Python's query-SSE behavior](https://github.com/speakeasy-api/openapi-generation/pull/4311)
- [Emit a stream-conditional `Accept` header for SSE-overload operations with multiple response content types, so callers get the correct `EventStream` vs `Array` overload based on the `stream` flag](https://github.com/speakeasy-api/openapi-generation/pull/4309)

## Python
- [Emit a stream-conditional `Accept` header for SSE-overload operations with multiple response content types](https://github.com/speakeasy-api/openapi-generation/pull/4309)

## Go
- [Pin the generated SDK Go directive to 1.25.10 (rolled back from an unreleased 1.26, then forward to 1.25.10)](https://github.com/speakeasy-api/openapi-generation/pull/4308)

## Terraform
- [Pin the generated provider Go directive to 1.25.10](https://github.com/speakeasy-api/openapi-generation/pull/4304)