### PR TITLE
feat(java): Spring Boot 3.5.14 (CVE-2022-1471); fix(python,typescript,terraform,php): SSE/retry/pagination/serialize fixes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.893.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.894.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.893.0 h1:PMXiosGXNdGYAqbGwzxtrsf/Dl0MrXoPpjxvITlP1+E=
-github.com/speakeasy-api/openapi-generation/v2 v2.893.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.894.0 h1:G/tkRYrGyo4A1FE/CqA7fxxfHh3J0LvhxcBxnXPhgaM=
+github.com/speakeasy-api/openapi-generation/v2 v2.894.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades `openapi-generation` to `v2.894.0`.

## Java
- [Bump Spring Boot starter from 2.7.18 to 3.5.14, resolving CVE-2022-1471 (snakeyaml). Spring Boot starter now requires Java 17+.](https://github.com/speakeasy-api/openapi-generation/pull/4267)

## Python
- [Close SSE response on all stream-termination paths.](https://github.com/speakeasy-api/openapi-generation/pull/4328)
- [Sync usage snippet code block formatting.](https://github.com/speakeasy-api/openapi-generation/pull/4325)

## TypeScript
- [Build a per-attempt AbortSignal so retries survive `timeoutMs`.](https://github.com/speakeasy-api/openapi-generation/pull/4256)
- [Allow assignable open-enum fallback.](https://github.com/speakeasy-api/openapi-generation/pull/4323)

## Terraform
- [Guard against nil response in the data-source pagination loop.](https://github.com/speakeasy-api/openapi-generation/pull/4327)

## PHP
- [Guard the union serialize path against empty arrays and discriminators.](https://github.com/speakeasy-api/openapi-generation/pull/4312)

---
> **Note:** This dependency line was briefly broken by an erroneous `v3.0.0`–`v3.0.7` major bump (a "Breaking change" phrase in #4267 tripped a conventional-commits major while the module path stayed `/v2`, making those tags invalid Go versions). The v3 tags were deleted and the changes re-released as `v2.894.0`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded `github.com/speakeasy-api/openapi-generation/v2` to v2.894.0. This brings Spring Boot 3.5.14 (fixes CVE-2022-1471) and reliability fixes for Python, TypeScript, Terraform, and PHP SDKs.

- **Bug Fixes**
  - Python: Close SSE responses on all stream-termination paths.
  - TypeScript: Use per-attempt AbortSignal so retries survive `timeoutMs`; allow assignable open-enum fallback.
  - Terraform: Guard against nil response in the data-source pagination loop.
  - PHP: Guard union serialization against empty arrays and missing discriminators.

- **Migration**
  - Java SDKs now require Java 17+ due to the Spring Boot 3.5.x upgrade.

<sup>Written for commit 206099fb5cde5d8056815b8cc2f7771ffdc39706. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

