### PR TITLE
feat(python): relative imports, SSE stream config; fix(python,typescript,terraform,php,java) various fixes incl. CVE-2022-1471

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.893.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.896.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.9
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
@@ -225,7 +225,7 @@ require (
 	github.com/skeema/knownhosts v1.3.1 // indirect
 	github.com/sourcegraph/conc v0.3.0 // indirect
 	github.com/sourcegraph/jsonrpc2 v0.2.0 // indirect
-	github.com/speakeasy-api/easytemplate v0.12.3 // indirect
+	github.com/speakeasy-api/easytemplate v0.12.4 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.3 // indirect
 	github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 // indirect
 	github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd // indirect

--- a/go.sum
+++ b/go.sum
@@ -528,8 +528,8 @@ github.com/sourcegraph/conc v0.3.0 h1:OQTbbt6P72L20UqAkXXuLOj79LfEanQ+YQFNpLA9yS
 github.com/sourcegraph/conc v0.3.0/go.mod h1:Sdozi7LEKbFPqYX2/J+iBAM6HpqSLTASQIKqDmF7Mt0=
 github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzzSrr/U=
 github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
-github.com/speakeasy-api/easytemplate v0.12.3 h1:+loYwiWeQntciHop/RHLU5HrlZQ7iM0tGg1PbDndxcA=
-github.com/speakeasy-api/easytemplate v0.12.3/go.mod h1:UF8bFhTpyr1sHiEWacT7ULN67Bve6UIrTH7uvzdbTEY=
+github.com/speakeasy-api/easytemplate v0.12.4 h1:0xEm93tqPfdIWKUwgxvFgDLBmSDXlCImp+mQF3XZcOg=
+github.com/speakeasy-api/easytemplate v0.12.4/go.mod h1:UF8bFhTpyr1sHiEWacT7ULN67Bve6UIrTH7uvzdbTEY=
 github.com/speakeasy-api/git-diff-parser v0.2.0 h1:fvPsWhTqTt+8j9Kx4eXF6kRRqDUC60gy0VII4PnjIHA=
 github.com/speakeasy-api/git-diff-parser v0.2.0/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
 github.com/speakeasy-api/goja v0.0.0-20260223084236-ed0328a0a462 h1:wFAq/dFgXzPkOpI36BkHdUl4rKi7qh6iMsvlRkh2fCs=
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.893.0 h1:PMXiosGXNdGYAqbGwzxtrsf/Dl0MrXoPpjxvITlP1+E=
-github.com/speakeasy-api/openapi-generation/v2 v2.893.0/go.mod h1:CSR2tU9I8ICigixqL9cAo6ToIyojIGc51ZeIi3YtIh4=
+github.com/speakeasy-api/openapi-generation/v2 v2.896.0 h1:0imV6EmvQPjL4oJ4u9k9zByP5hBYnnUAiVZnL3FXE28=
+github.com/speakeasy-api/openapi-generation/v2 v2.896.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Python
- [feat: add support for relative import paths (`imports.relative: true`)](https://github.com/speakeasy-api/openapi-generation/pull/4330)
- [feat: configure SSE stream type surface — generated `Stream[...]` / `AsyncStream[...]` signatures and `close()` helpers](https://github.com/speakeasy-api/openapi-generation/pull/4306)
- [fix: close SSE response on all stream-termination paths (prevents connection-pool exhaustion under load)](https://github.com/speakeasy-api/openapi-generation/pull/4328)
- [fix: sync/async split-mode usage snippet code-block formatting](https://github.com/speakeasy-api/openapi-generation/pull/4325)

## TypeScript
- [fix: allow assignable open enum fallback via new `openEnumUnknownValues` option](https://github.com/speakeasy-api/openapi-generation/pull/4323)
- [fix: build per-attempt AbortSignal so retries survive `timeoutMs`](https://github.com/speakeasy-api/openapi-generation/pull/4256)

## Terraform
- [fix: guard against nil response in data source pagination loop (prevents provider panic)](https://github.com/speakeasy-api/openapi-generation/pull/4327)

## PHP
- [fix: guard union serialize path against empty arrays and discriminated unions (resolves `TypeError` in `UnionHandler::serializeUnion`)](https://github.com/speakeasy-api/openapi-generation/pull/4312)

## Java
- [fix: bump Spring Boot starter from 2.7.18 to 3.5.14 (CVE-2022-1471). Breaking for `generateSpringBootStarter: true` with `languageVersion < 17`](https://github.com/speakeasy-api/openapi-generation/pull/4267)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Python support for relative imports and a configurable SSE stream surface with typed `Stream[...]`/`AsyncStream[...]` and `close()` helpers. Includes fixes across TypeScript, Terraform, PHP, and Java, including a Spring Boot starter bump to 3.5.14 to address CVE-2022-1471 (breaking for generated starters on Java <17).

- **New Features**
  - Python: Optional relative imports via `imports.relative: true`.
  - Python: Configurable SSE stream types; generated `Stream[...]`/`AsyncStream[...]` signatures and `close()` helpers.

- **Bug Fixes**
  - Python: Ensure SSE responses close on all termination paths; fix sync/async split-mode snippet formatting.
  - TypeScript: Support assignable open-enum fallback via `openEnumUnknownValues`; build per-attempt `AbortSignal` so retries survive `timeoutMs`.
  - Terraform: Guard nil response in data-source pagination to prevent provider panic.
  - PHP: Handle empty arrays and discriminated unions in union serialization to avoid `TypeError`.
  - Java: Upgrade Spring Boot starter 2.7.18 -> 3.5.14 (CVE-2022-1471). Breaking when `generateSpringBootStarter: true` with `languageVersion < 17` (requires Java 17+).

<sup>Written for commit e49824bc2f0254389591ba9ef8c6aa61ad137e33. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

