### PR TITLE
feat(python): native uuid.UUID and timedelta for uuid/duration formats; fix(cli): repopulate secret config fields from OS keychain; fix(docs): unmatched backtick no longer breaks MDX docs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.915.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.916.2
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.915.1 h1:OWbRdlcgiaGCFMuzF5jUaJRw8KtBmOtGAjKZ9572LWQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.915.1/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.916.2 h1:/hERhI8xYcoSTOIrRvKQ4jXs8ZoGNcJNTU6ugs732YM=
+github.com/speakeasy-api/openapi-generation/v2 v2.916.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## Core
- [Fix Mintlify docs generation: an unmatched inline-code backtick no longer suppresses MDX escaping, which caused generated docs with generics like `<Foo, Bar>` to fail compilation (applies to all doc targets)](https://github.com/speakeasy-api/openapi-generation/pull/4394)

## Python
- [Native `uuid.UUID` and `datetime.timedelta` types for `uuid`/`duration` string formats via new opt-in `gen.yaml` flags (`python.uuidFormat`, `python.durationFormat`); `durationFormat` defaults on for new SDKs](https://github.com/speakeasy-api/openapi-generation/pull/4385)

## CLI
- [Secret credentials (e.g. API keys) stored in the OS keychain are now read back when re-running `configure`/`auth login`, so saved credentials display masked instead of appearing unset; the "stored in OS keychain" message only prints when a keychain write actually succeeded](https://github.com/speakeasy-api/openapi-generation/pull/4389)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds native Python types for UUIDs and durations, improves CLI secret handling, and fixes MDX docs generation when a backtick is unmatched.

- **New Features**
  - Python: Opt-in `gen.yaml` flags `python.uuidFormat` and `python.durationFormat` use `uuid.UUID` and `datetime.timedelta`; `python.durationFormat` defaults to on for new SDKs.

- **Bug Fixes**
  - CLI: Secrets stored in the OS keychain are repopulated on `configure`/`auth login`, showing masked values; the “stored in OS keychain” message prints only on successful writes.
  - Docs: Unmatched inline-code backticks no longer break MDX escaping, fixing cases with generics like `<Foo, Bar>`.

<sup>Written for commit cdcc72315dfb0d91eb32c174aac69bde1f94ef04. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2097?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

