### PR TITLE
fix(python,mcp,typescript): response helpers; zod transforms; npm deps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.911.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.911.3
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.911.0 h1:XR/cG5FW7F+K/PASc6+myqOKonxDvqfixcJiM57JBl8=
-github.com/speakeasy-api/openapi-generation/v2 v2.911.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.911.3 h1:VWMpEUkItDcPzUucy4ZnJK4YAEoyzX3W7yDVo2kTJas=
+github.com/speakeasy-api/openapi-generation/v2 v2.911.3/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
- fix(python): raise error responses eagerly in raw/streaming response helpers
- fix(mcp): dynamic mode describe_tool_input handles Zod transforms
- chore(mcp,typescript):  bump hono, fast-uri and vitest dependencies

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve error handling in Python response helpers and add Zod transform support in MCP dynamic mode. Refresh Go and npm dependencies.

- **Bug Fixes**
  - Python: raw/streaming response helpers now raise on non-2xx responses immediately.
  - MCP: dynamic `describe_tool_input` applies Zod transforms when generating input schemas.

- **Dependencies**
  - npm: bump `hono`, `fast-uri`, `vitest`; refresh transitive deps.
  - Go: bump `github.com/speakeasy-api/openapi-generation/v2` to `v2.911.3`.

<sup>Written for commit 204031ec493b40e22c7deab6548ce643c8c35f3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

