### PR TITLE
fix: bump libopenapi to v0.21.10-fixhiddencomps-fixed (GEN-3129)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.2
 
 replace github.com/pb33f/doctor => github.com/speakeasy-api/doctor v0.20.0-fixvacuum
 
-replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed
+replace github.com/pb33f/libopenapi => github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed
 
 replace github.com/daveshanley/vacuum => github.com/speakeasy-api/vacuum v0.16.16
 

--- a/go.sum
+++ b/go.sum
@@ -544,8 +544,8 @@ github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4 h1:oMiM5kw8Jd9j
 github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4/go.mod h1:ZdhxzEyMG0RE+ZEfqbpL8gvD8nw80UO7KPlf9t+dUCQ=
 github.com/speakeasy-api/jsonpath v0.6.3 h1:c+QPwzAOdrWvzycuc9HFsIZcxKIaWcNpC+xhOW9rJxU=
 github.com/speakeasy-api/jsonpath v0.6.3/go.mod h1:2cXloNuQ+RSXi5HTRaeBh7JEmjRXTiaKpFTdZiL7URI=
-github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed h1:PL/kpBY5vkBmwLjg6l7J4amgSrPf3CNWReGNdwrRqJQ=
-github.com/speakeasy-api/libopenapi v0.21.9-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
+github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x73crANhspQ2CGyZZaBmAHmKUA+Hn2JnpI=
+github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
 github.com/speakeasy-api/openapi-generation/v2 v2.916.4 h1:Y3Om+6QqFMpvVJFkoByoeLVPCF7QFbP0KJolMS4Kqug=


### PR DESCRIPTION
## Summary

Bumps the `github.com/speakeasy-api/libopenapi` replace to `v0.21.10-fixhiddencomps-fixed`, picking up speakeasy-api/libopenapi#9 (merged today).

This fixes GEN-3129: a nil-pointer panic (`(*Schema).Hash` on a nil receiver) in the "Computing changes" step of `speakeasy run` when SDK changelog is enabled and a schema property flips between inline and `$ref` across revisions onto an unresolvable circular alias chain. Currently crashing customer generation pipelines (renconnex, and the original GEN-3129 reporter).

## Testing

- `go build ./...` passes with the bumped dependency.
- The underlying fix carries regression test `TestCompareSchemas_UnresolvableCircularAliasRef` in the libopenapi fork, which panics with the exact ticket stack unpatched and passes patched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes GEN-3129 by bumping `github.com/speakeasy-api/libopenapi` to v0.21.10-fixhiddencomps-fixed. Prevents a nil-pointer panic in change tracking when a schema property switches between inline and `$ref` across an unresolvable circular alias.

- **Dependencies**
  - Update `replace` for `github.com/pb33f/libopenapi` to `github.com/speakeasy-api/libopenapi` v0.21.10-fixhiddencomps-fixed.

<sup>Written for commit 8fab5dc78656f9021b9a3d415bf8b9ee6311f1a1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2099?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

