### PR TITLE
fix(csharp): escape open enum members that collide with their enclosing class name

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.918.3
+	github.com/speakeasy-api/openapi-generation/v2 v2.918.4
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.918.3 h1:Q5uhB1n1qlFpwAN2HcFCTlH70jAiRXf54tmkepWfG7U=
-github.com/speakeasy-api/openapi-generation/v2 v2.918.3/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.4 h1:6rS7wL8wv90LQoSz+wLyMljH0M27e4AMMMo5CIPrFuw=
+github.com/speakeasy-api/openapi-generation/v2 v2.918.4/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
## CSharp
- [Escape open enum members that collide with their enclosing class name — open enums (`x-speakeasy-unknown-values: allow`) with a value pascal-casing to the enum's own type name now emit `{Name}Value` instead of an uncompilable member (CS0542)](https://github.com/speakeasy-api/openapi-generation/pull/4407)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes C# codegen for open enums by escaping member names that collide with their enclosing type, preventing CS0542 compile errors. Pulls in the fix by bumping `github.com/speakeasy-api/openapi-generation/v2` to `v2.918.4`.

- **Bug Fixes**
  - Open enums (`x-speakeasy-unknown-values: allow`) whose value pascal-cases to the enum type name now emit `{Name}Value` instead of a colliding member.

- **Dependencies**
  - Update `github.com/speakeasy-api/openapi-generation/v2` from `v2.918.3` to `v2.918.4`.

<sup>Written for commit 233754a25f0a96da36d8b794fb69aa7a4b66eee3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

