### PR TITLE
fix(overlay): keep folded block scalars stable across repeated applies

### DIFF
--- a/pkg/overlay/foldedscalar.go
+++ b/pkg/overlay/foldedscalar.go
@@ -1,0 +1,36 @@
+package overlay
+
+import (
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Block indentation is stripped on decode, so leading whitespace means more-indented.
+func hasMoreIndentedLine(value string) bool {
+	for _, line := range strings.Split(value, "\n") {
+		if line == "" {
+			continue
+		}
+		if line[0] == ' ' || line[0] == '\t' {
+			return true
+		}
+	}
+
+	return false
+}
+
+// yaml.v3 injects a line break before more-indented lines in folded scalars on every encode; literal blocks round trip unchanged.
+func stabilizeFoldedScalars(node *yaml.Node) {
+	if node == nil {
+		return
+	}
+
+	if node.Kind == yaml.ScalarNode && node.Style == yaml.FoldedStyle && hasMoreIndentedLine(node.Value) {
+		node.Style = yaml.LiteralStyle
+	}
+
+	for _, child := range node.Content {
+		stabilizeFoldedScalars(child)
+	}
+}

--- a/pkg/overlay/foldedscalar_test.go
+++ b/pkg/overlay/foldedscalar_test.go
@@ -1,0 +1,127 @@
+package overlay
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const foldedWithMoreIndentedLine = `description: >-
+  ### Authorization
+
+  | Type | Scopes |
+  | ---- | ------ |
+   | Organization | ` + "`manage_passwords`" + ` |
+`
+
+func roundTrip(t *testing.T, doc string, stabilize bool) string {
+	t.Helper()
+
+	var node yaml.Node
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &node))
+
+	if stabilize {
+		stabilizeFoldedScalars(&node)
+	}
+
+	out, err := yaml.Marshal(&node)
+	require.NoError(t, err)
+
+	return string(out)
+}
+
+func decodeDescription(t *testing.T, doc string) string {
+	t.Helper()
+
+	var decoded struct {
+		Description string `yaml:"description"`
+	}
+	require.NoError(t, yaml.Unmarshal([]byte(doc), &decoded))
+
+	return decoded.Description
+}
+
+func TestStabilizeFoldedScalarsSurvivesRepeatedApplies(t *testing.T) {
+	t.Parallel()
+
+	want := decodeDescription(t, foldedWithMoreIndentedLine)
+
+	doc := foldedWithMoreIndentedLine
+	for i := range 30 {
+		doc = roundTrip(t, doc, true)
+		assert.Equal(t, want, decodeDescription(t, doc), "value changed after %d applies", i+1)
+	}
+}
+
+// Fails once gopkg.in/yaml.v3 fixes the emitter, at which point stabilizeFoldedScalars can go.
+func TestFoldedScalarGrowsWithoutStabilizer(t *testing.T) {
+	t.Parallel()
+
+	before := decodeDescription(t, foldedWithMoreIndentedLine)
+	after := decodeDescription(t, roundTrip(t, foldedWithMoreIndentedLine, false))
+
+	assert.NotEqual(t, before, after)
+}
+
+func TestStabilizeFoldedScalarsLeavesStableStylesAlone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		doc  string
+	}{
+		{
+			name: "folded scalar with no more-indented line",
+			doc:  "description: >-\n  one line\n  another line\n",
+		},
+		{
+			name: "literal scalar with more-indented line",
+			doc:  "description: |-\n  one line\n   more indented\n",
+		},
+		{
+			name: "plain scalar",
+			doc:  "description: just a string\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			want := decodeDescription(t, tt.doc)
+
+			doc := tt.doc
+			for range 5 {
+				doc = roundTrip(t, doc, true)
+				assert.Equal(t, want, decodeDescription(t, doc))
+			}
+		})
+	}
+}
+
+func TestHasMoreIndentedLine(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  bool
+	}{
+		{name: "no indentation", value: "one\ntwo", want: false},
+		{name: "space indented line", value: "one\n two", want: true},
+		{name: "tab indented line", value: "one\n\ttwo", want: true},
+		{name: "blank lines only", value: "one\n\ntwo", want: false},
+		{name: "empty", value: "", want: false},
+		{name: "first line indented", value: " one\ntwo", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, hasMoreIndentedLine(tt.value))
+		})
+	}
+}

