### PR TITLE
fix(java): jackson-databind; feat(typescript): opt-in body in react query key

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.917.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.918.1
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.917.0 h1:mDiZc1SfFvWwdir1BUNz8qE3s891elQQOnUdHvRcF/s=
-github.com/speakeasy-api/openapi-generation/v2 v2.917.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.1 h1:5vu2iNtBqOzg168KRPueRohskSliKHBngN0RLj7XQ8w=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.1/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
- fix(java): bump `jackson-databind` to 2.22.1 ([CVE-2026-54515](https://github.com/advisories/GHSA-5jmj-h7xm-6q6v)) and remove `jackson-databind-nullable` dependency when unused
- feat(typescript): add opt-in `queryKey.includeRequestBody` option on `x-speakeasy-react-hook` to expose the request body in the generated React Query hook query keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates Java SDKs to use `jackson-databind` 2.22.1 and drop `jackson-databind-nullable` when unused, addressing GHSA-5jmj-h7xm-6q6v. Adds an opt-in `queryKey.includeRequestBody` setting in `x-speakeasy-react-hook` to include the request body in React Query hook keys.

- **New Features**
  - Add `queryKey.includeRequestBody` (default false) in `x-speakeasy-react-hook` to include the request body in the React Query `queryKey` for better cache uniqueness.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` to `v2.918.1`.

<sup>Written for commit d66d6a9e60fa7d37152ca14b887d454102536c37. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2101?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

