### PR TITLE
fix(validation): provide direct generation access context

### DIFF
--- a/internal/validation/generation_context_test.go
+++ b/internal/validation/generation_context_test.go
@@ -11,7 +11,11 @@ import (
 )
 
 func TestWithValidationGenerationContext(t *testing.T) {
+	t.Parallel()
+
 	t.Run("adds direct access when caller state is absent", func(t *testing.T) {
+		t.Parallel()
+
 		ctx := withValidationGenerationContext(context.Background())
 
 		state, ok := generationaccess.StateFromContext(ctx)
@@ -20,6 +24,8 @@ func TestWithValidationGenerationContext(t *testing.T) {
 	})
 
 	t.Run("preserves caller-supplied authenticated access", func(t *testing.T) {
+		t.Parallel()
+
 		createdAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
 		original, err := generationaccess.WithAuthenticated(context.Background(), generationaccess.AuthenticatedInfo{
 			AccountType:        shared.AccountTypeBusiness,

--- a/internal/validation/generation_context_test.go
+++ b/internal/validation/generation_context_test.go
@@ -1,0 +1,46 @@
+package validation
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	generationaccess "github.com/speakeasy-api/generation-context/access"
+	"github.com/speakeasy-api/speakeasy-client-sdk-go/v3/pkg/models/shared"
+	"github.com/stretchr/testify/require"
+)
+
+func TestWithValidationGenerationContext(t *testing.T) {
+	t.Run("adds direct access when caller state is absent", func(t *testing.T) {
+		ctx := withValidationGenerationContext(context.Background())
+
+		state, ok := generationaccess.StateFromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, generationaccess.ModeDirect, state.Mode())
+	})
+
+	t.Run("preserves caller-supplied authenticated access", func(t *testing.T) {
+		createdAt := time.Date(2024, time.January, 2, 3, 4, 5, 0, time.UTC)
+		original, err := generationaccess.WithAuthenticated(context.Background(), generationaccess.AuthenticatedInfo{
+			AccountType:        shared.AccountTypeBusiness,
+			WorkspaceID:        "validation-test-workspace",
+			WorkspaceCreatedAt: &createdAt,
+			GeneratedLicense:   generationaccess.GeneratedLicenseCommercial,
+		})
+		require.NoError(t, err)
+
+		ctx := withValidationGenerationContext(original)
+
+		state, ok := generationaccess.StateFromContext(ctx)
+		require.True(t, ok)
+		require.Equal(t, generationaccess.ModeAuthenticated, state.Mode())
+		require.Equal(t, generationaccess.GeneratedLicenseCommercial, state.GeneratedLicense())
+		accountType, ok := state.AccountType()
+		require.True(t, ok)
+		require.Equal(t, shared.AccountTypeBusiness, accountType)
+		workspaceID, ok := state.WorkspaceID()
+		require.True(t, ok)
+		require.Equal(t, "validation-test-workspace", workspaceID)
+		require.Equal(t, &createdAt, state.WorkspaceCreatedAt())
+	})
+}

--- a/internal/validation/openapi.go
+++ b/internal/validation/openapi.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/speakeasy-api/sdk-gen-config/lint"
 
+	generationaccess "github.com/speakeasy-api/generation-context/access"
 	"github.com/speakeasy-api/speakeasy-core/openapi"
 
 	"github.com/speakeasy-api/speakeasy/internal/reports"
@@ -254,8 +255,20 @@ func getDetailedView(lines []string, err errors.ValidationError) string {
 	return sb.String()
 }
 
+func withValidationGenerationContext(ctx context.Context) context.Context {
+	if _, ok := generationaccess.StateFromContext(ctx); ok {
+		return ctx
+	}
+
+	// Validation is available without authentication, so it runs in direct OSS
+	// mode when no caller-supplied generation access state exists.
+	return generationaccess.WithDirect(ctx)
+}
+
 // Validate returns (validation errors, validation warnings, validation info, error)
 func Validate(ctx context.Context, outputLogger log.Logger, schema []byte, schemaPath string, limits *OutputLimits, isRemote bool, defaultRuleset, workingDir string, parseValidOperations bool, skipGenerateReport bool, target string) (*ValidationResult, error) {
+	ctx = withValidationGenerationContext(ctx)
+
 	l := log.From(ctx).WithFormatter(log.PrefixedFormatter)
 
 	opts := []generate.GeneratorOptions{


### PR DESCRIPTION
## Why

`speakeasy lint openapi` can invoke generator validation without a generation-access state. After generation access became mandatory, this caused validation to fail before it could lint the document:

```text
generation access state is required; use generation-context/access.WithDirect or WithAuthenticated
```

## What changed

- Supply direct generation access when validation receives a context with no access state.
- Preserve caller-supplied authenticated access state so licensed generation behavior is unchanged.
- Add focused coverage for both context paths.

## Testing

- `go test ./internal/validation -count=1`
- `go test ./cmd/lint -count=1`
- `gofmt -d internal/validation/openapi.go internal/validation/generation_context_test.go`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure validation always runs with a generation-access state to prevent early failures from `speakeasy lint openapi`. Previously validation failed without access; now it defaults to direct OSS mode when no state exists and preserves any authenticated access.

- Injects direct access via `generationaccess.WithDirect` when `generationaccess.StateFromContext` is absent; leaves authenticated state unchanged.
- Applies context setup at the start of `Validate`; adds parallel tests in `internal/validation/generation_context_test.go`.

<sup>Written for commit f458a28972bba9a8730ff89036a8c3ac8d42ef7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

