### PR TITLE
fix(quickstart): hide unity from --target help text

### DIFF
--- a/prompts/utils.go
+++ b/prompts/utils.go
@@ -88,8 +88,22 @@ func targetOption(target, maturity string) huh.Option[string] {
 	return huh.NewOption(fmt.Sprintf("%s %s", getTargetDisplay(target), getMaturityDisplay(maturity)), target)
 }
 
+// hiddenTargetNames are valid generation targets that are intentionally
+// omitted from user-facing target listings (e.g. the quickstart --target help
+// text, which is published to the docs site). They remain fully supported for
+// generation and validation via generate.GetSupportedTargetNames().
+var hiddenTargetNames = map[string]bool{
+	"unity": true,
+}
+
 func GetSupportedTargetNames() []string {
-	targetNames := generate.GetSupportedTargetNames()
+	var targetNames []string
+	for _, name := range generate.GetSupportedTargetNames() {
+		if hiddenTargetNames[name] {
+			continue
+		}
+		targetNames = append(targetNames, name)
+	}
 
 	slices.Sort(targetNames)
 


### PR DESCRIPTION
## Problem

PRs keep getting opened against the marketing site re-adding `unity` to the `speakeasy quickstart` `--target` docs (e.g. [marketing-site#1720](https://github.com/speakeasy-api/marketing-site/pull/1720)).

The CLI reference docs are regenerated by walking the cobra command tree (`cmd/docs`). The `quickstart --target` help text is built from `prompts.GetSupportedTargetNames()`, which returns the full upstream target list — including `unity`. So every regen re-adds `unity` to `quickstart.md`.

## Fix

Filter `unity` out of `prompts.GetSupportedTargetNames()`, which is **display-only** — it's used in exactly one place, the `quickstart --target` help string. Generation and validation are unaffected: those paths call `generate.GetSupportedTargetNames()` directly, so `speakeasy quickstart --target unity` still works. The filter uses a `hiddenTargetNames` map so future deprecated-but-supported targets can be hidden the same way.

## Verification

Ran the real `cmd/docs` generator; the regenerated `quickstart.md` line now matches the desired (unity-free) output byte-for-byte:

```
-t, --target string  generation target (available options: [cli, csharp, go, java, mcp-typescript, php, postman, python, ruby, terraform, typescript])
```

`quickstart.md` is the only published doc affected — `run.md`'s `--target` is a target-ID field, and `generate sdk` isn't in the published CLI reference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hide `unity` from the `speakeasy quickstart --target` help text so it no longer shows up in published docs. Display-only change: `prompts.GetSupportedTargetNames()` filters `unity` via a `hiddenTargetNames` map; generation/validation still use `generate.GetSupportedTargetNames()`, so `--target unity` still works.

<sup>Written for commit cede30c37cca14bbea4a7479e3f24e48e354a33c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

