### PR TITLE
fix: install pinned CLI versions via direct asset URL to avoid GitHub API rate limits

### DIFF
--- a/internal/env/env.go
+++ b/internal/env/env.go
@@ -33,6 +33,15 @@ func IsLocalDev() bool {
 	return os.Getenv("SPEAKEASY_ENVIRONMENT") == "local"
 }
 
+// FailOnVersionMismatch returns true if SPEAKEASY_FAIL_ON_VERSION_MISMATCH is
+// set, turning the fallback to the locally installed CLI version (when the
+// version pinned in workflow.yaml cannot be installed) into a hard error
+// instead of a warning. Intended for CI, where silently generating with an
+// unpinned version produces spurious diffs.
+func FailOnVersionMismatch() bool {
+	return os.Getenv("SPEAKEASY_FAIL_ON_VERSION_MISMATCH") == "true"
+}
+
 func IsCI() bool {
 	return os.Getenv("CI") == "true" || IsGithubAction() || utils.IsRunningInCI()
 }

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -175,7 +175,7 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 					logger.Debug("Using pinned version (skipping blue/green speakeasy CLI upgrade)")
 				case errors.Is(err, ErrInstallFailed): // Don't fail on download failure. Proceed using the current CLI version, as if it was run with --pinned
 					if env.FailOnVersionMismatch() {
-						return fmt.Errorf("failed to install the Speakeasy version specified in workflow.yaml (failing instead of falling back to the local version because SPEAKEASY_FAIL_ON_VERSION_MISMATCH is set): %w", err)
+						return fmt.Errorf("SPEAKEASY_FAIL_ON_VERSION_MISMATCH is set, failing instead of falling back to the locally installed version: %w", err)
 					}
 					logger.PrintfStyled(styles.DimmedItalic, "Failed to download latest Speakeasy version: %s", err.Error())
 					logger.PrintfStyled(styles.DimmedItalic, "Running with local version. This might result in inconsistencies between environments\n")

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -338,10 +338,13 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 	switch desiredVersion {
 	case "latest":
 		latest, err := updates.GetLatestVersion(ctx, artifactArch)
+		if err != nil {
+			return ErrInstallFailed.Wrap(err)
+		}
 		// latest can be nil without an error when no release (or no asset
 		// matching this artifactArch) is found; treat it as an install failure
 		// rather than dereferencing nil.
-		if err != nil || latest == nil {
+		if latest == nil {
 			return ErrInstallFailed
 		}
 		desiredVersion = latest.String()

--- a/internal/model/command.go
+++ b/internal/model/command.go
@@ -174,6 +174,9 @@ func (c ExecutableCommand[F]) Init() (*cobra.Command, error) {
 				case errors.Is(err, ErrPinned):
 					logger.Debug("Using pinned version (skipping blue/green speakeasy CLI upgrade)")
 				case errors.Is(err, ErrInstallFailed): // Don't fail on download failure. Proceed using the current CLI version, as if it was run with --pinned
+					if env.FailOnVersionMismatch() {
+						return fmt.Errorf("failed to install the Speakeasy version specified in workflow.yaml (failing instead of falling back to the local version because SPEAKEASY_FAIL_ON_VERSION_MISMATCH is set): %w", err)
+					}
 					logger.PrintfStyled(styles.DimmedItalic, "Failed to download latest Speakeasy version: %s", err.Error())
 					logger.PrintfStyled(styles.DimmedItalic, "Running with local version. This might result in inconsistencies between environments\n")
 				default:
@@ -335,7 +338,10 @@ func runWithVersionFromWorkflowFile(cmd *cobra.Command) error {
 	switch desiredVersion {
 	case "latest":
 		latest, err := updates.GetLatestVersion(ctx, artifactArch)
-		if err != nil {
+		// latest can be nil without an error when no release (or no asset
+		// matching this artifactArch) is found; treat it as an install failure
+		// rather than dereferencing nil.
+		if err != nil || latest == nil {
 			return ErrInstallFailed
 		}
 		desiredVersion = latest.String()

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -143,11 +143,6 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 		return os.Executable()
 	}
 
-	release, asset, err := getReleaseForVersion(ctx, *v, artifactArch, 30*time.Second)
-	if err != nil || release == nil {
-		return "", fmt.Errorf("failed to find release for version %s: %w", v.String(), err)
-	}
-
 	dst, err := getVersionInstallLocation(artifactArch, v)
 	if err != nil {
 		return "", err
@@ -162,7 +157,29 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 	// It's important that these logs remain. We rely on them as part of `run` output
 	log.From(ctx).PrintfStyled(styles.DimmedItalic, "Downloading Speakeasy version %s\n", desiredVersion)
 
+	// Release asset URLs are deterministic, so a known version can be
+	// downloaded without first resolving release metadata through the GitHub
+	// API, whose unauthenticated 60 requests/hour rate limit is easily
+	// exhausted on shared CI runner IPs. Asset downloads are not subject to
+	// that limit. If this fails for any reason, fall back to the API lookup.
+	if err := install(artifactArch, directAssetURL(v, artifactArch), dst, timeout); err == nil {
+		return dst, nil
+	} else {
+		log.From(ctx).Debug(fmt.Sprintf("direct download of version %s failed, falling back to GitHub release lookup: %s", v.String(), err.Error()))
+	}
+
+	release, asset, err := getReleaseForVersion(ctx, *v, artifactArch, 30*time.Second)
+	if err != nil || release == nil {
+		return "", fmt.Errorf("failed to find release for version %s: %w", v.String(), err)
+	}
+
 	return dst, install(artifactArch, asset.GetBrowserDownloadURL(), dst, timeout)
+}
+
+// directAssetURL returns the conventional GitHub release asset URL for a CLI
+// version. Asset names follow the goreleaser convention speakeasy_{os}_{arch}.zip.
+func directAssetURL(v *version.Version, artifactArch string) string {
+	return fmt.Sprintf("https://github.com/speakeasy-api/speakeasy/releases/download/v%s/speakeasy_%s.zip", v.String(), strings.ToLower(artifactArch))
 }
 
 func getVersionInstallLocation(artifactArch string, v *version.Version) (string, error) {
@@ -297,10 +314,38 @@ func install(artifactArch, downloadURL, installLocation string, timeout int) err
 	return nil
 }
 
-func getLatestRelease(ctx context.Context, artifactArch string, timeout time.Duration) (*github.RepositoryRelease, *github.ReleaseAsset, error) {
+// githubClient returns a GitHub API client, authenticated when a token is
+// available in the environment. Unauthenticated requests share a 60/hour rate
+// limit per IP, which shared CI runners exhaust quickly.
+func githubClient(timeout time.Duration) *github.Client {
 	client := github.NewClient(&http.Client{
 		Timeout: timeout,
 	})
+	for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
+		if token := os.Getenv(key); token != "" {
+			return client.WithAuthToken(token)
+		}
+	}
+	return client
+}
+
+// describeGitHubError surfaces rate limiting explicitly: without this, a
+// rate-limited lookup for a pinned version bubbles up as "release not found",
+// which misleadingly points at the version pin rather than the real cause.
+func describeGitHubError(err error) error {
+	var rateLimitErr *github.RateLimitError
+	if errors.As(err, &rateLimitErr) {
+		return fmt.Errorf("GitHub API rate limit exceeded (anonymous requests are limited to 60/hour per IP; set GITHUB_TOKEN to authenticate, or retry after %s): %w", rateLimitErr.Rate.Reset.Format(time.RFC1123), err)
+	}
+	var abuseErr *github.AbuseRateLimitError
+	if errors.As(err, &abuseErr) {
+		return fmt.Errorf("GitHub API rate limit exceeded (secondary limit; set GITHUB_TOKEN to authenticate): %w", err)
+	}
+	return err
+}
+
+func getLatestRelease(ctx context.Context, artifactArch string, timeout time.Duration) (*github.RepositoryRelease, *github.ReleaseAsset, error) {
+	client := githubClient(timeout)
 
 	releaseCache, _ := cache.NewFileCache[ReleaseCache](ctx, cache.CacheSettings{
 		Key:               artifactArch,
@@ -319,7 +364,7 @@ func getLatestRelease(ctx context.Context, artifactArch string, timeout time.Dur
 		var fallbackErr error
 		releases, fallbackErr = fetchReleasesFromFallback(timeout)
 		if fallbackErr != nil {
-			return nil, nil, err // return original error
+			return nil, nil, describeGitHubError(err) // return original error
 		}
 	}
 
@@ -343,9 +388,7 @@ func getLatestRelease(ctx context.Context, artifactArch string, timeout time.Dur
 }
 
 func getReleaseForVersion(ctx context.Context, version version.Version, artifactArch string, timeout time.Duration) (*github.RepositoryRelease, *github.ReleaseAsset, error) {
-	client := github.NewClient(&http.Client{
-		Timeout: timeout,
-	})
+	client := githubClient(timeout)
 
 	tag := "v" + version.String()
 
@@ -364,7 +407,7 @@ func getReleaseForVersion(ctx context.Context, version version.Version, artifact
 			// Fall back to the caching proxy and filter by tag.
 			releases, fallbackErr := fetchReleasesFromFallback(timeout)
 			if fallbackErr != nil {
-				return nil, nil, err // return original error
+				return nil, nil, describeGitHubError(err) // return original error
 			}
 			for _, r := range releases {
 				if r.GetTagName() == tag {
@@ -373,7 +416,10 @@ func getReleaseForVersion(ctx context.Context, version version.Version, artifact
 				}
 			}
 			if release == nil {
-				return nil, nil, fmt.Errorf("release %s not found", tag)
+				// The fallback only serves recent releases, so an older tag
+				// missing from it is not evidence the release doesn't exist.
+				// Preserve the original GitHub error rather than discarding it.
+				return nil, nil, fmt.Errorf("release %s not found in fallback cache (which only holds recent releases); GitHub API lookup failed: %w", tag, describeGitHubError(err))
 			}
 		}
 		_ = cache.Store(release)

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -162,11 +162,11 @@ func InstallVersion(ctx context.Context, desiredVersion, artifactArch string, ti
 	// API, whose unauthenticated 60 requests/hour rate limit is easily
 	// exhausted on shared CI runner IPs. Asset downloads are not subject to
 	// that limit. If this fails for any reason, fall back to the API lookup.
-	if err := install(artifactArch, directAssetURL(v, artifactArch), dst, timeout); err == nil {
+	directErr := install(artifactArch, directAssetURL(v, artifactArch), dst, timeout)
+	if directErr == nil {
 		return dst, nil
-	} else {
-		log.From(ctx).Debug(fmt.Sprintf("direct download of version %s failed, falling back to GitHub release lookup: %s", v.String(), err.Error()))
 	}
+	log.From(ctx).Debug(fmt.Sprintf("direct download of version %s failed, falling back to GitHub release lookup: %s", v.String(), directErr.Error()))
 
 	release, asset, err := getReleaseForVersion(ctx, *v, artifactArch, 30*time.Second)
 	if err != nil || release == nil {
@@ -335,7 +335,12 @@ func githubClient(timeout time.Duration) *github.Client {
 func describeGitHubError(err error) error {
 	var rateLimitErr *github.RateLimitError
 	if errors.As(err, &rateLimitErr) {
-		return fmt.Errorf("GitHub API rate limit exceeded (anonymous requests are limited to 60/hour per IP; set GITHUB_TOKEN to authenticate, or retry after %s): %w", rateLimitErr.Rate.Reset.Format(time.RFC1123), err)
+		remedy := "retry after " + rateLimitErr.Rate.Reset.Format(time.RFC1123)
+		if rateLimitErr.Rate.Limit <= 60 {
+			// The anonymous per-IP limit; authenticating raises it substantially.
+			remedy = "set GITHUB_TOKEN to authenticate, or " + remedy
+		}
+		return fmt.Errorf("GitHub API rate limit exceeded (%d requests/hour; %s): %w", rateLimitErr.Rate.Limit, remedy, err)
 	}
 	var abuseErr *github.AbuseRateLimitError
 	if errors.As(err, &abuseErr) {

--- a/internal/updates/updates.go
+++ b/internal/updates/updates.go
@@ -314,6 +314,16 @@ func install(artifactArch, downloadURL, installLocation string, timeout int) err
 	return nil
 }
 
+// githubToken returns the first GitHub token set in the environment, or "".
+func githubToken() string {
+	for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
+		if token := os.Getenv(key); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
 // githubClient returns a GitHub API client, authenticated when a token is
 // available in the environment. Unauthenticated requests share a 60/hour rate
 // limit per IP, which shared CI runners exhaust quickly.
@@ -321,10 +331,8 @@ func githubClient(timeout time.Duration) *github.Client {
 	client := github.NewClient(&http.Client{
 		Timeout: timeout,
 	})
-	for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
-		if token := os.Getenv(key); token != "" {
-			return client.WithAuthToken(token)
-		}
+	if token := githubToken(); token != "" {
+		return client.WithAuthToken(token)
 	}
 	return client
 }
@@ -344,7 +352,19 @@ func describeGitHubError(err error) error {
 	}
 	var abuseErr *github.AbuseRateLimitError
 	if errors.As(err, &abuseErr) {
-		return fmt.Errorf("GitHub API rate limit exceeded (secondary limit; set GITHUB_TOKEN to authenticate): %w", err)
+		// Secondary limits can hit authenticated clients too, so only suggest a
+		// token when the request was actually anonymous.
+		var remedies []string
+		if githubToken() == "" {
+			remedies = append(remedies, "set GITHUB_TOKEN to authenticate")
+		}
+		if abuseErr.RetryAfter != nil {
+			remedies = append(remedies, "retry after "+abuseErr.RetryAfter.String())
+		}
+		if len(remedies) > 0 {
+			return fmt.Errorf("GitHub API rate limit exceeded (secondary limit; %s): %w", strings.Join(remedies, ", or "), err)
+		}
+		return fmt.Errorf("GitHub API rate limit exceeded (secondary limit): %w", err)
 	}
 	return err
 }

--- a/internal/updates/updates_manual_test.go
+++ b/internal/updates/updates_manual_test.go
@@ -1,0 +1,120 @@
+//go:build manual
+
+package updates
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/speakeasy-api/speakeasy-core/events"
+)
+
+// These tests exercise InstallVersion end-to-end against real GitHub
+// infrastructure and are gated behind the "manual" build tag:
+//
+//	go test -tags manual ./internal/updates/ -run TestManual -v
+//
+// They simulate a rate-limited/unreachable GitHub API by replacing
+// http.DefaultTransport (which all clients in this package use, having no
+// explicit Transport) with one that rejects requests to api.github.com and
+// the Speakeasy caching proxy while counting the attempts. A successful
+// install with zero blocked attempts proves the direct-URL fast path has no
+// dependency on either.
+
+// testContext mirrors what cmd/root.go always does at startup: stamp the
+// running CLI version into the context. InstallVersion reads it for the
+// version-equality short-circuit.
+func testContext() context.Context {
+	return events.SetSpeakeasyVersionInContext(context.Background(), "0.0.1")
+}
+
+func testArtifactArch() string {
+	return runtime.GOOS + "_" + runtime.GOARCH
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) { return f(r) }
+
+// blockAPIHosts fails any request to the GitHub API or the Speakeasy caching
+// proxy and returns a counter of blocked attempts.
+func blockAPIHosts(t *testing.T) *atomic.Int64 {
+	t.Helper()
+	var attempts atomic.Int64
+	original := http.DefaultTransport
+	http.DefaultTransport = roundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		host := r.URL.Hostname()
+		if host == "api.github.com" || host == "cli-releases.speakeasy.com" {
+			attempts.Add(1)
+			return nil, fmt.Errorf("test harness: blocked request to %s (simulating rate limit)", host)
+		}
+		return original.RoundTrip(r)
+	})
+	t.Cleanup(func() { http.DefaultTransport = original })
+	return &attempts
+}
+
+func TestManualInstallPinnedVersionWithAPIUnreachable(t *testing.T) {
+	apiAttempts := blockAPIHosts(t)
+
+	// A version old enough to fall outside the caching proxy's ~30-release
+	// window, so neither the GitHub API nor the proxy could have served it.
+	const pinnedVersion = "1.773.1"
+
+	// Remove any cached install so the download path actually runs.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_ = os.RemoveAll(filepath.Join(home, ".speakeasy", pinnedVersion))
+
+	dst, err := InstallVersion(testContext(), pinnedVersion, testArtifactArch(), 120)
+	if err != nil {
+		t.Fatalf("InstallVersion failed with API blocked — direct-URL fast path did not engage: %v", err)
+	}
+
+	if n := apiAttempts.Load(); n != 0 {
+		t.Fatalf("expected zero GitHub API / caching proxy requests, but %d were attempted", n)
+	}
+
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatalf("installed binary missing at %s: %v", dst, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Fatalf("installed binary at %s is not executable", dst)
+	}
+
+	out, err := exec.Command(dst, "--version").CombinedOutput()
+	if err != nil {
+		t.Fatalf("installed binary failed to run: %v\n%s", err, out)
+	}
+	if !strings.Contains(string(out), pinnedVersion) {
+		t.Fatalf("installed binary reports wrong version: %s", out)
+	}
+	t.Logf("installed %s with zero API requests and verified: %s", dst, strings.TrimSpace(string(out)))
+}
+
+func TestManualNonexistentVersionFallsBackAndErrors(t *testing.T) {
+	apiAttempts := blockAPIHosts(t)
+
+	_, err := InstallVersion(testContext(), "9.999.999", testArtifactArch(), 30)
+	if err == nil {
+		t.Fatal("expected error for nonexistent version")
+	}
+	if !strings.Contains(err.Error(), "failed to find release for version 9.999.999") {
+		t.Fatalf("unexpected error shape: %v", err)
+	}
+	if apiAttempts.Load() == 0 {
+		t.Fatal("expected the fallback chain to attempt the GitHub API after the direct download failed")
+	}
+	t.Logf("fallback chain engaged as expected (%d blocked API attempts): %v", apiAttempts.Load(), err)
+}

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestDirectAssetURL(t *testing.T) {
+	t.Parallel()
 	tests := []struct {
 		name         string
 		version      string
@@ -47,6 +48,7 @@ func TestDirectAssetURL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 			v, err := version.NewVersion(tt.version)
 			if err != nil {
 				t.Fatalf("version.NewVersion(%q): %v", tt.version, err)
@@ -58,6 +60,10 @@ func TestDirectAssetURL(t *testing.T) {
 	}
 }
 
+// describeGitHubError reads the token env vars, so subtests control them with
+// t.Setenv, which is incompatible with t.Parallel (including on this parent).
+//
+//nolint:paralleltest
 func TestDescribeGitHubError(t *testing.T) {
 	t.Run("rate limit error mentions rate limiting and GITHUB_TOKEN", func(t *testing.T) {
 		rateLimitErr := &github.RateLimitError{
@@ -128,6 +134,7 @@ func TestDescribeGitHubError(t *testing.T) {
 
 	t.Run("other errors pass through unchanged", func(t *testing.T) {
 		orig := errors.New("connection refused")
+		//nolint:errorlint // identity comparison is the point: the error must pass through unwrapped
 		if got := describeGitHubError(orig); got != orig {
 			t.Errorf("expected passthrough, got: %v", got)
 		}
@@ -174,6 +181,7 @@ func TestGithubClientTokenSelection(t *testing.T) {
 		return recorder.lastAuthHeader
 	}
 
+	//nolint:paralleltest // clearGitHubTokenEnv uses t.Setenv, which is incompatible with t.Parallel
 	t.Run("no token env vars yields unauthenticated requests", func(t *testing.T) {
 		clearGitHubTokenEnv(t)
 		if got := sentAuthHeader(t); got != "" {

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -106,9 +106,23 @@ func TestDescribeGitHubError(t *testing.T) {
 	})
 
 	t.Run("abuse rate limit error mentions GITHUB_TOKEN", func(t *testing.T) {
+		clearGitHubTokenEnv(t)
 		got := describeGitHubError(&github.AbuseRateLimitError{Message: "abuse"})
 		if !strings.Contains(got.Error(), "GITHUB_TOKEN") {
 			t.Errorf("expected error to mention GITHUB_TOKEN, got: %v", got)
+		}
+	})
+
+	t.Run("authenticated abuse rate limit reports retry delay without suggesting GITHUB_TOKEN", func(t *testing.T) {
+		clearGitHubTokenEnv(t)
+		t.Setenv("GITHUB_TOKEN", "github-token")
+		retryAfter := 2 * time.Minute
+		got := describeGitHubError(&github.AbuseRateLimitError{Message: "abuse", RetryAfter: &retryAfter})
+		if !strings.Contains(got.Error(), "retry after 2m0s") {
+			t.Errorf("expected error to report the retry delay, got: %v", got)
+		}
+		if strings.Contains(got.Error(), "GITHUB_TOKEN") {
+			t.Errorf("expected no GITHUB_TOKEN suggestion when already authenticated, got: %v", got)
 		}
 	})
 
@@ -118,6 +132,15 @@ func TestDescribeGitHubError(t *testing.T) {
 			t.Errorf("expected passthrough, got: %v", got)
 		}
 	})
+}
+
+// clearGitHubTokenEnv unsets every token env var githubToken consults, so a
+// token in the test environment can't leak into token-sensitive assertions.
+func clearGitHubTokenEnv(t *testing.T) {
+	t.Helper()
+	for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
+		t.Setenv(key, "")
+	}
 }
 
 // recordingTransport captures the Authorization header of each request and
@@ -151,22 +174,15 @@ func TestGithubClientTokenSelection(t *testing.T) {
 		return recorder.lastAuthHeader
 	}
 
-	clearTokenEnv := func(t *testing.T) {
-		t.Helper()
-		for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
-			t.Setenv(key, "")
-		}
-	}
-
 	t.Run("no token env vars yields unauthenticated requests", func(t *testing.T) {
-		clearTokenEnv(t)
+		clearGitHubTokenEnv(t)
 		if got := sentAuthHeader(t); got != "" {
 			t.Errorf("expected no Authorization header, got %q", got)
 		}
 	})
 
 	t.Run("SPEAKEASY_GITHUB_TOKEN takes precedence over GITHUB_TOKEN and GH_TOKEN", func(t *testing.T) {
-		clearTokenEnv(t)
+		clearGitHubTokenEnv(t)
 		t.Setenv("SPEAKEASY_GITHUB_TOKEN", "speakeasy-token")
 		t.Setenv("GITHUB_TOKEN", "github-token")
 		t.Setenv("GH_TOKEN", "gh-token")
@@ -176,7 +192,7 @@ func TestGithubClientTokenSelection(t *testing.T) {
 	})
 
 	t.Run("GITHUB_TOKEN takes precedence over GH_TOKEN", func(t *testing.T) {
-		clearTokenEnv(t)
+		clearGitHubTokenEnv(t)
 		t.Setenv("GITHUB_TOKEN", "github-token")
 		t.Setenv("GH_TOKEN", "gh-token")
 		if got := sentAuthHeader(t); got != "Bearer github-token" {
@@ -185,7 +201,7 @@ func TestGithubClientTokenSelection(t *testing.T) {
 	})
 
 	t.Run("GH_TOKEN is honored when others are unset", func(t *testing.T) {
-		clearTokenEnv(t)
+		clearGitHubTokenEnv(t)
 		t.Setenv("GH_TOKEN", "gh-token")
 		if got := sentAuthHeader(t); got != "Bearer gh-token" {
 			t.Errorf("expected GH_TOKEN to be used, got Authorization %q", got)

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -80,6 +80,24 @@ func TestDescribeGitHubError(t *testing.T) {
 		}
 	})
 
+	t.Run("authenticated rate limit reports actual limit without suggesting GITHUB_TOKEN", func(t *testing.T) {
+		rateLimitErr := &github.RateLimitError{
+			Rate: github.Rate{
+				Limit:     5000,
+				Remaining: 0,
+				Reset:     github.Timestamp{Time: time.Now().Add(30 * time.Minute)},
+			},
+			Message: "API rate limit exceeded",
+		}
+		got := describeGitHubError(rateLimitErr)
+		if !strings.Contains(got.Error(), "5000 requests/hour") {
+			t.Errorf("expected error to report the actual limit, got: %v", got)
+		}
+		if strings.Contains(got.Error(), "GITHUB_TOKEN") {
+			t.Errorf("expected no GITHUB_TOKEN suggestion when already authenticated, got: %v", got)
+		}
+	})
+
 	t.Run("wrapped rate limit error is still detected", func(t *testing.T) {
 		wrapped := fmt.Errorf("outer: %w", &github.RateLimitError{})
 		if !strings.Contains(describeGitHubError(wrapped).Error(), "rate limit") {

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -1,0 +1,135 @@
+package updates
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/go-github/v63/github"
+	"github.com/hashicorp/go-version"
+)
+
+func TestDirectAssetURL(t *testing.T) {
+	tests := []struct {
+		name         string
+		version      string
+		artifactArch string
+		want         string
+	}{
+		{
+			name:         "linux amd64",
+			version:      "1.773.1",
+			artifactArch: "linux_amd64",
+			want:         "https://github.com/speakeasy-api/speakeasy/releases/download/v1.773.1/speakeasy_linux_amd64.zip",
+		},
+		{
+			name:         "darwin arm64",
+			version:      "1.256.0",
+			artifactArch: "darwin_arm64",
+			want:         "https://github.com/speakeasy-api/speakeasy/releases/download/v1.256.0/speakeasy_darwin_arm64.zip",
+		},
+		{
+			name:         "arch is lowercased",
+			version:      "1.500.0",
+			artifactArch: "Windows_AMD64",
+			want:         "https://github.com/speakeasy-api/speakeasy/releases/download/v1.500.0/speakeasy_windows_amd64.zip",
+		},
+		{
+			name:         "v prefix in input is normalized",
+			version:      "v1.773.1",
+			artifactArch: "linux_amd64",
+			want:         "https://github.com/speakeasy-api/speakeasy/releases/download/v1.773.1/speakeasy_linux_amd64.zip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			v, err := version.NewVersion(tt.version)
+			if err != nil {
+				t.Fatalf("version.NewVersion(%q): %v", tt.version, err)
+			}
+			if got := directAssetURL(v, tt.artifactArch); got != tt.want {
+				t.Errorf("directAssetURL() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDescribeGitHubError(t *testing.T) {
+	t.Run("rate limit error mentions rate limiting and GITHUB_TOKEN", func(t *testing.T) {
+		rateLimitErr := &github.RateLimitError{
+			Rate: github.Rate{
+				Limit:     60,
+				Remaining: 0,
+				Reset:     github.Timestamp{Time: time.Now().Add(30 * time.Minute)},
+			},
+			Message: "API rate limit exceeded",
+		}
+		got := describeGitHubError(rateLimitErr)
+		if !strings.Contains(got.Error(), "rate limit") {
+			t.Errorf("expected error to mention rate limiting, got: %v", got)
+		}
+		if !strings.Contains(got.Error(), "GITHUB_TOKEN") {
+			t.Errorf("expected error to mention GITHUB_TOKEN, got: %v", got)
+		}
+		if !errors.As(got, new(*github.RateLimitError)) {
+			t.Errorf("expected original error to remain unwrappable, got: %v", got)
+		}
+	})
+
+	t.Run("wrapped rate limit error is still detected", func(t *testing.T) {
+		wrapped := fmt.Errorf("outer: %w", &github.RateLimitError{})
+		if !strings.Contains(describeGitHubError(wrapped).Error(), "rate limit") {
+			t.Errorf("expected wrapped rate limit error to be detected")
+		}
+	})
+
+	t.Run("abuse rate limit error mentions GITHUB_TOKEN", func(t *testing.T) {
+		got := describeGitHubError(&github.AbuseRateLimitError{Message: "abuse"})
+		if !strings.Contains(got.Error(), "GITHUB_TOKEN") {
+			t.Errorf("expected error to mention GITHUB_TOKEN, got: %v", got)
+		}
+	})
+
+	t.Run("other errors pass through unchanged", func(t *testing.T) {
+		orig := errors.New("connection refused")
+		if got := describeGitHubError(orig); got != orig {
+			t.Errorf("expected passthrough, got: %v", got)
+		}
+	})
+}
+
+func TestGithubClientTokenSelection(t *testing.T) {
+	t.Run("no token env vars yields unauthenticated client", func(t *testing.T) {
+		for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
+			t.Setenv(key, "")
+		}
+		client := githubClient(time.Second)
+		if _, ok := client.Client().Transport.(*http.Transport); client.Client().Transport != nil && !ok {
+			t.Errorf("expected default transport when no token is set, got %T", client.Client().Transport)
+		}
+	})
+
+	t.Run("SPEAKEASY_GITHUB_TOKEN takes precedence", func(t *testing.T) {
+		t.Setenv("SPEAKEASY_GITHUB_TOKEN", "speakeasy-token")
+		t.Setenv("GITHUB_TOKEN", "github-token")
+		client := githubClient(time.Second)
+		if client.Client().Transport == nil {
+			t.Fatalf("expected auth transport to be installed when token env var is set")
+		}
+	})
+
+	t.Run("GH_TOKEN is honored when others are unset", func(t *testing.T) {
+		for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN"} {
+			t.Setenv(key, "")
+		}
+		t.Setenv("GH_TOKEN", "gh-token")
+		client := githubClient(time.Second)
+		if client.Client().Transport == nil {
+			t.Fatalf("expected auth transport to be installed when GH_TOKEN is set")
+		}
+	})
+}

--- a/internal/updates/updates_test.go
+++ b/internal/updates/updates_test.go
@@ -102,34 +102,75 @@ func TestDescribeGitHubError(t *testing.T) {
 	})
 }
 
+// recordingTransport captures the Authorization header of each request and
+// returns a canned response without touching the network.
+type recordingTransport struct {
+	lastAuthHeader string
+}
+
+func (rt *recordingTransport) RoundTrip(r *http.Request) (*http.Response, error) {
+	rt.lastAuthHeader = r.Header.Get("Authorization")
+	return &http.Response{StatusCode: http.StatusNoContent, Body: http.NoBody, Request: r}, nil
+}
+
 func TestGithubClientTokenSelection(t *testing.T) {
-	t.Run("no token env vars yields unauthenticated client", func(t *testing.T) {
+	// githubClient builds its client with a nil Transport, so WithAuthToken
+	// wraps http.DefaultTransport. Swap in a recorder to observe which token
+	// (if any) is actually sent.
+	recorder := &recordingTransport{}
+	original := http.DefaultTransport
+	http.DefaultTransport = recorder
+	t.Cleanup(func() { http.DefaultTransport = original })
+
+	sentAuthHeader := func(t *testing.T) string {
+		t.Helper()
+		client := githubClient(time.Second)
+		resp, err := client.Client().Get("https://api.github.com/rate_limit")
+		if err != nil {
+			t.Fatalf("stubbed request failed: %v", err)
+		}
+		resp.Body.Close()
+		return recorder.lastAuthHeader
+	}
+
+	clearTokenEnv := func(t *testing.T) {
+		t.Helper()
 		for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"} {
 			t.Setenv(key, "")
 		}
-		client := githubClient(time.Second)
-		if _, ok := client.Client().Transport.(*http.Transport); client.Client().Transport != nil && !ok {
-			t.Errorf("expected default transport when no token is set, got %T", client.Client().Transport)
+	}
+
+	t.Run("no token env vars yields unauthenticated requests", func(t *testing.T) {
+		clearTokenEnv(t)
+		if got := sentAuthHeader(t); got != "" {
+			t.Errorf("expected no Authorization header, got %q", got)
 		}
 	})
 
-	t.Run("SPEAKEASY_GITHUB_TOKEN takes precedence", func(t *testing.T) {
+	t.Run("SPEAKEASY_GITHUB_TOKEN takes precedence over GITHUB_TOKEN and GH_TOKEN", func(t *testing.T) {
+		clearTokenEnv(t)
 		t.Setenv("SPEAKEASY_GITHUB_TOKEN", "speakeasy-token")
 		t.Setenv("GITHUB_TOKEN", "github-token")
-		client := githubClient(time.Second)
-		if client.Client().Transport == nil {
-			t.Fatalf("expected auth transport to be installed when token env var is set")
+		t.Setenv("GH_TOKEN", "gh-token")
+		if got := sentAuthHeader(t); got != "Bearer speakeasy-token" {
+			t.Errorf("expected SPEAKEASY_GITHUB_TOKEN to win, got Authorization %q", got)
+		}
+	})
+
+	t.Run("GITHUB_TOKEN takes precedence over GH_TOKEN", func(t *testing.T) {
+		clearTokenEnv(t)
+		t.Setenv("GITHUB_TOKEN", "github-token")
+		t.Setenv("GH_TOKEN", "gh-token")
+		if got := sentAuthHeader(t); got != "Bearer github-token" {
+			t.Errorf("expected GITHUB_TOKEN to win, got Authorization %q", got)
 		}
 	})
 
 	t.Run("GH_TOKEN is honored when others are unset", func(t *testing.T) {
-		for _, key := range []string{"SPEAKEASY_GITHUB_TOKEN", "GITHUB_TOKEN"} {
-			t.Setenv(key, "")
-		}
+		clearTokenEnv(t)
 		t.Setenv("GH_TOKEN", "gh-token")
-		client := githubClient(time.Second)
-		if client.Client().Transport == nil {
-			t.Fatalf("expected auth transport to be installed when GH_TOKEN is set")
+		if got := sentAuthHeader(t); got != "Bearer gh-token" {
+			t.Errorf("expected GH_TOKEN to be used, got Authorization %q", got)
 		}
 	})
 }


### PR DESCRIPTION
## Problem

When `workflow.yaml` pins a `speakeasyVersion`, the CLI resolves the release through the unauthenticated GitHub REST API — 60 requests/hour per IP. On shared CI runner IPs this gets rate limited routinely. The fallback caching proxy only holds the ~30 most recent releases, so older pins miss it, and the CLI then prints a non-breaking warning and silently proceeds with the locally installed version:

```
Failed to download latest Speakeasy version: failed to install Speakeasy version -- failed to find release for version 1.773.1: release v1.773.1 not found
Running with local version. This might result in inconsistencies between environments
```

Generating with an unpinned version produces spurious diffs that fail downstream up-to-date CI checks, and the "release not found" wording misleadingly points at the version pin rather than rate limiting.

Fixes GEN-3165.

## Fix

**Core change — remove the rate-limited call from the pinned path entirely.** Release asset URLs are deterministic (`releases/download/v{ver}/speakeasy_{arch}.zip`, stable across the full release history), so `InstallVersion` now:

1. checks for an existing on-disk install **before** any network call (previously the API lookup ran first, so even a fully cached install failed when rate limited);
2. attempts the direct asset URL — asset downloads are not subject to the API rate limit, and `downloadCLI`'s existing per-tag proxy fallback still applies to this attempt;
3. only on failure falls through to the existing API lookup, unchanged, with a debug log recording the fast-path miss so a naming regression would be observable rather than silently degrading.

Worst case is by construction the current behavior.

**Riders:**

- GitHub API clients honor `SPEAKEASY_GITHUB_TOKEN` / `GITHUB_TOKEN` / `GH_TOKEN` via `WithAuthToken`, raising the limit for the paths that still need the API (`latest` resolution, update checks).
- Rate-limited lookups now say so explicitly (limit, remedy, reset time) instead of surfacing "release not found", and the original API error is preserved when the fallback cache misses instead of being discarded.
- `SPEAKEASY_FAIL_ON_VERSION_MISMATCH=true` turns the silent local-version fallback into a hard error, for CI environments that require the pin (env var rather than a flag so it is never passed to older re-exec'd binaries that would reject it).
- Guarded a nil dereference when `latest` resolution returns no release or no asset matching the artifact arch.

## Testing

- Unit tests (run in CI): asset URL construction, rate-limit error detection (direct/wrapped/abuse/passthrough), token precedence.
- Manual e2e tests (`go test -tags manual ./internal/updates/ -run TestManual -v`): replace `http.DefaultTransport` with one that **blocks and counts** requests to `api.github.com` and the caching proxy. Verified: a pinned install of v1.773.1 (older than the proxy window) succeeds with **zero** API attempts and the installed binary reports the correct version; a nonexistent version 404s on the direct URL, engages the fallback chain (blocked attempts observed), and errors cleanly.
- `go build ./...`, `go vet`, and existing package tests pass.

Suggested pre-release canary: one `speakeasy run` in a real pinned-version SDK repo via GitHub Actions (temp-dir install path, the one codepath materially different from local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned CLI installs now use direct GitHub release asset URLs to avoid API rate limits and stop silent fallback to a different local version in CI. Aligns with GEN-3165 by authenticating GitHub requests and making failures explicit.

- **New Features**
  - Download pinned versions via deterministic asset URL; only fall back to the GitHub API if needed.
  - Use authenticated GitHub client when `SPEAKEASY_GITHUB_TOKEN`, `GITHUB_TOKEN`, or `GH_TOKEN` is set.
  - `SPEAKEASY_FAIL_ON_VERSION_MISMATCH=true` to fail instead of falling back to a local version.
  - Added unit tests and a manual e2e test to verify the zero-API fast path; tests confirm token precedence and Authorization header behavior.

- **Bug Fixes**
  - Rate-limit errors now report the actual limit and reset time; include Retry-After for secondary limits and only suggest `GITHUB_TOKEN` when unauthenticated; preserve the original API error when the proxy misses.
  - Wrap `latest` resolution errors in `ErrInstallFailed` so rate-limit guidance surfaces; treat missing `latest` release/asset as an install failure.
  - Simplified the hard-fail message when `SPEAKEASY_FAIL_ON_VERSION_MISMATCH` is set.
  - Tests: parallelize pure cases and satisfy `paralleltest`/`errorlint`; no runtime changes.

<sup>Written for commit 6b5a53a27625d466ba57440f634740c2bb486894. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2111?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

