### PR TITLE
feat: route cli generation through openapi-generation-next

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -113,6 +113,6 @@ jobs:
       - name: Build
         run: go build ./...
 
-      - run: go test -json -v -timeout=20m ./... | gotestfmt
+      - run: go test -json -v -timeout=30m ./... | gotestfmt
         env:
           SPEAKEASY_API_KEY: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/cmd/generate/generate_test.go
+++ b/cmd/generate/generate_test.go
@@ -103,11 +103,10 @@ func TestGetChangelogs(t *testing.T) {
 				Raw: true,
 			},
 			expectError: false,
-			// The latest changelog should contain version headers, GitHub links, and commit info
+			// Bootstrap releases can intentionally contain a generic changelog entry
+			// without predecessor repository links or commit attribution.
 			expectPatterns: []string{
 				`## \[v\d+\.\d+\.\d+\]`,
-				`github\.com/speakeasy-api/openapi-generation`,
-				`\(commit by`,
 			},
 		},
 		{

--- a/cmd/lint/lint.go
+++ b/cmd/lint/lint.go
@@ -9,6 +9,7 @@ import (
 	"slices"
 	"strings"
 
+	generationaccess "github.com/speakeasy-api/generation-context/access"
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
 	"github.com/speakeasy-api/speakeasy-core/openapi"
 	"github.com/speakeasy-api/speakeasy-core/suggestions"
@@ -588,6 +589,12 @@ func warningsToTabContents(warnings []error) []interactivity.InspectableContent 
 
 // runDryRunGeneration runs a dry-run SDK generation for the specified target and returns warnings
 func runDryRunGeneration(ctx context.Context, schemaPath, targetLanguage, workingDir string) ([]error, error) {
+	// Lint is available without authentication, so its optional diagnostic
+	// generation must explicitly use the direct AGPL mode when no caller state exists.
+	if _, ok := generationaccess.StateFromContext(ctx); !ok {
+		ctx = generationaccess.WithDirect(ctx)
+	}
+
 	// Load the OpenAPI schema
 	isRemote, schema, err := openapi.GetSchemaContents(ctx, schemaPath, "", "")
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ replace github.com/dop251/goja => github.com/speakeasy-api/goja v0.0.0-202602230
 
 replace github.com/dop251/goja/debugger => github.com/speakeasy-api/goja/debugger v0.0.0-20260223084236-ed0328a0a462
 
+// Keep this version aligned with the canonical require below; update both through scripts/upgrade.bash.
 replace github.com/speakeasy-api/openapi-generation/v2 => github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0
 
 require (

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,8 @@ replace github.com/dop251/goja => github.com/speakeasy-api/goja v0.0.0-202602230
 
 replace github.com/dop251/goja/debugger => github.com/speakeasy-api/goja/debugger v0.0.0-20260223084236-ed0328a0a462
 
+replace github.com/speakeasy-api/openapi-generation/v2 => github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0
+
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5
 	github.com/MichaelMure/go-term-markdown v0.1.4
@@ -41,16 +43,17 @@ require (
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2
 	github.com/samber/lo v1.52.0
 	github.com/sethvargo/go-githubactions v1.3.2
+	github.com/speakeasy-api/generation-context v1.0.0
 	github.com/speakeasy-api/git-diff-parser v0.2.0
 	github.com/speakeasy-api/gram v0.0.0-20260121234743-5a36906a8929
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.927.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.928.0
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7
-	github.com/speakeasy-api/speakeasy-core v0.22.1
+	github.com/speakeasy-api/speakeasy-core v0.22.2
 	github.com/speakeasy-api/versioning-reports v0.6.1
 	github.com/spf13/cobra v1.10.1
 	github.com/spf13/pflag v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -528,6 +528,8 @@ github.com/sourcegraph/jsonrpc2 v0.2.0 h1:KjN/dC4fP6aN9030MZCJs9WQbTOjWHhrtKVpzz
 github.com/sourcegraph/jsonrpc2 v0.2.0/go.mod h1:ZafdZgk/axhT1cvZAPOhw+95nz2I/Ra5qMlU4gTRwIo=
 github.com/speakeasy-api/easytemplate v0.12.4 h1:0xEm93tqPfdIWKUwgxvFgDLBmSDXlCImp+mQF3XZcOg=
 github.com/speakeasy-api/easytemplate v0.12.4/go.mod h1:UF8bFhTpyr1sHiEWacT7ULN67Bve6UIrTH7uvzdbTEY=
+github.com/speakeasy-api/generation-context v1.0.0 h1:LMHn7k1GCT1lIuwWSCn2ogaUgaIq8eGsGGPUXmvpW0s=
+github.com/speakeasy-api/generation-context v1.0.0/go.mod h1:AxqOSyH55Kp70pQynKl0nSlpke6P3/FlnFL//7sPM50=
 github.com/speakeasy-api/git-diff-parser v0.2.0 h1:fvPsWhTqTt+8j9Kx4eXF6kRRqDUC60gy0VII4PnjIHA=
 github.com/speakeasy-api/git-diff-parser v0.2.0/go.mod h1:P46HmmVVmwA9P8h2wa0fDpmRM8/grbVQ+uKhWDtpkIY=
 github.com/speakeasy-api/goja v0.0.0-20260223084236-ed0328a0a462 h1:wFAq/dFgXzPkOpI36BkHdUl4rKi7qh6iMsvlRkh2fCs=
@@ -546,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation/v2 v2.927.0 h1:aHmzBntnY0O0KoJxMffzcteuAnNLprEr+SLRQscI1HU=
-github.com/speakeasy-api/openapi-generation/v2 v2.927.0/go.mod h1:Yl5GQcdXTGTFTm7Wqo+WK9vpwTJ8oZvXcM3NHUEeyYQ=
+github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0 h1:jKeib5ha8PlnctCgsIJUYx/z+ZH35NVUifxbQ5zObls=
+github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0/go.mod h1:VoPI9mXvW1JZ1IyMyu0L79/rcwp2JYi2e1xymslrpXo=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=
@@ -556,8 +558,8 @@ github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12 h1:dGONbW8WLNc4uSo
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7 h1:SoWZkRlpFlv8qibCfXWrBZay1JeLS9uqJ+1cu+DFgXo=
 github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7/go.mod h1:k9JD6Rj0+Iizc5COoLZHyRIOGGITpKZ2qBuFFO8SqNI=
-github.com/speakeasy-api/speakeasy-core v0.22.1 h1:qGKlVk/37fATCbmPMNFjA7HxFV8ERA/E2ly9Z+IUn3Q=
-github.com/speakeasy-api/speakeasy-core v0.22.1/go.mod h1:iFlS4QkN5mtOh2nV77VjpHtoyiI06WeNPKJYyPs9A28=
+github.com/speakeasy-api/speakeasy-core v0.22.2 h1:hWJjOQVQ8GKIpqQLQYmQ54td5O5N25GD9KZ496L/Enk=
+github.com/speakeasy-api/speakeasy-core v0.22.2/go.mod h1:584TlOBtX4Bks5cwrbo1OPjzP3YMvzgH/NK1HKBqoo0=
 github.com/speakeasy-api/versioning-reports v0.6.1 h1:pvuvA1IFO7PVlpdFh7J2Y3hENDzhISFdNy0NVg/Cxb4=
 github.com/speakeasy-api/versioning-reports v0.6.1/go.mod h1:LW5FABrvi5SBbeiD3HJYw0JZYe6Rw2Xna59pFJ2BmLI=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd h1:csraKifkLpqDClUIbFTetjtraueL1KUhKBm6okL+ug4=

--- a/integration/quickstart_test.go
+++ b/integration/quickstart_test.go
@@ -17,7 +17,11 @@ import (
 )
 
 func TestQuickstart(t *testing.T) {
-	t.Parallel()
+	// Concurrent quickstarts leave Windows child processes waiting indefinitely.
+	// Keep all non-skipped targets covered there, but run them serially.
+	if runtime.GOOS != "windows" {
+		t.Parallel()
+	}
 
 	now := time.Now()
 	t.Logf("Building binary")
@@ -33,7 +37,9 @@ func TestQuickstart(t *testing.T) {
 	targets := prompts.GetSupportedTargetNames()
 	for _, target := range targets {
 		t.Run(target, func(t *testing.T) {
-			t.Parallel()
+			if runtime.GOOS != "windows" {
+				t.Parallel()
+			}
 
 			if shouldSkipTarget(t, target) {
 				return

--- a/integration/quickstart_test.go
+++ b/integration/quickstart_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestQuickstart(t *testing.T) {
+func TestQuickstart(t *testing.T) { //nolint:paralleltest // Windows quickstarts must run serially to avoid child-process hangs.
 	// Concurrent quickstarts leave Windows child processes waiting indefinitely.
 	// Keep all non-skipped targets covered there, but run them serially.
 	if runtime.GOOS != "windows" {

--- a/internal/run/generation_context_test.go
+++ b/internal/run/generation_context_test.go
@@ -1,0 +1,45 @@
+package run
+
+import (
+	"context"
+	"testing"
+
+	generationaccess "github.com/speakeasy-api/generation-context/access"
+)
+
+func TestWithWorkflowGenerationContextPreservesExistingState(t *testing.T) {
+	t.Parallel()
+
+	original := generationaccess.WithDirect(context.Background())
+
+	ctx, err := withWorkflowGenerationContext(original)
+	if err != nil {
+		t.Fatalf("with workflow generation context: %v", err)
+	}
+	if ctx != original {
+		t.Fatal("existing state must be returned unchanged")
+	}
+	state, ok := generationaccess.StateFromContext(ctx)
+	if !ok || state.Mode() != generationaccess.ModeDirect {
+		t.Fatalf("existing direct state was not preserved: %#v", state)
+	}
+}
+
+func TestWithWorkflowGenerationContextUnauthenticatedIsDirect(t *testing.T) {
+	t.Parallel()
+
+	ctx, err := withWorkflowGenerationContext(context.Background())
+	if err != nil {
+		t.Fatalf("with workflow generation context: %v", err)
+	}
+	state, ok := generationaccess.StateFromContext(ctx)
+	if !ok {
+		t.Fatal("expected direct state for unauthenticated invocation")
+	}
+	if state.Mode() != generationaccess.ModeDirect {
+		t.Fatalf("unexpected mode %d", state.Mode())
+	}
+	if state.GeneratedLicense() != generationaccess.GeneratedLicenseAGPL {
+		t.Fatalf("direct generation must be AGPL, got %q", state.GeneratedLicense())
+	}
+}

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -179,7 +179,7 @@ func withWorkflowGenerationContext(ctx context.Context) (context.Context, error)
 	}
 
 	if _, err := core.GetWorkspaceIDFromContext(ctx); err != nil {
-		return generationaccess.WithDirect(ctx), nil
+		return generationaccess.WithDirect(ctx), nil //nolint:nilerr // Direct runs do not carry workspace context.
 	}
 
 	// Target-level access checks decide whether authenticated output is commercial.

--- a/internal/run/run.go
+++ b/internal/run/run.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/charmbracelet/lipgloss"
 	"github.com/samber/lo"
+	generationaccess "github.com/speakeasy-api/generation-context/access"
 	"gopkg.in/yaml.v3"
 
 	"github.com/speakeasy-api/openapi-generation/v2/pkg/generate"
@@ -128,6 +129,11 @@ func (w *Workflow) PrintSuccessSummary(ctx context.Context) {
 }
 
 func (w *Workflow) Run(ctx context.Context) error {
+	ctx, generationContextErr := withWorkflowGenerationContext(ctx)
+	if generationContextErr != nil {
+		return fmt.Errorf("failed to prepare generation context: %w", generationContextErr)
+	}
+
 	startTime := time.Now()
 	err := w.RunInner(ctx)
 	w.Error = err
@@ -165,6 +171,20 @@ func (w *Workflow) Run(ctx context.Context) error {
 	}
 
 	return err
+}
+
+func withWorkflowGenerationContext(ctx context.Context) (context.Context, error) {
+	if _, ok := generationaccess.StateFromContext(ctx); ok {
+		return ctx, nil
+	}
+
+	if _, err := core.GetWorkspaceIDFromContext(ctx); err != nil {
+		return generationaccess.WithDirect(ctx), nil
+	}
+
+	// Target-level access checks decide whether authenticated output is commercial.
+	// The workflow-level state only establishes the authenticated invocation context.
+	return core.WithGenerationContext(ctx, generationaccess.GeneratedLicenseAGPL)
 }
 
 func (w *Workflow) RunInner(ctx context.Context) error {

--- a/internal/sdkgen/generation_context_test.go
+++ b/internal/sdkgen/generation_context_test.go
@@ -11,6 +11,8 @@ import (
 )
 
 func TestWithGenerationContextSelectsCallerDecidedLicense(t *testing.T) {
+	t.Parallel()
+
 	createdAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 	testCases := []struct {
 		name              string
@@ -23,6 +25,7 @@ func TestWithGenerationContextSelectsCallerDecidedLicense(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			legacy := auth.WithAdminSkipLicenseCheck(
 				context.Background(),
 				"workspace-id",
@@ -56,6 +59,8 @@ func TestWithGenerationContextSelectsCallerDecidedLicense(t *testing.T) {
 }
 
 func TestWithGenerationContextPreservesCancellableContext(t *testing.T) {
+	t.Parallel()
+
 	createdAt := time.Now()
 	legacy := auth.WithAdminSkipLicenseCheck(
 		context.Background(), "workspace-id", shared.AccountTypeBusiness, nil, "org", "workspace", createdAt, nil,
@@ -78,6 +83,8 @@ func TestWithGenerationContextPreservesCancellableContext(t *testing.T) {
 }
 
 func TestWithGenerationContextRejectsIncompleteAuthentication(t *testing.T) {
+	t.Parallel()
+
 	original := auth.SetAccountTypeInContext(context.Background(), string(shared.AccountTypeBusiness))
 	ctx, err := withGenerationContext(original, true)
 	if err == nil {

--- a/internal/sdkgen/generation_context_test.go
+++ b/internal/sdkgen/generation_context_test.go
@@ -1,0 +1,92 @@
+package sdkgen
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	generationaccess "github.com/speakeasy-api/generation-context/access"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+	"github.com/speakeasy-api/speakeasy-core/auth"
+)
+
+func TestWithGenerationContextSelectsCallerDecidedLicense(t *testing.T) {
+	createdAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+	testCases := []struct {
+		name              string
+		generationAllowed bool
+		wantLicense       generationaccess.GeneratedLicense
+	}{
+		{name: "allowed generation is commercial", generationAllowed: true, wantLicense: generationaccess.GeneratedLicenseCommercial},
+		{name: "unentitled generation is AGPL", generationAllowed: false, wantLicense: generationaccess.GeneratedLicenseAGPL},
+	}
+
+	for _, tt := range testCases {
+		t.Run(tt.name, func(t *testing.T) {
+			legacy := auth.WithAdminSkipLicenseCheck(
+				context.Background(),
+				"workspace-id",
+				shared.AccountTypeBusiness,
+				nil,
+				"org",
+				"workspace",
+				createdAt,
+				[]shared.BillingAddOn{shared.BillingAddOnSnippetAi},
+			)
+
+			ctx, err := withGenerationContext(legacy, tt.generationAllowed)
+			if err != nil {
+				t.Fatalf("with generation context: %v", err)
+			}
+			state, ok := generationaccess.StateFromContext(ctx)
+			if !ok {
+				t.Fatal("expected shared authenticated state")
+			}
+			if state.Mode() != generationaccess.ModeAuthenticated {
+				t.Fatalf("unexpected mode %d", state.Mode())
+			}
+			if state.GeneratedLicense() != tt.wantLicense {
+				t.Fatalf("expected license %q, got %q", tt.wantLicense, state.GeneratedLicense())
+			}
+			if !state.HasBillingAddOn(shared.BillingAddOnSnippetAi) {
+				t.Fatal("caller bridge lost authenticated billing add-ons")
+			}
+		})
+	}
+}
+
+func TestWithGenerationContextPreservesCancellableContext(t *testing.T) {
+	createdAt := time.Now()
+	legacy := auth.WithAdminSkipLicenseCheck(
+		context.Background(), "workspace-id", shared.AccountTypeBusiness, nil, "org", "workspace", createdAt, nil,
+	)
+	cancellable, cancel := context.WithCancel(legacy)
+	defer cancel()
+
+	ctx, err := withGenerationContext(cancellable, true)
+	if err != nil {
+		t.Fatalf("with generation context: %v", err)
+	}
+	state, ok := generationaccess.StateFromContext(ctx)
+	if !ok || state.GeneratedLicense() != generationaccess.GeneratedLicenseCommercial {
+		t.Fatalf("cancellable context lost generation state: %#v", state)
+	}
+	cancel()
+	if ctx.Err() != context.Canceled {
+		t.Fatalf("cancellable context lost cancellation: %v", ctx.Err())
+	}
+}
+
+func TestWithGenerationContextRejectsIncompleteAuthentication(t *testing.T) {
+	original := auth.SetAccountTypeInContext(context.Background(), string(shared.AccountTypeBusiness))
+	ctx, err := withGenerationContext(original, true)
+	if err == nil {
+		t.Fatal("expected incomplete authentication error")
+	}
+	if ctx != original {
+		t.Fatal("failure must return the original context")
+	}
+	if _, ok := generationaccess.StateFromContext(ctx); ok {
+		t.Fatal("failure inserted partial shared state")
+	}
+}

--- a/internal/sdkgen/sdkgen.go
+++ b/internal/sdkgen/sdkgen.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/charmbracelet/lipgloss"
+	generationaccess "github.com/speakeasy-api/generation-context/access"
 	"github.com/speakeasy-api/speakeasy-core/auth"
 	"github.com/speakeasy-api/speakeasy-core/openapi"
 
@@ -101,10 +102,13 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 
 	logger := log.From(ctx).WithAssociatedFile(opts.SchemaPath)
 
-	generationAccess, level, message, _ := access.HasGenerationAccess(ctx, &access.GenerationAccessArgs{
+	generationAccess, level, message, accessErr := access.HasGenerationAccess(ctx, &access.GenerationAccessArgs{
 		GenLockID:  GetGenLockID(opts.OutDir),
 		TargetType: &opts.Language,
 	})
+	if accessErr != nil {
+		return &GenerationAccess{}, fmt.Errorf("failed to evaluate generation access: %w", accessErr)
+	}
 
 	if !generationAccess && level != nil && *level == shared.LevelBlocked {
 		msg := styles.RenderErrorMessage(
@@ -118,6 +122,15 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 			Message:       message,
 			Level:         level,
 		}, stderrors.New("generation access blocked")
+	}
+
+	ctx, err := withGenerationContext(ctx, generationAccess)
+	if err != nil {
+		return &GenerationAccess{
+			AccessAllowed: generationAccess,
+			Message:       message,
+			Level:         level,
+		}, fmt.Errorf("failed to prepare generation context: %w", err)
 	}
 
 	logger.Infof("Generating SDK for %s...\n", opts.Language)
@@ -263,7 +276,10 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 
 		var errs []error
 		if opts.CancellableGeneration != nil && opts.CancellableGeneration.CancellableContext != nil {
-			cancelCtx := opts.CancellableGeneration.CancellableContext
+			cancelCtx, err := withGenerationContext(opts.CancellableGeneration.CancellableContext, generationAccess)
+			if err != nil {
+				return fmt.Errorf("failed to prepare cancellable generation context: %w", err)
+			}
 
 			var cancelled bool
 			cancelled, errs = g.GenerateWithCancel(cancelCtx, schema, opts.SchemaPath, opts.Language, opts.OutDir, isRemote, opts.Compile)
@@ -330,6 +346,14 @@ func Generate(ctx context.Context, opts GenerateOptions) (*GenerationAccess, err
 		Message:               message,
 		RenderedUsageSnippets: g.GetRenderedUsageSnippets(),
 	}, nil
+}
+
+func withGenerationContext(ctx context.Context, generationAllowed bool) (context.Context, error) {
+	generatedLicense := generationaccess.GeneratedLicenseAGPL
+	if generationAllowed {
+		generatedLicense = generationaccess.GeneratedLicenseCommercial
+	}
+	return auth.WithGenerationContext(ctx, generatedLicense)
 }
 
 func ValidateConfig(ctx context.Context, outDir string) error {

--- a/scripts/upgrade.bash
+++ b/scripts/upgrade.bash
@@ -7,18 +7,43 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
   cd "${SCRIPT_DIR}/.."
   export GOPRIVATE="github.com/speakeasy-api/*"
 
-  read -r CURRENT_OPENAPI_GENERATION_VERSION <<<"$(cat go.mod | grep github.com/speakeasy-api/openapi-generation/v2 | awk '{ print $2 }' | awk '{print substr($1,2); }')"
-  # echo "  => CURRENT_OPENAPI_GENERATION_VERSION=${CURRENT_OPENAPI_GENERATION_VERSION}"
-  START_DATE=$(gh release view "v${CURRENT_OPENAPI_GENERATION_VERSION}" --repo speakeasy-api/openapi-generation --json createdAt | jq -r '.createdAt')
+  MODULE_PATH="github.com/speakeasy-api/openapi-generation/v2"
+  CANONICAL_REPOSITORY="speakeasy-api/openapi-generation"
+  NEXT_MODULE_PATH="github.com/speakeasy-api/openapi-generation-next/v2"
+  NEXT_REPOSITORY="speakeasy-api/openapi-generation-next"
 
-  if [[ -z $START_DATE ]]; then
-    echo "Could not find current version (v${CURRENT_OPENAPI_GENERATION_VERSION}) release"
+  MODULE_JSON=$(go mod edit -json)
+  CURRENT_OPENAPI_GENERATION_VERSION=$(jq -r --arg module "$MODULE_PATH" '.Require[] | select(.Path == $module) | .Version' <<<"$MODULE_JSON")
+  REPLACEMENT_VERSION=$(jq -r --arg module "$MODULE_PATH" --arg next "$NEXT_MODULE_PATH" '.Replace[]? | select(.Old.Path == $module and .New.Path == $next) | .New.Version' <<<"$MODULE_JSON")
+
+  if [[ -z "$CURRENT_OPENAPI_GENERATION_VERSION" || "$CURRENT_OPENAPI_GENERATION_VERSION" == "null" ]]; then
+    echo "Could not find required version for ${MODULE_PATH}"
     exit 1
   fi
 
-  PRS=$(gh pr list --repo speakeasy-api/openapi-generation --state merged --search "merged:>${START_DATE}" --json title,url | jq -r '.[] | .title+"\n > "+.url+"\n"')
+  if [[ -n "$REPLACEMENT_VERSION" && "$REPLACEMENT_VERSION" != "null" ]]; then
+    if [[ "$REPLACEMENT_VERSION" != "$CURRENT_OPENAPI_GENERATION_VERSION" ]]; then
+      echo "Require and replace versions for ${MODULE_PATH} must match"
+      exit 1
+    fi
+    OPENAPI_GENERATION_REPOSITORY="$NEXT_REPOSITORY"
+    OPENAPI_GENERATION_REPLACEMENT_ACTIVE=true
+  else
+    OPENAPI_GENERATION_REPOSITORY="$CANONICAL_REPOSITORY"
+    OPENAPI_GENERATION_REPLACEMENT_ACTIVE=false
+  fi
+
+  CURRENT_OPENAPI_GENERATION_VERSION="${CURRENT_OPENAPI_GENERATION_VERSION#v}"
+  START_DATE=$(gh release view "v${CURRENT_OPENAPI_GENERATION_VERSION}" --repo "$OPENAPI_GENERATION_REPOSITORY" --json createdAt | jq -r '.createdAt')
+
+  if [[ -z "$START_DATE" || "$START_DATE" == "null" ]]; then
+    echo "Could not find current version (v${CURRENT_OPENAPI_GENERATION_VERSION}) release in ${OPENAPI_GENERATION_REPOSITORY}"
+    exit 1
+  fi
+
+  PRS=$(gh pr list --repo "$OPENAPI_GENERATION_REPOSITORY" --state merged --search "merged:>${START_DATE}" --json title,url | jq -r '.[] | .title+"\n > "+.url+"\n"')
 #  echo "  => PRS=${PRS}"
-  LATEST_OPENAPI_GENERATION_VERSION=$(gh release list --limit 1 --repo speakeasy-api/openapi-generation --json tagName | jq -r '.[0].tagName')
+  LATEST_OPENAPI_GENERATION_VERSION=$(gh release list --limit 1 --repo "$OPENAPI_GENERATION_REPOSITORY" --json tagName | jq -r '.[0].tagName')
 #  echo "  => LATEST_OPENAPI_GENERATION_VERSION=${LATEST_OPENAPI_GENERATION_VERSION}"
 
   read -r SEMVER_CHANGE <<<"$("${SCRIPT_DIR}/semver.bash" diff "${CURRENT_OPENAPI_GENERATION_VERSION}" "${LATEST_OPENAPI_GENERATION_VERSION}")"
@@ -41,7 +66,10 @@ SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
     read -r -p "Commit Message (please summarize changes above): " SUMMARY
   fi
 
-  go get -v "github.com/speakeasy-api/openapi-generation/v2@${LATEST_OPENAPI_GENERATION_VERSION}"
+  go mod edit -require="${MODULE_PATH}@${LATEST_OPENAPI_GENERATION_VERSION}"
+  if [[ "$OPENAPI_GENERATION_REPLACEMENT_ACTIVE" == true ]]; then
+    go mod edit -replace="${MODULE_PATH}=${NEXT_MODULE_PATH}@${LATEST_OPENAPI_GENERATION_VERSION}"
+  fi
   go mod tidy
 
   echo "$ git add go.mod go.sum"


### PR DESCRIPTION
## Why

The private generator is now published from `openapi-generation-next` at `v2.928.0`, while the canonical module/import path must remain unchanged until the separate repository-rename migration. The CLI needs an explicit, temporary remote Go module replacement so day-to-day generator work can move to `-next` without breaking existing imports.

## What changed

- Require canonical `github.com/speakeasy-api/openapi-generation/v2 v2.928.0` and route it to `github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0` through one exact remote replacement.
- Use released `generation-context v1.0.0` and `speakeasy-core v0.22.2`; no local filesystem dependency replacements are included.
- Pass caller-decided commercial/AGPL generation context to regular and cancellable generator execution, with focused coverage for authenticated state, cancellation, and invalid partial authentication.
- Preserve direct/unauthenticated behavior in workflow and lint generation paths.
- Make `scripts/upgrade.bash` inspect Go module state structurally, query `openapi-generation-next` while the replacement is active, and update the require and replacement versions together.

## Review notes

- The temporary `replace` is intentional and must remain until the separately approved repository rename. Imports stay canonical.
- `scripts/upgrade.bash` is the main migration-sensitive behavior: it switches release lookup only when it detects the exact approved replacement and rejects mismatched require/replace versions.
- This PR does not rename repositories, change generator release workflow/protection, enable WASM delivery, or change snapshot routing.
- **Do not merge** until the separately tracked protected normal-release rehearsal on `openapi-generation-next` has completed successfully.

## Testing

- `go test ./internal/sdkgen ./internal/run ./cmd/lint ./cmd/generate -count=1`
- `go test -race ./internal/sdkgen -run 'TestWithGenerationContext' -count=1`
- `go build ./...`
- `go vet ./...`
- `go mod tidy` twice with no diff; `go mod verify`
- `bash -n scripts/upgrade.bash`
- Isolated cold-cache module resolution using the exact canonical require plus remote `-next` replacement.
- Independent review found no actionable issues.

## Rollout / deployment notes

- Hosted CLI validation/release already uses `GOPRIVATE` and `BOT_REPO_TOKEN` Git URL rewrite for private `speakeasy-api` modules. Its selected-repository access to `openapi-generation-next` must be confirmed by the PR’s hosted checks before merge.
- After the later rename, remove only the temporary remote replacement, keep imports canonical, restore canonical release lookup in `scripts/upgrade.bash`, and refresh module sums.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes CLI generation to `openapi-generation-next` with canonical imports and makes generation license-aware (Commercial vs AGPL). Also stabilizes Windows quickstart tests by running them serially and increases CI test timeouts to 30m.

- **New Features**
  - Route `github.com/speakeasy-api/openapi-generation/v2 v2.928.0` to `github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0` via a remote `replace`; imports remain canonical.
  - Integrate `generation-context v1.0.0`: choose Commercial vs AGPL by access; apply to generate and cancellable runs; lint uses Direct AGPL if unauthenticated; workflow sets context from workspace or Direct; preserves cancellation; rejects partial auth; add tests for workflow and cancellable contexts.
  - Loosen changelog test to allow bootstrap releases with generic entries.
  - Bump `github.com/speakeasy-api/speakeasy-core` to `v0.22.2`.

- **Migration**
  - Keep the temporary `replace` until the repository rename; imports stay `github.com/speakeasy-api/openapi-generation/v2`.
  - `scripts/upgrade.bash` reads `go.mod` structurally, switches release lookup to `openapi-generation-next` when the `replace` is active, enforces matching require/replace versions, and updates both together.

<sup>Written for commit f76078ef094c0c93dd212e29a094946584a34586. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2110?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

