### PR TITLE
fix(go,cli,mockserver,terraform): bump staticcheck to v0.8.1 for Go 1.27

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.25.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.933.0
+	github.com/speakeasy-api/openapi-generation/v2 v2.933.1
 	github.com/speakeasy-api/sdk-gen-config v1.58.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.0

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.25.0 h1:xyJ5ZzW4YwStT2ICo0o7v9M890J7VpsR7AqhQSZnwl4=
 github.com/speakeasy-api/openapi v1.25.0/go.mod h1:9gGkzi9jNspEbcB08zta+IjzAi5Zy4QgSEQfF/LSrbQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.933.0 h1:hjvM5S+wNMaNcfUh8azuy8TVI6NdCCLQWUlQx6t+JhU=
-github.com/speakeasy-api/openapi-generation/v2 v2.933.0/go.mod h1:1Yypyh8Dl2dg/aYMY8ySCJ6kfuI9xTpUxuSs30XpZPE=
+github.com/speakeasy-api/openapi-generation/v2 v2.933.1 h1:g0lZi8XsS2NjArwP1hyC08bJRKeOHjgD9gx9ie7KONQ=
+github.com/speakeasy-api/openapi-generation/v2 v2.933.1/go.mod h1:1Yypyh8Dl2dg/aYMY8ySCJ6kfuI9xTpUxuSs30XpZPE=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.58.0 h1:JrDgDU3XBIidv+TXFqYBvIomfeGEQ0zN+OnHyUc+kNw=


### PR DESCRIPTION
## Go
- [Fix SDK generation failing at the lint step on Go 1.27 hosts by bumping the pinned staticcheck from v0.7.0 to v0.8.1 (applies to Go SDKs and mock servers)](https://github.com/speakeasy-api/openapi-generation/pull/95)

## Terraform
- [Fix provider generation failing at the lint step on Go 1.27 hosts by bumping the pinned staticcheck from v0.7.0 to v0.8.1](https://github.com/speakeasy-api/openapi-generation/pull/95)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `github.com/speakeasy-api/openapi-generation/v2` from v2.933.0 to v2.933.1 so Go SDK, mock server, CLI, and Terraform provider generation no longer fails the lint step on Go 1.27 hosts. The upstream change pins staticcheck v0.8.1, replacing the incompatible v0.7.0. No migration or rollout steps required.

<sup>Written for commit 042ca7aa4fb5bbb3e2d5ab56372997fa451fe943. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2125?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

