### PR TITLE
feat(go,typescript,csharp): allowReserved parameter encoding; fix(go,java,python,ruby,php,csharp): nullable paginated request bodies; fix(python): streaming retry connection leak; fix(typescript): MCP process event listeners

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.25.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.932.10
+	github.com/speakeasy-api/openapi-generation/v2 v2.933.0
 	github.com/speakeasy-api/sdk-gen-config v1.58.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.0

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.25.0 h1:xyJ5ZzW4YwStT2ICo0o7v9M890J7VpsR7AqhQSZnwl4=
 github.com/speakeasy-api/openapi v1.25.0/go.mod h1:9gGkzi9jNspEbcB08zta+IjzAi5Zy4QgSEQfF/LSrbQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.932.10 h1:ZuWliIIRLGHiEtoo/qFavVFJEArnQKYMqSc7ZCxFL9c=
-github.com/speakeasy-api/openapi-generation/v2 v2.932.10/go.mod h1:1Yypyh8Dl2dg/aYMY8ySCJ6kfuI9xTpUxuSs30XpZPE=
+github.com/speakeasy-api/openapi-generation/v2 v2.933.0 h1:hjvM5S+wNMaNcfUh8azuy8TVI6NdCCLQWUlQx6t+JhU=
+github.com/speakeasy-api/openapi-generation/v2 v2.933.0/go.mod h1:1Yypyh8Dl2dg/aYMY8ySCJ6kfuI9xTpUxuSs30XpZPE=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.58.0 h1:JrDgDU3XBIidv+TXFqYBvIomfeGEQ0zN+OnHyUc+kNw=


### PR DESCRIPTION
Bumps `openapi-generation` from v2.932.10 to v2.933.0.

## Core
- [Operations with `allowReserved` annotations on languages without allowReserved support now generate with a warning and standard percent-encoding instead of being dropped](https://github.com/speakeasy-api/openapi-generation/pull/83)

## Go
- [Support `allowReserved` on query parameters, passing RFC 3986 reserved characters through unencoded](https://github.com/speakeasy-api/openapi-generation/pull/83)
- [Handle a nullable request body in paginated operations, advancing through an optional wrapped request body instead of failing to compile or repeating the first page](https://github.com/speakeasy-api/openapi-generation/pull/59)

## TypeScript
- [Support `allowReserved` on query parameters and the param encoding override on path parameters, passing RFC 3986 reserved characters through unencoded](https://github.com/speakeasy-api/openapi-generation/pull/83)
- [Register process event listeners through the EventEmitter interface, keeping MCP servers compatible with updated bun type definitions](https://github.com/speakeasy-api/openapi-generation/pull/86)

## Python
- [Close retried responses before sleeping so streaming retries do not leak pooled connections](https://github.com/speakeasy-api/openapi-generation/pull/91)
- [Handle a nullable request body in paginated operations, advancing through an optional wrapped request body instead of failing to compile or repeating the first page](https://github.com/speakeasy-api/openapi-generation/pull/59)

## Java
- [`allowReserved: true` is no longer honoured on path parameters (the keyword only applies to query parameters); use `x-speakeasy-param-encoding-override: allowReserved` to preserve the previous encoding behaviour](https://github.com/speakeasy-api/openapi-generation/pull/83)
- [Handle a nullable request body in paginated operations](https://github.com/speakeasy-api/openapi-generation/pull/59)

## C#
- [Support `allowReserved` on query parameters and the param encoding override on path parameters, passing RFC 3986 reserved characters through unencoded](https://github.com/speakeasy-api/openapi-generation/pull/83)
- [Copy the caller's limit instead of a fabricated default into the next page of a nullable paginated request body](https://github.com/speakeasy-api/openapi-generation/pull/59)

## PHP
- [Fall back to pagination defaults when a paginated request or its input property is null](https://github.com/speakeasy-api/openapi-generation/pull/59)

## Ruby
- [Handle a nullable request body in paginated operations](https://github.com/speakeasy-api/openapi-generation/pull/59)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `openapi-generation` from v2.932.10 to v2.933.0, adding `allowReserved` parameter encoding for Go, TypeScript, and C# (RFC 3986 reserved characters now pass through unencoded) and fixing nullable paginated request bodies in Go, Java, Python, Ruby, PHP, and C#.

**Breaking Changes**
- Java no longer honors `allowReserved: true` on path parameters; use `x-speakeasy-param-encoding-override: allowReserved` to preserve prior behavior.

**Bug Fixes**
- Paginated operations with nullable request bodies now advance through an optional wrapped body instead of failing to compile or repeating the first page.
- Python streaming retries close responses before sleeping, preventing pooled connection leaks.
- TypeScript MCP servers register process event listeners through the EventEmitter interface.

<sup>Written for commit 4afd6c1f132fabf6ee0a2a59e6d233b4c5ce3324. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2123?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

