### PR TITLE
fix(typescript,mcp): erasableSyntexOnly; fix(csharp): open enum reserved keywords

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.916.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.916.4
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBm
 github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.916.2 h1:/hERhI8xYcoSTOIrRvKQ4jXs8ZoGNcJNTU6ugs732YM=
-github.com/speakeasy-api/openapi-generation/v2 v2.916.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.916.4 h1:Y3Om+6QqFMpvVJFkoByoeLVPCF7QFbP0KJolMS4Kqug=
+github.com/speakeasy-api/openapi-generation/v2 v2.916.4/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
- [fix(typescript,mcp): emit erasable TypeScript syntax in http and security lib](https://github.com/speakeasy-api/openapi-generation/pull/4404)
- [fix(csharp): escape reserved keywords in open enum implicit operator param](https://github.com/speakeasy-api/openapi-generation/pull/4403)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update `github.com/speakeasy-api/openapi-generation/v2` to v2.916.4 to pick up generator fixes for TypeScript and C#.

- **Bug Fixes**
  - TypeScript/MCP: emit erasable syntax in HTTP and security libs.
  - C#: escape reserved keywords in open-enum implicit operator parameter to prevent compile errors.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` from v2.916.2 to v2.916.4.

<sup>Written for commit 4403b0f33100517f39fa76ab941359f23edd32ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2098?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

