### PR TITLE
feat(core): documentation:none option to disable docs generation; fix(core): warn on lost forward-compat union fallback; fix(python): base64 stream position restore, BytesIO multipart uploads; fix(typescript): mcp APIPromise unhandled rejection

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.903.5
+	github.com/speakeasy-api/openapi-generation/v2 v2.904.2
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.903.5 h1:Sdisc1vta5PdpNspL0WMPtH+yer+bYoMSqzqmBMPj64=
-github.com/speakeasy-api/openapi-generation/v2 v2.903.5/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.904.2 h1:evV0w93x2xHxHXImrN9GpK+zu24doTSBmRBvgwflQJg=
+github.com/speakeasy-api/openapi-generation/v2 v2.904.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades openapi-generation v2.903.5 → v2.904.2.

## Core
- [Add `generation.documentation: none` gen.yaml option to disable per-operation docs generation; stale docs from previous runs are cleaned up automatically](https://github.com/speakeasy-api/openapi-generation/pull/4353)
- [Warn during generation when a response union silently loses its forward-compat Unknown fallback because no single discriminator property can be inferred](https://github.com/speakeasy-api/openapi-generation/pull/4352)

## Python
- [Fix base64 file inputs draining seekable streams on repeated union validation, which could silently send empty file content; stream position is now restored after each read](https://github.com/speakeasy-api/openapi-generation/pull/4354)
- [Accept `io.BytesIO`, `io.StringIO`, and text-mode file handles for multipart file uploads; previously only `open(..., 'rb')` handles worked](https://github.com/speakeasy-api/openapi-generation/pull/4336)

## TypeScript
- [Fix `APIPromise` in MCP SDKs leaking an unhandled rejection when a request fails and the caller has already caught the error](https://github.com/speakeasy-api/openapi-generation/pull/4346)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade `github.com/speakeasy-api/openapi-generation/v2` to v2.904.2 to add a docs-off switch and harden generation/runtime behavior. Improves union safety, fixes Python stream handling, and stops a TypeScript MCP unhandled rejection.

- **New Features**
  - Add `generation.documentation: none` to disable per-operation docs; cleans up stale docs automatically.
  - Warn when a response union would lose its forward-compatible Unknown fallback if no single discriminator can be inferred.

- **Bug Fixes**
  - Python: Restore stream position after base64 reads; accept `io.BytesIO`, `io.StringIO`, and text-mode file handles for multipart uploads.
  - TypeScript: Prevent unhandled rejection in MCP SDK `APIPromise` when callers already handle request errors.

<sup>Written for commit ce7a30d2afc0ac6d52efbc4a00f00d1f3d3a265c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2079?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

