### PR TITLE
chore: update agent mode content

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/speakeasy-api/openapi v1.23.0
 	github.com/speakeasy-api/openapi-generation/v2 v2.893.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
-	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9
+	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
 	github.com/speakeasy-api/speakeasy-core v0.22.1
 	github.com/speakeasy-api/versioning-reports v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-2026020602382
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=
 github.com/speakeasy-api/sdk-gen-config v1.57.1/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
-github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9 h1:thIFxdIZixrj1TFfTx5Pw5d1Ndq4l0TG4K34DZKvWNI=
-github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
+github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11 h1:p3FdoHJVHe8N7xLmxVytzZWfybgKvFiPmZP4M/a4ze8=
+github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7 h1:SoWZkRlpFlv8qibCfXWrBZay1JeLS9uqJ+1cu+DFgXo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
 github.com/speakeasy-api/speakeasy-core v0.22.1 h1:qGKlVk/37fATCbmPMNFjA7HxFV8ERA/E2ly9Z+IUn3Q=


### PR DESCRIPTION
## Summary
- update github.com/speakeasy-api/speakeasy-agent-mode-content from v0.2.9 to v0.2.10
- pulls in the new SDK compatibility agent-context guide

## Validation
- go mod tidy
- git diff --check
- go test ./cmd/...

Note: local `go test ./...` was not usable because this checkout contains ignored generated `integrationTests/env*` fixture directories that import `testsdk/...` packages outside a clean checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `github.com/speakeasy-api/speakeasy-agent-mode-content` to v0.2.11 to pull the latest agent-mode docs, including the SDK compatibility agent-context guide. No functional changes to our code.

- **Dependencies**
  - Bump `github.com/speakeasy-api/speakeasy-agent-mode-content` from v0.2.9 to v0.2.11.

<sup>Written for commit d0d51bcc3edad81db736d3f987892847ea184bc1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2066?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