--- a/pkg/overlay/overlay.go
+++ b/pkg/overlay/overlay.go
@@ -120,6 +120,8 @@ func apply(document *yaml.Node, o *overlay.Overlay, sourceLocation string, yamlI
 		}
 	}
 
+	stabilizeFoldedScalars(document)
+
 	bytes, err := schemas.RenderDocument(document, sourceLocation, yamlIn, yamlOut)
 	if err != nil {
 		return fmt.Errorf("failed to Render document: %w", err)


### PR DESCRIPTION
## Why

`gopkg.in/yaml.v3` emits an extra line break immediately before a more-indented line inside a folded (`>-`) scalar. Applying an overlay is a decode/mutate/encode round trip, so every apply grew such a scalar by one blank line. The break lands inside the scalar, so it becomes part of the decoded string rather than cosmetic whitespace.

A source configured with many overlays accumulated roughly one blank line per overlay in descriptions that no overlay targeted, and those inflated descriptions reached generated SDK and provider doc strings.

Minimal reproduction, no overlays needed:

```go
cur := "d: >-\n  normal line\n   more-indented line\n  another normal\n"
for i := 0; i < 4; i++ {
    var n yaml.Node
    yaml.Unmarshal([]byte(cur), &n)
    out, _ := yaml.Marshal(&n)
    cur = string(out) // grows one blank line each pass
}
```

Folded scalars without a more-indented line, and literal (`|-`) blocks, are already stable.

## What changed

`stabilizeFoldedScalars` re-styles folded scalars containing a more-indented line as literal blocks, called in `apply()` before `RenderDocument`. Literal blocks reproduce their value verbatim and round trip unchanged.

This removes the trigger rather than patching the emitter, so it needs no fork or `replace` directive. The decoded value is unchanged — the node already holds the folded value — so only the on-disk representation differs.

`apply()` is the shared path for `speakeasy run`, `speakeasy overlay apply`, CI document generation, and registry application, so all four are covered.

## Testing

- `go test ./pkg/overlay/...` passes, including the pre-existing expected-output fixtures.
- End-to-end: a spec containing an affected description chained through 26 distinct overlays. Before this change the description grew by 26 characters, one injected newline per overlay. After, it is byte-identical to the input.
- `TestFoldedScalarGrowsWithoutStabilizer` asserts the unpatched emitter still misbehaves, so it fails if `yaml.v3` is ever fixed or bumped and the workaround can be removed.

## Note for reviewers

Affected descriptions change representation from `>-` to `|` on their first regeneration after this lands. That is a one-time diff; output is stable afterwards.

Two call sites still invoke `ApplyTo` directly and bypass this path: `internal/suggest/suggest.go` and `pkg/transform/filterOperations.go`. Neither is on the regeneration path, so they are left out of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes YAML folded (`>-`) scalars across repeated overlay applies. Previously, each apply added a blank line before any more‑indented line due to `gopkg.in/yaml.v3`; now we re-style those scalars to literal (`|`) before render so values round-trip unchanged. Decoded strings stay the same; only on-disk representation changes.

- Coverage: runs in `apply()` via `stabilizeFoldedScalars`, so `speakeasy run`, `speakeasy overlay apply`, CI doc generation, and registry application all benefit.
- One-time diff: affected scalars switch from `>-` to `|` on first regeneration; subsequent outputs are stable.
- No migration required: decoded text is identical; generated SDK/provider docs stop accumulating blank lines.
- Notes: two call sites (`internal/suggest/suggest.go`, `pkg/transform/filterOperations.go`) still call `ApplyTo` directly and are not on the regeneration path. Tests assert current `yaml.v3` behavior and stability to flag removal if the emitter is fixed.

<sup>Written for commit 1a2b3b17e1f4bfe49cb5704445f436148cc60899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2116?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

