### PR TITLE
fix(typescript): SSE overload return types stay narrowed with documented error responses; fix(terraform): drop invalid uniqueItems set validator; fix(go): stream/timeout ownership, retries, unions, pagination; fix(php): big integer overflow raises instead of clamping; fix(ruby,csharp,python): retry strategy none; feat(go): expose versions to hooks; feat(terraform): server-variable provider attributes

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -47,7 +47,7 @@ require (
 	github.com/speakeasy-api/huh v1.1.2
 	github.com/speakeasy-api/jq v0.1.1-0.20251107233444-84d7e49e84a4
 	github.com/speakeasy-api/openapi v1.25.0
-	github.com/speakeasy-api/openapi-generation/v2 v2.934.2
+	github.com/speakeasy-api/openapi-generation/v2 v2.935.2
 	github.com/speakeasy-api/sdk-gen-config v1.58.0
 	github.com/speakeasy-api/speakeasy-agent-mode-content v0.2.12
 	github.com/speakeasy-api/speakeasy-client-sdk-go/v3 v3.28.1

--- a/go.sum
+++ b/go.sum
@@ -550,8 +550,8 @@ github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed h1:ZtuakKtG6x7
 github.com/speakeasy-api/libopenapi v0.21.10-fixhiddencomps-fixed/go.mod h1:Gc8oQkjr2InxwumK0zOBtKN9gIlv9L2VmSVIUk2YxcU=
 github.com/speakeasy-api/openapi v1.25.0 h1:xyJ5ZzW4YwStT2ICo0o7v9M890J7VpsR7AqhQSZnwl4=
 github.com/speakeasy-api/openapi v1.25.0/go.mod h1:9gGkzi9jNspEbcB08zta+IjzAi5Zy4QgSEQfF/LSrbQ=
-github.com/speakeasy-api/openapi-generation/v2 v2.934.2 h1:GrZVC9SxbyLuBYOk8LvC4gVJt9+L8tffkka2VC6z6pI=
-github.com/speakeasy-api/openapi-generation/v2 v2.934.2/go.mod h1:OOjYkuR25Q5RvpwR5z1EeA9tIKdp3TK4jnXQsNbpmHg=
+github.com/speakeasy-api/openapi-generation/v2 v2.935.2 h1:1+a+uXR/oxrN9oBnnLU4rgbo4O2b9aCVWzXei/DnAQk=
+github.com/speakeasy-api/openapi-generation/v2 v2.935.2/go.mod h1:OOjYkuR25Q5RvpwR5z1EeA9tIKdp3TK4jnXQsNbpmHg=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4 h1:gV+lYeVNNJG9X3Sl9Su3cRh1iF/oNqzvb5Ijq2QR8jY=
 github.com/speakeasy-api/openapi/openapi/linter/customrules v0.0.0-20260206023826-2483fb8e98b4/go.mod h1:1zQpVio7X6QJDtyNdUguCgZ+IC7CzKhhjvNgJdvGVF0=
 github.com/speakeasy-api/sdk-gen-config v1.58.0 h1:JrDgDU3XBIidv+TXFqYBvIomfeGEQ0zN+OnHyUc+kNw=


### PR DESCRIPTION
Bumps openapi-generation v2.934.2 → v2.935.2.

## Core
- [Embedded Go SDK: retry strategy `none`, per-operation disabled retries; SSE/JSONL streams, raw stream bodies and skipped JSON bodies own the per-operation timeout cancel instead of it firing when the method returns](https://github.com/speakeasy-api/openapi-generation/pull/107)
- [Expose SDK, generator and document versions to SDK hooks](https://github.com/speakeasy-api/openapi-generation/pull/104)

## TypeScript
- [Keep narrowed SSE overload return types when error responses are documented (regression since 1.769.0)](https://github.com/speakeasy-api/openapi-generation/pull/110)
- [Support retry strategy `none` and operation-level disabled retry overrides](https://github.com/speakeasy-api/openapi-generation/pull/107)

## Go
- [Streaming/timeout ownership: timeouts bound the caller's read instead of severing bodies when the method returns; request timeouts no longer cancel SSE/JSONL streams before iteration; pagination `Next()` uses the caller's context and preserves options; context cancellation surfaces over retryable errors; union values reset stale variants before re-decoding; pagination dropped for polled operations with a warning](https://github.com/speakeasy-api/openapi-generation/pull/107)
- [Expose `SDKVersion`, `GenVersion` and `OpenAPIDocVersion` on `SDKConfiguration` for custom User-Agent hooks](https://github.com/speakeasy-api/openapi-generation/pull/104)

## Terraform
- [Remove invalid `setvalidator.UniqueValues()` emitted for set attributes with `uniqueItems` (fixes provider compile failure)](https://github.com/speakeasy-api/openapi-generation/pull/109)
- [Add `terraform.serverVariableProviderAttributes` to rename server variables that collide with reserved provider-schema names; retry strategy `none` support](https://github.com/speakeasy-api/openapi-generation/pull/107)

## PHP
- [Raise an overflow error for integers larger than PHP_INT_MAX instead of silently clamping](https://github.com/speakeasy-api/openapi-generation/pull/108)
- [Support retry strategy `none` and operation-level disabled retry overrides](https://github.com/speakeasy-api/openapi-generation/pull/107)

## Ruby
- [Retry strategy `none`; streaming methods buffer JSON/text bodies while SSE, JSONL and raw streams stay live; case-insensitive content-type matching](https://github.com/speakeasy-api/openapi-generation/pull/107)

## C#
- [Support retry strategy `none` and operation-level disabled retry overrides](https://github.com/speakeasy-api/openapi-generation/pull/107)

## Python
- [Support retry strategy `none` and operation-level disabled retry overrides](https://github.com/speakeasy-api/openapi-generation/pull/107)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bumps `openapi-generation` from v2.934.2 to v2.935.2, picking up bug fixes and new retry/streaming capabilities across generated SDKs.

**Bug Fixes**
- TypeScript: SSE overload return types stay narrowed when error responses are documented.
- Terraform: invalid `uniqueItems` set validator no longer breaks provider compilation.
- Go: stream and timeout ownership now follows the caller's read, stale union variants are reset before re-decoding, and polled operations no longer emit pagination.
- PHP: integers above `PHP_INT_MAX` raise an overflow error instead of clamping.
- Ruby: streaming methods buffer JSON/text bodies while SSE, JSONL, and raw streams stay live; content-type matching is case-insensitive.

**New Features**
- Go: exposes `SDKVersion`, `GenVersion`, and `OpenAPIDocVersion` on `SDKConfiguration`.
- Terraform: adds `terraform.serverVariableProviderAttributes` for renaming reserved provider-schema server variables.
- Go, TypeScript, Terraform, PHP, Ruby, C#, and Python now support retry strategy `none` and operation-level disabled retry overrides.

<sup>Written for commit c8bc87472e0065d096b57edd9381f6a6a59d4c4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/speakeasy-api/speakeasy/pull/2130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

