### PR TITLE
fix(python): preserve nullable discriminated unions under Pydantic 2.13; fix(typescript): npm overrides for vulnerable deps; fix(php,ruby): support RFC 9110 Retry-After HTTP-dates; fix(terraform): preserve nested writeOnly values in oneOf refresh; fix(cli): version internal/sdk import paths for SDK v2+; feat(core): opt-in lint rule for unsupported JSON Schema not keyword

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.924.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.926.2
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.924.0 h1:wXK2vao5WIh/RLV6tjMhhpFy8qdSAPPNhDTutTkTsUc=
-github.com/speakeasy-api/openapi-generation/v2 v2.924.0/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.926.2 h1:n82QaYRO03xjY7BFo39ClVjY4xkyPN7Fe208j99O5JU=
+github.com/speakeasy-api/openapi-generation/v2 v2.926.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades openapi-generation to v2.926.2 (from v2.924.0).

## Core
- [fix(cli): append /vN module path suffix to internal/sdk imports when the SDK major version is above 1](https://github.com/speakeasy-api/openapi-generation/pull/4417)
- [feat: add opt-in lint rule that flags the unsupported JSON Schema `not` keyword (new `speakeasy-unsupported-constructs` ruleset)](https://github.com/speakeasy-api/openapi-generation/pull/4427)

## Python
- [fix: preserve nullable discriminated-union request fields under Pydantic 2.13, and lift the Pydantic <2.13 version cap](https://github.com/speakeasy-api/openapi-generation/pull/4411)

## TypeScript
- [fix: add npm overrides excluding vulnerable dependency versions (fast-uri, js-yaml) in TypeScript and MCP SDKs](https://github.com/speakeasy-api/openapi-generation/pull/4418)

## PHP
- [fix: parse RFC 9110 HTTP-date values in the Retry-After header](https://github.com/speakeasy-api/openapi-generation/pull/4420)

## Ruby
- [fix: honor the standard Retry-After header (delta-seconds and HTTP-date) alongside retry-after-ms](https://github.com/speakeasy-api/openapi-generation/pull/4420)

## Terraform
- [fix: preserve nested writeOnly values when refreshing root-level oneOf entities](https://github.com/speakeasy-api/openapi-generation/pull/4419)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `github.com/speakeasy-api/openapi-generation/v2` to v2.926.2. Adds an opt-in lint rule for unsupported JSON Schema `not` and ships cross-SDK fixes (Python, TypeScript, PHP/Ruby, Terraform, CLI).

- **New Features**
  - New lint rule in `speakeasy-unsupported-constructs` to flag JSON Schema `not` usage (opt-in).

- **Bug Fixes**
  - Python: preserve nullable discriminated-union request fields on Pydantic 2.13; remove the <2.13 cap.
  - TypeScript/MCP: add npm overrides to block vulnerable `fast-uri` and `js-yaml`.
  - PHP/Ruby: support RFC 9110 Retry-After (HTTP-date and delta-seconds).
  - Terraform: preserve nested writeOnly values during root-level oneOf refresh.
  - CLI: version `internal/sdk` import paths with `/vN` for SDK v2+.

<sup>Written for commit 60e3157d9033eb410a6bc3a3cd6a679c2119d1ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

