### PR TITLE
fix(cli): prevent unchanged flag defaults from overriding --body/stdin in generated Go CLIs; fix(terraform): enforce secure minimum versions for transitive Go modules in generated providers

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.926.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.926.8
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.926.2 h1:n82QaYRO03xjY7BFo39ClVjY4xkyPN7Fe208j99O5JU=
-github.com/speakeasy-api/openapi-generation/v2 v2.926.2/go.mod h1:6rV5doAvCjENg+yA9M8MfQ1EVdWp3zEF0tAbPU7ptyc=
+github.com/speakeasy-api/openapi-generation/v2 v2.926.8 h1:PDl4KiIA3GNZ5m5mjrOJZFVx/4jQqyY2KC6DdR32+cA=
+github.com/speakeasy-api/openapi-generation/v2 v2.926.8/go.mod h1:Yl5GQcdXTGTFTm7Wqo+WK9vpwTJ8oZvXcM3NHUEeyYQ=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades openapi-generation to v2.926.8 (from v2.926.2).

## Core
- [fix(cli): prevent unchanged flag defaults from overwriting --body/stdin values in generated Go CLIs](https://github.com/speakeasy-api/openapi-generation/pull/4428)

## Terraform
- [fix: update terraform-plugin-log to v0.11.0 and enforce secure minimum versions for the golang.org/x/crypto, golang.org/x/net, and google.golang.org/grpc transitive modules in generated providers](https://github.com/speakeasy-api/openapi-generation/pull/4440)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `github.com/speakeasy-api/openapi-generation/v2` to v2.926.8 to fix Go CLI flag handling and harden security in generated Terraform providers. Go CLIs now respect `--body`/stdin, and Terraform providers enforce secure transitive module versions.

- **Bug Fixes**
  - Go CLI: prevent unchanged flag defaults from overriding `--body`/stdin.
  - Terraform: enforce minimum secure versions for `golang.org/x/crypto`, `golang.org/x/net`, and `google.golang.org/grpc`, and update `terraform-plugin-log` to v0.11.0.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` from v2.926.2 to v2.926.8.

<sup>Written for commit af5aa61a7491070a2afbfbfe86c2e3789cbc0472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2108?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

