### PR TITLE
chore: update speakeasy-agent-mode-content to v0.2.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -48,7 +48,7 @@ require (
 	github.com/speakeasy-api/openapi v1.23.0
 	github.com/speakeasy-api/openapi-generation/v2 v2.905.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
-	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11
+	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
 	github.com/speakeasy-api/speakeasy-core v0.22.1
 	github.com/speakeasy-api/versioning-reports v0.6.1

--- a/go.sum
+++ b/go.sum
@@ -554,8 +554,8 @@ github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-2026020602382
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=
 github.com/speakeasy-api/sdk-gen-config v1.57.1/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
-github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11 h1:p3FdoHJVHe8N7xLmxVytzZWfybgKvFiPmZP4M/a4ze8=
-github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.11/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
+github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12 h1:dGONbW8WLNc4uSox1/k8O4JFggHoQy1v6R9cLqbTf5M=
+github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7 h1:SoWZkRlpFlv8qibCfXWrBZay1JeLS9uqJ+1cu+DFgXo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
 github.com/speakeasy-api/speakeasy-core v0.22.1 h1:qGKlVk/37fATCbmPMNFjA7HxFV8ERA/E2ly9Z+IUn3Q=


### PR DESCRIPTION
## Summary
- Update `github.com/speakeasy-api/speakeasy-agent-mode-content` from `v0.2.11` to `v0.2.12`
- Picks up agent context documentation for the new `attempt-count-backoff` retry strategy and `maxRetries` semantics

## Context
- Source PR: https://github.com/speakeasy-api/speakeasy-agent-mode-content/pull/13
- Released version: https://github.com/speakeasy-api/speakeasy-agent-mode-content/releases/tag/v0.2.12
- The automated downstream update step in the agent-context release workflow failed while fetching private modules over HTTPS, so this PR applies the same `go get` update manually.

## Testing
- `go build . ./cmd/... ./internal/... ./pkg/... ./integration/...`
- `go test . ./cmd/... ./internal/... ./pkg/...`
- `git diff --check -- go.mod go.sum`

Note: local `go test ./...` is not usable in this checkout because ignored generated fixtures under `integrationTests/` are present locally and fail package setup; CI runs from a clean checkout.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated `github.com/speakeasy-api/speakeasy-agent-mode-content` to v0.2.12 to include agent context docs for the `attempt-count-backoff` retry strategy and updated `maxRetries` semantics.

- **Dependencies**
  - Applied a manual `go get` because the agent-context release workflow failed to fetch private modules over HTTPS.

<sup>Written for commit ac4c187ee8dd5aac3e7498f62065a775c18330ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

