### PR TITLE
feat(python,typescript): public exports surface; feat(typescript): params-object methods; fix(python): root lazy-load models

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.899.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.900.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.899.1 h1:/72wJXz+aQzBr97GWEE2z1j72ubmN6YuVIo151bTaMg=
-github.com/speakeasy-api/openapi-generation/v2 v2.899.1/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.900.0 h1:b5lHt2ykHxo9/BSemJiaJH4RVa8x9ppiblFxXeblXtM=
+github.com/speakeasy-api/openapi-generation/v2 v2.900.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Python
- [feat: `x-speakeasy-exports` public type surface — explicit aliases plus opt-in namespace auto-export via `imports.paths.resources`, supports `representation: input` for TypedDict companions](https://github.com/speakeasy-api/openapi-generation/pull/4339)
- [fix: lazy-load models in root `__init__.py` via `__getattr__` delegation — restores lazy import benefit for large SDKs (e.g. Polar: 2,264 symbols, 756 modules)](https://github.com/speakeasy-api/openapi-generation/pull/4273)

## TypeScript
- [feat: `x-speakeasy-exports` public type surface — flat aliases plus per-group `export declare namespace`, including operation request-type aliases (Stainless-style `<Op>Params`)](https://github.com/speakeasy-api/openapi-generation/pull/4339)
- [feat: `methodSignature: params-object` — SDK methods gather non-path arguments into generated `<Op>Params` objects with `NonStreaming`/`Streaming` overloads for SSE](https://github.com/speakeasy-api/openapi-generation/pull/4339)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/speakeasy-api/openapi-generation/v2` to v2.900.0 to add a clear public exports surface for Python/TypeScript, TypeScript params-object method signatures, and to restore Python root model lazy-loading.

- New Features
  - Python: `x-speakeasy-exports` with explicit aliases and optional namespace auto-exports via `imports.paths.resources`; supports `representation: input` for TypedDict companions.
  - TypeScript: `x-speakeasy-exports` with flat aliases and per-group `export declare namespace`, plus `<Op>Params` request-type aliases.
  - TypeScript: `methodSignature: params-object` groups non-path args into generated `<Op>Params`, with `NonStreaming`/`Streaming` overloads for SSE.

- Bug Fixes
  - Python: Lazy-load models in root `__init__.py` via `__getattr__` to reduce import overhead in large SDKs.

<sup>Written for commit cc82eccb5e6e1d81850cc27cc54e45c76bb5f4b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2073?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

