### PR TITLE
feat(csharp): open-unions; fix(csharp): open-enum serialization; fix(java): open-unions config

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -46,7 +46,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.926.8
+	github.com/speakeasy-api/openapi-generation/v2 v2.927.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -546,8 +546,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.926.8 h1:PDl4KiIA3GNZ5m5mjrOJZFVx/4jQqyY2KC6DdR32+cA=
-github.com/speakeasy-api/openapi-generation/v2 v2.926.8/go.mod h1:Yl5GQcdXTGTFTm7Wqo+WK9vpwTJ8oZvXcM3NHUEeyYQ=
+github.com/speakeasy-api/openapi-generation/v2 v2.927.0 h1:aHmzBntnY0O0KoJxMffzcteuAnNLprEr+SLRQscI1HU=
+github.com/speakeasy-api/openapi-generation/v2 v2.927.0/go.mod h1:Yl5GQcdXTGTFTm7Wqo+WK9vpwTJ8oZvXcM3NHUEeyYQ=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
### C#
- feat: add support for forward-compatible open unions: unrecognized variants deserialize as Unknown with the payload preserved, instead of throwing
- fix: serialize open enums in form/query/header params and coerce int32/bool payloads in OpenEnumConverter

### Java
- fix: prevent `forwardCompatibleUnionsByDefault: false` to silently enable open unions

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds forward-compatible open unions in C#; unknown variants deserialize as Unknown and keep the payload. Also fixes C# open-enum serialization (form/query/header with int32/bool coercion) and stops Java configs with forwardCompatibleUnionsByDefault: false from silently enabling open unions.

- **Dependencies**
  - Bump `github.com/speakeasy-api/openapi-generation/v2` to `v2.927.0`.

<sup>Written for commit 5b6fa5d299bed60b71f03178e0649f1c1d9e2cad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2109?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

