### PR TITLE
feat(python): add with_raw_response and with_streaming_response helpers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.892.5
+	github.com/speakeasy-api/openapi-generation/v2 v2.893.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.892.5 h1:Q4e7SWpMrGcZ4MzzA0B1jJHuNvWEW+qbus0qSblGhn8=
-github.com/speakeasy-api/openapi-generation/v2 v2.892.5/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.893.0 h1:PMXiosGXNdGYAqbGwzxtrsf/Dl0MrXoPpjxvITlP1+E=
+github.com/speakeasy-api/openapi-generation/v2 v2.893.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Python
- [Add opt-in `with_raw_response` and `with_streaming_response` helpers for Python SDK resources, exposing raw `httpx.Response` metadata, `request_id`, body readers, iterators, `.parse()`, close methods, and context manager protocols (sync + async streaming variants). Enable via `python.rawResponseHelpers` config.](https://github.com/speakeasy-api/openapi-generation/pull/4316)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds opt-in helpers to the Python SDK for accessing raw and streaming responses, and updates the generator to include them.

- **New Features**
  - Add `with_raw_response` and `with_streaming_response` on resources to expose raw `httpx.Response`, `request_id`, body readers/iterators, `.parse()`, `close()`, and context manager support (sync + async).
  - Enable via `python.rawResponseHelpers`.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` to `v2.893.0`.

<sup>Written for commit b345dfb898e72ea56164775c5ecef6dbbf4884d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

