### PR TITLE
feat(csharp): presence-aware serialization for optional-nullable fields + smart-union deserialization; fix(csharp): pagination default value coalescing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.916.4
+	github.com/speakeasy-api/openapi-generation/v2 v2.917.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.916.4 h1:Y3Om+6QqFMpvVJFkoByoeLVPCF7QFbP0KJolMS4Kqug=
-github.com/speakeasy-api/openapi-generation/v2 v2.916.4/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.917.0 h1:mDiZc1SfFvWwdir1BUNz8qE3s891elQQOnUdHvRcF/s=
+github.com/speakeasy-api/openapi-generation/v2 v2.917.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## C#
- [Distinguish absent from explicit null on optional-nullable fields via `OptionalNullable<T>` (presence-aware JSON serialization), validate responses against the schema's required/nullability contract, and keep required object fields present in serialized output](https://github.com/speakeasy-api/openapi-generation/pull/4282)
- [Smart-union deserialization for undiscriminated unions: candidate scoring replaces the left-to-right fallback heuristic (requires `presenceAwareJsonSerialization`)](https://github.com/speakeasy-api/openapi-generation/pull/4282)
- [Fix: apply default value coalescing for optional pagination inputs to guarantee non-null value types](https://github.com/speakeasy-api/openapi-generation/pull/4282)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates `github.com/speakeasy-api/openapi-generation/v2` to v2.917.0 to ship C# generator changes. Adds presence-aware serialization for optional-nullable fields, smarter union deserialization, and fixes pagination defaults.

- **New Features**
  - Presence-aware JSON for optional-nullable fields via `OptionalNullable<T>`; distinguishes absent vs explicit null, validates required/nullability, and keeps required fields in output. Requires `presenceAwareJsonSerialization`.
  - Smart deserialization for undiscriminated unions using candidate scoring (replaces left-to-right fallback).

- **Bug Fixes**
  - Coalesce defaults for optional pagination inputs to ensure non-null value types.

<sup>Written for commit 77a07fa4e43b6e3e7b6bd22e1f220ad73191c2a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2100?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

