### PR TITLE
feat(typescript): opt-in requestExtras with extraQuery/extraBody; fix(typescript): deterministic query precedence and SSE detection import side-effect

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.900.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.901.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.900.0 h1:b5lHt2ykHxo9/BSemJiaJH4RVa8x9ppiblFxXeblXtM=
-github.com/speakeasy-api/openapi-generation/v2 v2.900.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.901.0 h1:825QF8gQtxUH4fsF21FQMIGG7XwArE4o9JnW4gU5Zl8=
+github.com/speakeasy-api/openapi-generation/v2 v2.901.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## TypeScript
- [feat: opt-in `typescript.requestExtras` config exposes `extraQuery` and `extraBody` on SDK method `RequestOptions` (mirrors Python's `extra_query`/`extra_body`). Default off.](https://github.com/speakeasy-api/openapi-generation/pull/4341)
- [fix: query merging preserves server URL query params and applies deterministic precedence (server URL → operation params → security), replacing duplicate keys instead of sending both. Applies to all typescriptv2 SDKs.](https://github.com/speakeasy-api/openapi-generation/pull/4341)
- [fix: params-object SSE detection is now side-effect free, removing a nondeterministic unused `import * as operations` in unrelated SDK class files that broke compilation under `noUnusedLocals` (TS6133).](https://github.com/speakeasy-api/openapi-generation/pull/4343)