### PR TITLE
feat(csharp): add support for netstandard2.0 target framework

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.913.3
+	github.com/speakeasy-api/openapi-generation/v2 v2.914.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.913.3 h1:m3keVbQ5aK4uV22g1YC1AmYBOFZhk7vgo0xGrioADbg=
-github.com/speakeasy-api/openapi-generation/v2 v2.913.3/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.914.0 h1:xNQrhWZTV7e7/AP59h8Sv5WOvITeFaDdERH4ODnkaL4=
+github.com/speakeasy-api/openapi-generation/v2 v2.914.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
- feat(csharp): adds the ability to generate C# SDKs that target the netstandard2.0 contract via a ne `targetFramework` config option.
- fix(java,php,python,typescript): address moderate dependabot advisories:

| Advisory | Package | Target | Was | Now |
|---|---|---|---|---|
| GHSA-5jmj-h7xm-6q6v | `jackson-databind` | java | `2.18.8` | `2.22.0` |
| GHSA-cwxw-98qj-8qjx | `guzzlehttp/guzzle` | php | `^7.0` | `^7.12.1` |
| GHSA-wpwq-4j6v-78m3 | `guzzlehttp/guzzle` | php | `^7.0` | `^7.12.1` |
| GHSA-6w46-j5rx-g56g | `pytest` | python | `^8.4.1` | `^9.0.3` |
| GHSA-w5hq-g745-h8pq | `uuid` | typescript| `^9.0.1` | `^11.1.1` |

