### PR TITLE
feat(java): AutoCloseable OkHttp SDKs; fix(terraform): hoisted any-typed oneOf fields; fix(csharp): NRE on null response content; fix(all): concurrent OAuth2 flows, primitive-only union path params, CVE bumps

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ replace github.com/dop251/goja => github.com/speakeasy-api/goja v0.0.0-202602230
 replace github.com/dop251/goja/debugger => github.com/speakeasy-api/goja/debugger v0.0.0-20260223084236-ed0328a0a462
 
 // Keep this version aligned with the canonical require below; update both through scripts/upgrade.bash.
-replace github.com/speakeasy-api/openapi-generation/v2 => github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0
+replace github.com/speakeasy-api/openapi-generation/v2 => github.com/speakeasy-api/openapi-generation-next/v2 v2.930.1
 
 require (
 	github.com/KimMachineGun/automemlimit v0.7.5
@@ -50,7 +50,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.23.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.928.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.930.1
 	github.com/speakeasy-api/sdk-gen-config v1.57.1
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.26.7

--- a/go.sum
+++ b/go.sum
@@ -548,8 +548,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.23.0 h1:BlnHqUR/8uIs4tp3d2B4QDN03gw1/QY2R2MHg6fLhRU=
 github.com/speakeasy-api/openapi v1.23.0/go.mod h1:Ih+ZzaTCCPyB2ykiDXaxhqk6jsY84ke3n5p6fobMDXk=
-github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0 h1:jKeib5ha8PlnctCgsIJUYx/z+ZH35NVUifxbQ5zObls=
-github.com/speakeasy-api/openapi-generation-next/v2 v2.928.0/go.mod h1:VoPI9mXvW1JZ1IyMyu0L79/rcwp2JYi2e1xymslrpXo=
+github.com/speakeasy-api/openapi-generation-next/v2 v2.930.1 h1:KmHIY6Ugy0fzcH62nTMqzD4vFOIFd6BEZ4Thf/5fvNA=
+github.com/speakeasy-api/openapi-generation-next/v2 v2.930.1/go.mod h1:kKO9vrzms+3gwZJLxzh7SFa1fftqZjzSL3lR/lq8dZA=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.57.1 h1:s0r+utcuSnJqbWxor7wYMGVzj7lRxp+HGYCGRBO0/uk=


### PR DESCRIPTION
Upgrades `openapi-generation` from `v2.928.0` to `v2.930.1`.

## Core
- [Support concurrent OAuth2 flows — client credentials and password grants no longer clash when configured together](https://github.com/speakeasy-api/openapi-generation-next/pull/21)
- [Collapse primitive-only unions in path parameters instead of dropping the operation](https://github.com/speakeasy-api/openapi-generation-next/pull/30)
- [Add AGPL licensing to direct SDK generation](https://github.com/speakeasy-api/openapi-generation-next/pull/24)

## Java
- [Make OkHttp SDKs `AutoCloseable`, close clients on Spring shutdown, and require compatible public close methods on custom clients](https://github.com/speakeasy-api/openapi-generation-next/pull/32)

## C#
- [Prevent `NullReferenceException` on netstandard2.0 when `HttpResponseMessage.Content` is null](https://github.com/speakeasy-api/openapi-generation-next/pull/13)

## Terraform
- [Ensure hoisted any-typed `oneOf` fields are populated after apply and plan without drift](https://github.com/speakeasy-api/openapi-generation-next/pull/28)
- [Bump `x/net` security pin to v0.56.0](https://github.com/speakeasy-api/openapi-generation-next/pull/19)

## PHP
- [Raise Guzzle floor to ^7.15.2](https://github.com/speakeasy-api/openapi-generation-next/pull/19)

## TypeScript
- [Patch js-yaml, nanoid, ip-address, fast-uri and brace-expansion advisories, and raise hono/body-parser overrides to patched versions (MCP TypeScript)](https://github.com/speakeasy-api/openapi-generation-next/pull/19)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades `github.com/speakeasy-api/openapi-generation-next/v2` to v2.930.1 to fix OAuth2 flow conflicts, stabilize path param unions, harden SDKs, and apply security patches. This reduces auth misconfigurations, eliminates drift and NREs, and tightens dependency posture.

- Concurrent OAuth2 flows: client credentials and password grants no longer clash when configured together.
- Path params: primitive-only unions are collapsed instead of dropping the operation.
- Java: OkHttp SDKs implement `AutoCloseable`, are closed on Spring shutdown, and custom clients must expose a compatible public `close()` method.
- C#: prevent `NullReferenceException` when `HttpResponseMessage.Content` is null on `netstandard2.0`.
- Terraform: hoisted any-typed `oneOf` fields populate correctly after plan/apply, avoiding drift.
- Security and licensing: bump `golang.org/x/net` to v0.56.0; patch `js-yaml`, `nanoid`, `ip-address`, `fast-uri`, `brace-expansion`; raise overrides for `@hono` and `body-parser`; raise PHP `guzzlehttp/guzzle` floor to ^7.15.2; add AGPL licensing to direct SDK generation.

**Migration**
- Java: if supplying a custom OkHttp client, ensure it implements `AutoCloseable` or provides a public `close()` method.
- Compliance: verify AGPL obligations if using direct SDK generation.

<sup>Written for commit b74703b48b27755109389ca279f639c0f6671ba1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2114?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

