### PR TITLE
chore(mcp): hide mcp deploy command

### DIFF
--- a/cmd/mcp/deploy.go
+++ b/cmd/mcp/deploy.go
@@ -26,6 +26,7 @@ var deployCmd = &model.ExecutableCommand[DeployFlags]{
 	Run:          deployExec,
 	RequiresAuth: false,
 	Experimental: true,
+	Hidden:       true,
 	Flags: []flag.Flag{
 		flag.StringFlag{
 			Name:        "target",

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -7,8 +7,6 @@ import (
 
 const mcpLong = `# MCP
 The ` + "`mcp`" + ` command provides utilities for managing MCP (Model Context Protocol) servers.
-
-Use these commands to manage your generated MCP servers.
 `
 
 var MCPCmd = &model.CommandGroup{

--- a/cmd/mcp/mcp.go
+++ b/cmd/mcp/mcp.go
@@ -8,10 +8,7 @@ import (
 const mcpLong = `# MCP
 The ` + "`mcp`" + ` command provides utilities for managing MCP (Model Context Protocol) servers.
 
-Commands:
-- ` + "`deploy`" + ` - Deploy an MCP server to Gram
-
-Use these commands to deploy and manage your generated MCP servers.
+Use these commands to manage your generated MCP servers.
 `
 
 var MCPCmd = &model.CommandGroup{
@@ -20,4 +17,5 @@ var MCPCmd = &model.CommandGroup{
 	Long:           utils.RenderMarkdown(mcpLong),
 	InteractiveMsg: "What do you want to do?",
 	Commands:       []model.Command{deployCmd},
+	Hidden:         true,
 }


### PR DESCRIPTION
## Summary
- Mark the `mcp` command group and its `deploy` subcommand as `Hidden` so they no longer appear in help output, the command tree, or shell completion
- Remove the `deploy` reference from the `mcp` group's long help text
- Code is left intact and still runs if invoked directly — this only makes the command unfindable

## Test plan
- [x] `go build ./cmd/...` passes
- [ ] `speakeasy --help` no longer lists `mcp`
- [ ] `speakeasy mcp --help` no longer lists `deploy`
- [ ] `speakeasy mcp deploy ...` still executes when invoked directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide the `mcp` command group and its `deploy` subcommand from help, the command tree, and shell completion. Cleaned up the `mcp` long help by removing the commands list and "use these commands" blurb; both commands still run if invoked directly.

<sup>Written for commit cfcab63cc092d67d353b0ef222ff5e89428a88c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

