### PR TITLE
feat(run): support --parallel with specific targets

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -443,14 +443,16 @@ func resolveParallelTargets(target string, allTargets []string) ([]string, error
 	}
 
 	var targets []string
+	seen := make(map[string]bool)
 	for _, t := range strings.Split(target, ",") {
 		t = strings.TrimSpace(t)
-		if t == "" {
+		if t == "" || seen[t] {
 			continue
 		}
 		if !slices.Contains(allTargets, t) {
 			return nil, fmt.Errorf("target %q is not defined in the workflow", t)
 		}
+		seen[t] = true
 		targets = append(targets, t)
 	}
 	return targets, nil

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,7 +83,7 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 		flag.StringFlag{
 			Name:        "target",
 			Shorthand:   "t",
-			Description: "target to run. specify 'all' to run all targets, or a comma-separated list (e.g. 'python,typescript') to run a specific subset with --parallel",
+			Description: "target ID to run (as defined under 'targets' in workflow.yaml). specify 'all' to run all targets, or a comma-separated list of target IDs (e.g. 'my-first-target,my-second-target') to run a specific subset with --parallel",
 		},
 		flag.StringFlag{
 			Name:        "source",

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -83,7 +83,7 @@ var runCmd = &model.ExecutableCommand[RunFlags]{
 		flag.StringFlag{
 			Name:        "target",
 			Shorthand:   "t",
-			Description: "target to run. specify 'all' to run all targets",
+			Description: "target to run. specify 'all' to run all targets, or a comma-separated list (e.g. 'python,typescript') to run a specific subset with --parallel",
 		},
 		flag.StringFlag{
 			Name:        "source",
@@ -434,17 +434,47 @@ var minimalOpts = []run.Opt{
 	run.WithSkipGenerateLintReport(),
 }
 
-func runParallel(ctx context.Context, flags RunFlags) error {
+// resolveParallelTargets returns the set of targets to run in parallel. When no
+// target (or "all") is specified it returns every target in the workflow;
+// otherwise it returns the comma-separated subset, validating each exists.
+func resolveParallelTargets(target string, allTargets []string) ([]string, error) {
+	if target == "" || target == "all" {
+		return allTargets, nil
+	}
+
+	var targets []string
+	for _, t := range strings.Split(target, ",") {
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if !slices.Contains(allTargets, t) {
+			return nil, fmt.Errorf("target %q is not defined in the workflow", t)
+		}
+		targets = append(targets, t)
+	}
+	return targets, nil
+}
+
+// runParallel runs the requested targets concurrently as subprocesses. It
+// reports whether it actually ran in parallel; when only a single target is
+// resolved it returns (false, nil) so the caller falls back to serial execution.
+func runParallel(ctx context.Context, flags RunFlags) (bool, error) {
 	logger := log.From(ctx)
 
-	_, targets, err := run.ParseSourcesAndTargets()
+	_, allTargets, err := run.ParseSourcesAndTargets()
 	if err != nil {
-		return err
+		return false, err
+	}
+
+	targets, err := resolveParallelTargets(flags.Target, allTargets)
+	if err != nil {
+		return false, err
 	}
 
 	if len(targets) <= 1 {
-		logger.Infof("Only one target found, falling back to serial execution")
-		return nil // caller will continue with normal serial path
+		logger.Infof("Only one target to run, falling back to serial execution")
+		return false, nil // caller will continue with normal serial path
 	}
 
 	logger.Infof("Running %d targets in parallel...\n", len(targets))
@@ -517,10 +547,10 @@ func runParallel(ctx context.Context, flags RunFlags) error {
 	}
 
 	if len(errs) > 0 {
-		return fmt.Errorf("%d of %d targets failed: %w", len(errs), len(results), stdErrors.Join(errs...))
+		return true, fmt.Errorf("%d of %d targets failed: %w", len(errs), len(results), stdErrors.Join(errs...))
 	}
 
-	return nil
+	return true, nil
 }
 
 func runNonInteractive(ctx context.Context, flags RunFlags) error {
@@ -531,15 +561,15 @@ func runNonInteractive(ctx context.Context, flags RunFlags) error {
 		return run.RunGitHub(ctx, flags.Target, flags.SetVersion, flags.Force)
 	}
 
-	if flags.Parallel && (flags.Target == "all" || flags.Target == "") {
-		if err := runParallel(ctx, flags); err != nil {
+	if flags.Parallel {
+		ran, err := runParallel(ctx, flags)
+		if err != nil {
 			return err
 		}
-		// runParallel returns nil without error when there's only 1 target (fallback to serial)
-		// but if it ran successfully with multiple targets, we're done
-		if _, targets, _ := run.ParseSourcesAndTargets(); len(targets) > 1 {
+		if ran {
 			return nil
 		}
+		// only a single target resolved: fall through to serial execution
 	}
 
 	opts := []run.Opt{
@@ -608,13 +638,15 @@ func runInteractive(ctx context.Context, flags RunFlags) error {
 		return run.RunDependent(ctx, flags.Source, flags.Dependent, stringifyFlags(flags, []string{"dependent", "source"}))
 	}
 
-	if flags.Parallel && (flags.Target == "all" || flags.Target == "") {
-		if err := runParallel(ctx, flags); err != nil {
+	if flags.Parallel {
+		ran, err := runParallel(ctx, flags)
+		if err != nil {
 			return err
 		}
-		if _, targets, _ := run.ParseSourcesAndTargets(); len(targets) > 1 {
+		if ran {
 			return nil
 		}
+		// only a single target resolved: fall through to serial execution
 	}
 
 	opts := []run.Opt{

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -44,6 +44,11 @@ func TestResolveParallelTargets(t *testing.T) {
 			want:   []string{"python-genai", "typescript-genai"},
 		},
 		{
+			name:   "deduplicates repeated targets",
+			target: "python-genai,python-genai,typescript-genai",
+			want:   []string{"python-genai", "typescript-genai"},
+		},
+		{
 			name:    "unknown target errors",
 			target:  "python-genai,ruby-genai",
 			wantErr: `target "ruby-genai" is not defined in the workflow`,

--- a/cmd/run_test.go
+++ b/cmd/run_test.go
@@ -1,0 +1,66 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestResolveParallelTargets(t *testing.T) {
+	t.Parallel()
+
+	allTargets := []string{"python-genai", "typescript-genai", "go-genai"}
+
+	tests := []struct {
+		name    string
+		target  string
+		want    []string
+		wantErr string
+	}{
+		{
+			name:   "empty runs all targets",
+			target: "",
+			want:   allTargets,
+		},
+		{
+			name:   "all runs all targets",
+			target: "all",
+			want:   allTargets,
+		},
+		{
+			name:   "single target",
+			target: "python-genai",
+			want:   []string{"python-genai"},
+		},
+		{
+			name:   "comma-separated subset",
+			target: "python-genai,typescript-genai",
+			want:   []string{"python-genai", "typescript-genai"},
+		},
+		{
+			name:   "trims whitespace and skips empties",
+			target: " python-genai , , typescript-genai ",
+			want:   []string{"python-genai", "typescript-genai"},
+		},
+		{
+			name:    "unknown target errors",
+			target:  "python-genai,ruby-genai",
+			wantErr: `target "ruby-genai" is not defined in the workflow`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveParallelTargets(tt.target, allTargets)
+			if tt.wantErr != "" {
+				require.EqualError(t, err, tt.wantErr)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/integration/run_parallel_test.go
+++ b/integration/run_parallel_test.go
@@ -1,0 +1,111 @@
+package integration_tests
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/speakeasy-api/sdk-gen-config/workflow"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRunParallelSpecificTargets verifies that `speakeasy run --parallel -t a,b`
+// runs only the requested subset of targets in parallel, leaving other targets
+// in the workflow untouched.
+func TestRunParallelSpecificTargets(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	temp := t.TempDir()
+
+	require.NoError(t, copyFile("resources/multi_root.yaml", filepath.Join(temp, "multi_root.yaml")))
+	require.NoError(t, copyFile("resources/multi_components.yaml", filepath.Join(temp, "multi_components.yaml")))
+
+	// Three typescript targets, each writing to its own output directory.
+	workflowFile := &workflow.Workflow{
+		Version: workflow.WorkflowVersion,
+		Sources: map[string]workflow.Source{
+			"src": {
+				Inputs: []workflow.Document{
+					{Location: workflow.LocationString("multi_root.yaml")},
+				},
+			},
+		},
+		Targets: map[string]workflow.Target{
+			"ts-a": {Target: "typescript", Source: "src", Output: stringPtr("ts-a")},
+			"ts-b": {Target: "typescript", Source: "src", Output: stringPtr("ts-b")},
+			"ts-c": {Target: "typescript", Source: "src", Output: stringPtr("ts-c")},
+		},
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755))
+	require.NoError(t, workflow.Save(temp, workflowFile))
+
+	genYaml := func(pkg string) string {
+		return `configVersion: 2.0.0
+generation:
+  sdkClassName: SDK
+typescript:
+  version: 0.0.1
+  packageName: ` + pkg + `
+`
+	}
+	for dir, pkg := range map[string]string{"ts-a": "pkga", "ts-b": "pkgb", "ts-c": "pkgc"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(temp, dir), 0o755))
+		require.NoError(t, os.WriteFile(filepath.Join(temp, dir, "gen.yaml"), []byte(genYaml(pkg)), 0o644))
+	}
+
+	gitInit(t, temp)
+
+	// Run only the ts-a and ts-b subset in parallel; ts-c is intentionally excluded.
+	args := []string{"run", "--parallel", "-t", "ts-a,ts-b", "--pinned", "--force", "--skip-versioning", "--skip-compile"}
+	require.NoError(t, execute(t, temp, args...).Run())
+
+	// The two requested targets were generated.
+	checkForExpectedFiles(t, filepath.Join(temp, "ts-a"), expectedFilesByLanguage("typescript"))
+	checkForExpectedFiles(t, filepath.Join(temp, "ts-b"), expectedFilesByLanguage("typescript"))
+
+	// The excluded target was not generated (only the gen.yaml we wrote is present).
+	require.NoFileExists(t, filepath.Join(temp, "ts-c", "package.json"))
+	require.NoFileExists(t, filepath.Join(temp, "ts-c", "README.md"))
+}
+
+// TestRunParallelUnknownTarget verifies that requesting a target that does not
+// exist in the workflow fails fast with a clear error.
+func TestRunParallelUnknownTarget(t *testing.T) {
+	t.Parallel()
+
+	if runtime.GOOS == "windows" {
+		t.Skip("Skipping test on Windows")
+	}
+
+	temp := t.TempDir()
+
+	require.NoError(t, copyFile("resources/multi_root.yaml", filepath.Join(temp, "multi_root.yaml")))
+	require.NoError(t, copyFile("resources/multi_components.yaml", filepath.Join(temp, "multi_components.yaml")))
+
+	workflowFile := &workflow.Workflow{
+		Version: workflow.WorkflowVersion,
+		Sources: map[string]workflow.Source{
+			"src": {
+				Inputs: []workflow.Document{
+					{Location: workflow.LocationString("multi_root.yaml")},
+				},
+			},
+		},
+		Targets: map[string]workflow.Target{
+			"ts-a": {Target: "typescript", Source: "src", Output: stringPtr("ts-a")},
+			"ts-b": {Target: "typescript", Source: "src", Output: stringPtr("ts-b")},
+		},
+	}
+	require.NoError(t, os.MkdirAll(filepath.Join(temp, ".speakeasy"), 0o755))
+	require.NoError(t, workflow.Save(temp, workflowFile))
+
+	gitInit(t, temp)
+
+	args := []string{"run", "--parallel", "-t", "ts-a,ts-nope", "--pinned", "--skip-compile"}
+	require.Error(t, execute(t, temp, args...).Run())
+}


### PR DESCRIPTION
## Summary
- `speakeasy run --parallel -t a,b` now runs a comma-separated **subset** of targets in parallel, instead of `--parallel` only working for all/empty targets.
- Resolves [GEN-3079](https://linear.app/speakeasy/issue/GEN-3079/feat-support-parallel-with-specific-targets) 

## How it works
- New `resolveParallelTargets` parses the `-t` value: empty/`all` → every workflow target; otherwise the comma-separated subset, validating each exists (fails fast on unknown targets).
- `runParallel` now returns `(ran bool, err error)`; when only one target resolves it returns `false` so the caller cleanly falls back to serial execution.
- Both the non-interactive and interactive call sites are gated on `flags.Parallel` alone, replacing the old `all`-or-empty condition and the fragile re-parse afterward.
- Each target still runs as an isolated `speakeasy run --target=<tid>` subprocess, so the core workflow logic is untouched.

### Syntax note
The Linear ticket showed `-t python-genai typescript-genai` (space-separated). pflag treats the trailing token as a positional arg, and the command framework discards positional args — supporting that literally would require plumbing args through every command. Comma-separated (`-t a,b`) delivers the same outcome with a contained change; the flag help documents it.

## Test plan
- [x] `go build ./cmd/...` and `go vet ./cmd/ ./integration/` clean
- [x] Unit: `TestResolveParallelTargets` (empty/all/single/subset/whitespace/unknown)
- [x] E2e `TestRunParallelSpecificTargets`: 3-target workflow, `--parallel -t ts-a,ts-b` generates ts-a + ts-b, leaves ts-c ungenerated
- [x] E2e `TestRunParallelUnknownTarget`: unknown target fails fast
- [x] Existing `TestMultiFileStability` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for running a specific subset of targets in parallel with `speakeasy run --parallel -t a,b`. Resolves Linear GEN-3079 and clarifies that `-t` uses target IDs from `workflow.yaml`, not language names.

- **New Features**
  - `-t` accepts a comma-separated list; trims whitespace and deduplicates repeats; empty or `all` runs every target. Space-separated lists are not supported due to `pflag`.
  - Validates target IDs from `workflow.yaml` and fails fast on unknown names; flag help updated with examples.
  - Falls back to serial execution when only one target resolves.
  - Works in both interactive and non-interactive flows; core workflow remains unchanged.

<sup>Written for commit c361e0c3f7dadbf673775095479e509cb82c16d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

