### PR TITLE
fix(docs): generate CLI reference for Astro Starlight

### DIFF
--- a/cmd/docs/main.go
+++ b/cmd/docs/main.go
@@ -21,9 +21,10 @@ func main() {
 
 	root.DisableAutoGenTag = true
 
+	// Static, hand-authored pages in the marketing-site docs tree that must be
+	// preserved when the generated CLI reference is regenerated.
 	exclusionList := []string{
 		filepath.Join(*outDir, "getting-started.mdx"),
-		filepath.Join(*outDir, "_meta.tsx"),
 		filepath.Join(*outDir, "mise-toolkit.mdx"),
 		filepath.Join(*outDir, "docker.mdx"),
 	}

--- a/internal/docs/docs.go
+++ b/internal/docs/docs.go
@@ -22,6 +22,33 @@ func stripAnsi(s string) string {
 	return ansiEscape.ReplaceAllString(s, "")
 }
 
+// h1Heading matches a top-level markdown heading line ("# Title").
+var h1Heading = regexp.MustCompile(`^# `)
+
+// codeFence matches the start/end of a fenced code block (``` or ~~~),
+// ignoring any leading indentation.
+var codeFence = regexp.MustCompile("^\\s*(```|~~~)")
+
+// demoteHeadings demotes top-level markdown headings ("# ") in a command's Long
+// description to second-level ("## "). Astro Starlight renders the frontmatter
+// `title` as the page's single H1, so an additional H1 in the body produces a
+// competing top-level heading. Headings inside fenced code blocks (e.g. shell
+// comments in usage examples) are left untouched.
+func demoteHeadings(s string) string {
+	lines := strings.Split(s, "\n")
+	inFence := false
+	for i, line := range lines {
+		if codeFence.MatchString(line) {
+			inFence = !inFence
+			continue
+		}
+		if !inFence && h1Heading.MatchString(line) {
+			lines[i] = "#" + line
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
 func GenerateDocs(cmd *cobra.Command, outDir string) error {
 	cmd.DisableAutoGenTag = true
 	return genDocs(cmd, outDir)
@@ -58,20 +85,25 @@ func genDoc(cmd *cobra.Command) string {
 
 	builder := &strings.Builder{}
 
-	// ✅ Add frontmatter if this is an index.md page
-	if strings.HasSuffix(getPath(cmd), "index.md") {
-		builder.WriteString("---\nasIndexPage: true\n---\n\n")
-	}
-
 	name := cmd.Name()
 
-	fmt.Fprintf(builder, "# %s  \n", name)
+	// Astro Starlight's docsSchema requires a `title` in the frontmatter of every
+	// page, and renders it as the page's H1 (so we omit a redundant `# name`
+	// heading below). Commands with sub commands are emitted as index pages and
+	// additionally set `asIndexPage: true`.
+	builder.WriteString("---\n")
+	fmt.Fprintf(builder, "title: %q\n", name)
+	if strings.HasSuffix(getPath(cmd), "index.md") {
+		builder.WriteString("asIndexPage: true\n")
+	}
+	builder.WriteString("---\n\n")
+
 	fmt.Fprintf(builder, "`%s`  \n\n\n", cmd.CommandPath())
 	fmt.Fprintf(builder, "%s  \n\n", stripAnsi(cmd.Short))
 
 	if len(cmd.Long) > 0 {
 		builder.WriteString("## Details\n\n")
-		builder.WriteString(stripAnsi(cmd.Long) + "\n\n")
+		builder.WriteString(demoteHeadings(stripAnsi(cmd.Long)) + "\n\n")
 	}
 
 	if cmd.Runnable() {


### PR DESCRIPTION
## Problem

The `Documentation` workflow (`.github/workflows/documentation.yml`) regenerates the CLI reference docs into the marketing-site and opens a PR. The marketing-site has migrated from **Nextra to Astro (Starlight)**, but the doc generator still emitted Nextra-style output. Running the action against the new site would have **reverted the migration and broken the Astro build**:

- **Missing `title` frontmatter** — Starlight's `docsSchema()` requires a `title` on every page. The generator emitted no frontmatter for leaf pages and only `asIndexPage: true` for index pages, so regenerating would strip the hand-added titles → build failure.
- **Duplicate H1** — the generator wrote a `# <name>` body heading, but Starlight renders the frontmatter `title` as the page H1.
- **H1 inside command `Long` text** — several commands' `Long` descriptions start with a `# Heading`, producing a second body H1. The migration had demoted these to `##`.

## Changes

`internal/docs/docs.go`:
- Emit `title: "<name>"` frontmatter on every page; keep `asIndexPage: true` on index pages.
- Drop the redundant `# <name>` body heading.
- Add `demoteHeadings()` to demote `# ` → `## ` in `Long`/Details content, respecting fenced code blocks so `#` shell comments in usage examples are left intact.

`cmd/docs/main.go`:
- Remove the dead `_meta.tsx` entry from the preserve-list (a Nextra sidebar file that no longer exists in the Astro structure).

The workflow YAML already targets the correct Astro path (`src/content/docs/speakeasy-reference/cli`) and sets `CLI_RUNTIME: docs`, so no change was needed there.

## Verification

Running the generator **in-place over the actual committed marketing-site docs** now yields a byte-for-byte match — the only diff is `pull.md`'s `--output-dir` default, which is the current working directory and resolves to the identical path on the CI runner. Static hand-authored files (`getting-started.mdx`, `mise-toolkit.mdx`, `docker.mdx`) are preserved. `go build`, `go vet`, and `gofmt` are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)