### PR TITLE
fix(csharp): escape open enum members colliding with enclosing class name; fix(all): resolve self-recursive additionalProperties maps as value-typed maps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.918.1
+	github.com/speakeasy-api/openapi-generation/v2 v2.918.3
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.918.1 h1:5vu2iNtBqOzg168KRPueRohskSliKHBngN0RLj7XQ8w=
-github.com/speakeasy-api/openapi-generation/v2 v2.918.1/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.3 h1:Q5uhB1n1qlFpwAN2HcFCTlH70jAiRXf54tmkepWfG7U=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.3/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## C#
- [Escape open enum members that collide with their enclosing class name, so enums like `Tax` with a value `TAX` compile](https://github.com/speakeasy-api/openapi-generation/pull/4407)
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## Python
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## TypeScript
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## Java
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## Go
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## PHP
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## Ruby
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

## Terraform
- [Generate self-recursive `additionalProperties` maps as maps of their value type instead of empty models](https://github.com/speakeasy-api/openapi-generation/pull/4402)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes C# enum member name collisions and corrects self-recursive additionalProperties to generate proper value-typed maps across all SDKs. Prevents compile errors and produces correct map types.

- **Bug Fixes**
  - C#: Escape open enum members that match the enclosing type name (e.g., Tax/TAX) so code compiles.
  - All SDKs (Python, TypeScript, Java, Go, PHP, Ruby, Terraform): Generate self-recursive additionalProperties as maps of their value type instead of empty models.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` to v2.918.3.

<sup>Written for commit 0f9b905693af6b42a9064e96c42cefe8a39d3acd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2102?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

