### PR TITLE
fix(typescript,terraform,go,ruby,php): bump openapi-generation to v2.935.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.25.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.934.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.935.2
 	github.com/speakeasy-api/sdk-gen-config v1.58.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.1

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.25.0 h1:xyJ5ZzW4YwStT2ICo0o7v9M890J7VpsR7AqhQSZnwl4=
 github.com/speakeasy-api/openapi v1.25.0/go.mod h1:9gGkzi9jNspEbcB08zta+IjzAi5Zy4QgSEQfF/LSrbQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.934.2 h1:GrZVC9SxbyLuBYOk8LvC4gVJt9+L8tffkka2VC6z6pI=
-github.com/speakeasy-api/openapi-generation/v2 v2.934.2/go.mod h1:OOjYkuR25Q5RvpwR5z1EeA9tIKdp3TK4jnXQsNbpmHg=
+github.com/speakeasy-api/openapi-generation/v2 v2.935.2 h1:1+a+uXR/oxrN9oBnnLU4rgbo4O2b9aCVWzXei/DnAQk=
+github.com/speakeasy-api/openapi-generation/v2 v2.935.2/go.mod h1:OOjYkuR25Q5RvpwR5z1EeA9tIKdp3TK4jnXQsNbpmHg=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.58.0 h1:JrDgDU3XBIidv+TXFqYBvIomfeGEQ0zN+OnHyUc+kNw=


### PR DESCRIPTION
Bumps the generator from v2.934.2 to v2.935.2 so the next CLI release ships:

- **typescript**: keep narrowed SSE overload return types when error responses are documented (speakeasy-api/openapi-generation#110, GEN-3192 — customer-reported regression since 1.769.0)
- **terraform**: stop emitting `setvalidator.UniqueValues` for set attributes with `uniqueItems` (speakeasy-api/openapi-generation#109, TFGEN-320 — customer-reported compile failure)
- **go,terraform,ruby**: timeouts, retries, streams, unions, and terraform server-variable attributes (speakeasy-api/openapi-generation#107)
- **php**: throw on big integer JSON serialization overflow instead of clamping (speakeasy-api/openapi-generation#108)
- **go,cli**: expose SDK, generator and document versions to SDK hooks (speakeasy-api/openapi-generation#104)

Merging this triggers the release workflow on main.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `openapi-generation` from v2.934.2 to v2.935.2 so the next CLI release ships the following generator fixes.

- TypeScript keeps narrowed SSE overload return types when error responses are documented (GEN-3192), fixing a regression since v1.769.0.
- Terraform stops emitting `setvalidator.UniqueValues` for set attributes with `uniqueItems` (TFGEN-320), fixing a customer-reported compile failure.
- PHP throws on big integer JSON serialization overflow instead of clamping.
- Go, Terraform, and Ruby get updates for timeouts, retries, streams, unions, and server-variable attributes.
- Go and CLI expose SDK, generator, and document versions to SDK hooks.

Merging this triggers the release workflow on main.

<sup>Written for commit 8a25085fb2f40ef8f67aa9655aa383fcf45c6949. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2129?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

