### PR TITLE
feat(all): support attempt-count retries; fix(csharp): throw on serializing body-less discriminated union

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.904.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.905.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.904.2 h1:evV0w93x2xHxHXImrN9GpK+zu24doTSBmRBvgwflQJg=
-github.com/speakeasy-api/openapi-generation/v2 v2.904.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.905.0 h1:67CIdyLgf6Y0XtEV7DSD3mVgmjcS9+XjWVB1yfpqkas=
+github.com/speakeasy-api/openapi-generation/v2 v2.905.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Python
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)

## TypeScript
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)

## Go
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)

## Java
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)

## C#
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)
- [Fix discriminated `oneOf` unions silently serializing a required field to `null` when built without a variant body; serialization now throws instead](https://github.com/speakeasy-api/openapi-generation/pull/4320)

## PHP
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)

## Ruby
- [Support attempt-count retries — express retry budgets as a retry count (`maxRetries`) rather than only elapsed time](https://github.com/speakeasy-api/openapi-generation/pull/4293)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds attempt-count retry support via `maxRetries` across generated SDKs and fixes a C# discriminated union serialization issue. Updates `github.com/speakeasy-api/openapi-generation/v2` to v2.905.0.

- **New Features**
  - Retries can be capped by attempt count using `maxRetries` (in addition to time-based budgets).

- **Bug Fixes**
  - C#: serializing a discriminated `oneOf` without a variant body now throws instead of writing a required field as `null`.

<sup>Written for commit efff7fee02cec0fc91cb03ec9524a18631392a18. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

