### PR TITLE
feat(python): expose operation tags and x- extensions on HookContext; fix(python): cap pydantic to <2.13; fix(ruby): bump faraday and yard for HIGH advisories; fix(java): bump jackson to clear HIGH advisories

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.912.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.913.2
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.912.1 h1:MyEwsEbdX6xpP6Ki/c/qbfDYFsfildXQrTfg92OH2CQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.912.1/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.913.2 h1:0LkCmnCmLaiTr1vRUv31TbVPyIPCHDt8gfm35kdl7xU=
+github.com/speakeasy-api/openapi-generation/v2 v2.913.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades `openapi-generation` from `v2.912.1` to `v2.913.2`.

## Python
- [Expose OpenAPI operation `tags` and `x-` extensions on `HookContext` so hooks can branch on spec metadata at runtime](https://github.com/speakeasy-api/openapi-generation/pull/4375)
- [Cap the generated SDK's Pydantic constraint to `<2.13` to avoid silent data loss on nullable discriminated-union fields under Pydantic 2.13.x](https://github.com/speakeasy-api/openapi-generation/pull/4388)

## Ruby
- [Bump faraday to `2.14.3` to clear HIGH advisory GHSA-98m9-hrrm-r99r (uncontrolled recursion / DoS)](https://github.com/speakeasy-api/openapi-generation/pull/4382)
- [Upgrade yard to `0.9.42` to address GHSA-3jfp-46x4-xgfj (path traversal)](https://github.com/speakeasy-api/openapi-generation/pull/4380)

## Java
- [Bump jackson-databind to `2.18.8` to clear HIGH advisories GHSA-j3rv-43j4-c7qm and GHSA-rmj7-2vxq-3g9f (PolymorphicTypeValidator bypasses)](https://github.com/speakeasy-api/openapi-generation/pull/4382)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `github.com/speakeasy-api/openapi-generation/v2` to v2.913.2 to expose OpenAPI metadata to Python hooks and ship security fixes in Ruby and Java. Caps Python `pydantic` to <2.13 to prevent data loss in nullable discriminated unions.

- **New Features**
  - Python: `HookContext` now exposes operation `tags` and `x-` extensions for runtime hook branching.

- **Dependencies**
  - Python: cap `pydantic` to <2.13 to avoid silent data loss on nullable discriminated unions.
  - Ruby: bump `faraday` to `2.14.3` and `yard` to `0.9.42` to address HIGH advisories (GHSA-98m9-hrrm-r99r, GHSA-3jfp-46x4-xgfj).
  - Java: bump `jackson-databind` to `2.18.8` to address HIGH advisories (GHSA-j3rv-43j4-c7qm, GHSA-rmj7-2vxq-3g9f).

<sup>Written for commit 40fdbc50dc5502fb553ebb29130d920acc42842a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

