### PR TITLE
build: bump speakeasy-core to v0.24.0 and client-sdk-go to v3.28.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -50,8 +50,8 @@ require (
 	github.com/speakeasy-api/openapi-generation/v2 v2.933.1
 	github.com/speakeasy-api/sdk-gen-config v1.58.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
-	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.0
-	github.com/speakeasy-api/speakeasy-core v0.23.0
+	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.1
+	github.com/speakeasy-api/speakeasy-core v0.24.0
 	github.com/speakeasy-api/versioning-reports v0.7.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9

--- a/go.sum
+++ b/go.sum
@@ -558,10 +558,10 @@ github.com/speakeasy-api/sdk-gen-config v1.58.0 h1:JrDgDU3XBIidv+TXFqYBvIomfeGEQ
 github.com/speakeasy-api/sdk-gen-config v1.58.0/go.mod h1:kD0NPNX5yaG4j+dcCpLL0hHKQbFk6X93obp+v1XlK5E=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12 h1:dGONbW8WLNc4uSox1/k8O4JFggHoQy1v6R9cLqbTf5M=
 github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12/go.mod h1:AiZRZLL+sv9uwtTHIECc1dcTgfJrXrEB5QxcAGifMkI=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.0 h1:IaPKp8UFXeei8LGuPQUAzAtZlrAWGfjAeygWAikrPCA=
-github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.0/go.mod h1:u+RMkW/w6JXMZI181XpGmcqszcmaD8sSI464D4eiUDk=
-github.com/speakeasy-api/speakeasy-core v0.23.0 h1:QhyPovIUhLzl/97yJmLTqYEe3vVPVBU4XyRL9rlMC08=
-github.com/speakeasy-api/speakeasy-core v0.23.0/go.mod h1:2tl8YXzZCDlAxaPvF4ILBsWpzgGg+1ZA4XH7+Vwcnh0=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.1 h1:BxqnNA5lMy24D/9yRIT/ZbGJ+X/gEtgtRlr/+DGP5U4=
+github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.1/go.mod h1:u+RMkW/w6JXMZI181XpGmcqszcmaD8sSI464D4eiUDk=
+github.com/speakeasy-api/speakeasy-core v0.24.0 h1:GveGJX3rgT4ypc9ik3gh5u/vvHIzHGd26YNHV+wKfGQ=
+github.com/speakeasy-api/speakeasy-core v0.24.0/go.mod h1:enYpVW+oahWErgGJHEyBhbaoJAeJZrtFYeeVez7F+uk=
 github.com/speakeasy-api/versioning-reports v0.7.0 h1:Q2uI1RrEiOkuudoILSu7Mtkg8+ObT/hZakAG9CD+8f0=
 github.com/speakeasy-api/versioning-reports v0.7.0/go.mod h1:LW5FABrvi5SBbeiD3HJYw0JZYe6Rw2Xna59pFJ2BmLI=
 github.com/spewerspew/spew v0.0.0-20230513223542-89b69fbbe2bd h1:csraKifkLpqDClUIbFTetjtraueL1KUhKBm6okL+ug4=


### PR DESCRIPTION
Dependency bump only, split out of #2124 so the SDK/core change ships and is verified on its own before the generator change.

- `speakeasy-client-sdk-go/v3` v3.28.0 → **v3.28.1** (regenerated from the registry spec after speakeasy-registry#4708: `AccessDetails` gains `license_jwt` and `status_code`; no signature changes).
- `speakeasy-core` v0.23.0 → **v0.24.0** (`access.CheckGenerationAccess` returns the full access decision including the platform-issued license token; `HasGenerationAccess` unchanged).

No CLI behaviour change: nothing reads the token yet. #2124 (generator pin + commercial-on-token wiring) rebases on top once openapi-generation#55 is released.

Guards from #2121 still apply: `internal/sdk/sdk_test.go` asserts `x-api-key` on `Artifacts.PostTags`/`GetRevisions`; `TestRegistryFlow` ends with `tag promote`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `speakeasy-core` to v0.24.0 and `speakeasy-client-sdk-go/v3` to v3.28.1. These upgrades expose a platform-issued license token and new `AccessDetails` fields (`license_jwt`, `status_code`), but nothing reads them yet, so CLI behavior is unchanged.

<sup>Written for commit 943cae88b427c8887daabf4c0bdfb2deaddeba9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2126?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

