### PR TITLE
feat(core): conflict-free gen.lock under manual versioning

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.914.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.915.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.914.0 h1:xNQrhWZTV7e7/AP59h8Sv5WOvITeFaDdERH4ODnkaL4=
-github.com/speakeasy-api/openapi-generation/v2 v2.914.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.915.0 h1:5l/jjKi5pDzseVYaBFg/qcrcbT6LiUIYCKGbe2lIuqQ=
+github.com/speakeasy-api/openapi-generation/v2 v2.915.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Core
- [Omit `gen.lock` checksums under `versioningStrategy: manual` + `persistentEdits.enabled: never` to keep the lock file merge-conflict free across parallel feature branches](https://github.com/speakeasy-api/openapi-generation/pull/4395). Drops churn-heavy `docChecksum`/`configChecksum` and `last_write_checksum`, and sorts the `examples` map by operation key so concurrent regenerations merge cleanly. Default (`versioningStrategy: automatic`) behavior is unchanged.

---
Upgrades `openapi-generation` `v2.914.0` → `v2.915.0`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `github.com/speakeasy-api/openapi-generation/v2` to v2.915.0 to make `gen.lock` conflict-free when using manual versioning with persistent edits disabled. Automatic versioning behavior is unchanged.

- **New Features**
  - Under `versioningStrategy: manual` + `persistentEdits.enabled: never`, omit `docChecksum`, `configChecksum`, and `last_write_checksum` from `gen.lock`, and sort the `examples` map by operation key to enable clean merges.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` from `v2.914.0` to `v2.915.0`.

<sup>Written for commit 25d6df80d8f57b4c78d92fecbeee53f28a818c77. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2094?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

